### PR TITLE
Resolved issues with instance schema naming not aligned with api

### DIFF
--- a/dm/templates/instance/instance.py.schema
+++ b/dm/templates/instance/instance.py.schema
@@ -46,7 +46,7 @@ properties:
       Defines wether the instance will use an external IP from a shared
       ephemeral IP address pool. If this is set to false, the instance
       will not have an external IP.
-  natIp:
+  natIP:
     type: string
     description: |
       An external IP address associated with this instance. Specify an unused
@@ -66,7 +66,7 @@ properties:
       or partial URL. For example, the following are all valid URLs:
         - https://www.googleapis.com/compute/v1/projects/project/regions/region/subnetworks/subnetwork
         - regions/region/subnetworks/subnetwork
-  networkIp:
+  networkIP:
     type: string
     description: |
       An IPv4 internal network address to assign to the instance for this

--- a/dm/templates/instance_template/instance_template.py.schema
+++ b/dm/templates/instance_template/instance_template.py.schema
@@ -46,7 +46,7 @@ properties:
       Defines wether the instance will use an external IP from a shared
       ephemeral IP address pool. If this is set to false, the instance
       will not have an external IP.
-  natIp:
+  natIP:
     type: string
     description: |
       An external IP address associated with this instance. Specify an unused
@@ -66,7 +66,7 @@ properties:
       or partial URL. For example, the following are all valid URLs:
         - https://www.googleapis.com/compute/v1/projects/project/regions/region/subnetworks/subnetwork
         - regions/region/subnetworks/subnetwork
-  networkIp:
+  networkIP:
     type: string
     description: |
       An IPv4 internal network address to assign to the instance for this
@@ -81,7 +81,7 @@ properties:
   canIpForward:
     type: boolean
     description: |
-      Defines whether the instance is allowed to send and receive packets 
+      Defines whether the instance is allowed to send and receive packets
       with non-matching destination or source IPs.
   diskType:
     type: string

--- a/dm/templates/managed_instance_group/managed_instance_group.py.schema
+++ b/dm/templates/managed_instance_group/managed_instance_group.py.schema
@@ -117,7 +117,7 @@ properties:
           Defines wether the instance will use an external IP from a shared
           ephemeral IP address pool. If this is set to false, the instance
           will not have an external IP.
-      natIp:
+      natIP:
         type: string
         description: |
           An external IP address associated with this instance. Specify an unused
@@ -137,7 +137,7 @@ properties:
           or partial URL. For example, the following are all valid URLs:
             - https://www.googleapis.com/compute/v1/projects/project/regions/region/subnetworks/subnetwork
             - regions/region/subnetworks/subnetwork
-      networkIp:
+      networkIP:
         type: string
         description: |
           An IPv4 internal network address to assign to the instance for this


### PR DESCRIPTION
Schema naming for `natIP` and `networkIP` were incorrectly named `natIp` and `networkIp`.

Not an issue with the actual API requests, however having a matching schema makes it a lot easier to troubleshoot the problem.