### PR TITLE
Add openssh to Kitchen-Terraform image

### DIFF
--- a/infra/concourse/Makefile.BUILD
+++ b/infra/concourse/Makefile.BUILD
@@ -14,7 +14,7 @@ BUILD_RUBY_VERSION := 2.5.3
 # Fixing bugs or making trivial changes should be considered a patch release.
 
 DOCKER_TAG_VERSION_TERRAFORM := 1.0.0
-DOCKER_TAG_VERSION_KITCHEN_TERRAFORM := 1.0.1
+DOCKER_TAG_VERSION_KITCHEN_TERRAFORM := 1.1.0
 
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/infra/concourse/build/Dockerfile.kitchen-terraform
+++ b/infra/concourse/build/Dockerfile.kitchen-terraform
@@ -27,6 +27,7 @@ RUN apk add --no-cache \
     jq \
     make \
     musl-dev \
+    openssh \
     python \
     python3
 


### PR DESCRIPTION
This package is necessary to facilitate SSH proxy connections.