### PR TITLE
Fix for Warming message in instance example

### DIFF
--- a/dm/templates/instance/examples/instance.yaml
+++ b/dm/templates/instance/examples/instance.yaml
@@ -12,7 +12,6 @@ resources:
     properties:
       zone: us-central1-a
       diskImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts
-      diskSizeGb: 100
       machineType: f1-micro
       diskType: pd-ssd
       network: default

--- a/dm/templates/instance/tests/integration/instance.bats
+++ b/dm/templates/instance/tests/integration/instance.bats
@@ -52,7 +52,7 @@ function setup() {
 }
 
 function teardown() {
-    Global teardown; this is executed once per test file
+    #Global teardown; this is executed once per test file
     if [[ "$BATS_TEST_NUMBER" -eq "${#BATS_TEST_NAMES[@]}" ]]; then
         gcloud compute networks subnets delete "test-subnet-${RAND}" \
             --project "${CLOUD_FOUNDATION_PROJECT_ID}" \


### PR DESCRIPTION
Removed declaration of diskSizeGb to have disk size default to image size and not post a warning message.

Added missing # to comment in bats file to allow test execution