### PR TITLE
Fixed GKE outputs: #436 GKE >1.12 versions are not creating ClientCer…

### DIFF
--- a/dm/templates/gke/gke.py
+++ b/dm/templates/gke/gke.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """ This template creates a Google Kubernetes Engine cluster. """
 
+from packaging import version
 
 def generate_config(context):
     """ Entry point for the deployment resources. """
@@ -82,7 +83,7 @@ def generate_config(context):
         'legacyAbac',
         'networkPolicy',
         'ipAllocationPolicy',
-        'masterAuthorizedNetworksConfig'
+        'masterAuthorizedNetworksConfig',
         'maintenancePolicy',
         'podSecurityPolicyConfig',
         'privateCluster',
@@ -112,13 +113,18 @@ def generate_config(context):
         'endpoint',
         'instanceGroupUrls',
         'clusterCaCertificate',
-        'clientCertificate',
-        'clientKey',
         'currentMasterVersion',
         'currentNodeVersion',
         'nodeIpv4CidrSize',
         'servicesIpv4Cidr'
     ]
+
+    if (
+        version.parse(propc.get('initialClusterVersion').split('-')[0]) < version.parse("1.12") or
+        propc.get('masterAuth', {}).get('clientCertificateConfig', False)
+    ):
+        output_props.append('clientCertificate')
+        output_props.append('clientKey')
 
     for outprop in output_props:
         output_obj = {}


### PR DESCRIPTION
…tificates by default

https://github.com/GoogleCloudPlatform/deploymentmanager-samples/issues/436