### PR TITLE
[WIP] Don't require hard-coded credentials for Terraform

### DIFF
--- a/infra/terraform/test_fixtures/main.tf
+++ b/infra/terraform/test_fixtures/main.tf
@@ -12,13 +12,11 @@ provider "google-beta" {
 
 provider "google" {
   alias       = "phoogle"
-  credentials = "${var.phoogle_credentials_path}"
   version     = "~> 1.20"
 }
 
 provider "google-beta" {
   alias       = "phoogle"
-  credentials = "${var.phoogle_credentials_path}"
   version     = "~> 1.20"
 }
 

--- a/infra/terraform/test_fixtures/terraform-google-forseti.tf
+++ b/infra/terraform/test_fixtures/terraform-google-forseti.tf
@@ -36,14 +36,13 @@ locals {
 // Define a host project for the Forseti shared VPC test suite.
 module "forseti-host-project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 2.0"
+  version = "~> 2.0.0"
 
   name              = "ci-forseti-host"
   random_project_id = "true"
   org_id            = "${var.phoogle_org_id}"
   folder_id         = "${google_folder.phoogle_cloud_foundation_cicd.name}"
   billing_account   = "${module.variables.phoogle_billing_account}"
-  credentials_path  = "${var.phoogle_credentials_path}"
 
   activate_apis = "${local.forseti_required_apis}"
 
@@ -162,14 +161,13 @@ resource "google_project_iam_member" "forseti" {
 // enforcer manages additional resources.
 module "forseti-enforcer-project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 2.0"
+  version = "~> 2.0.0"
 
   name              = "ci-forseti-enforcer"
   random_project_id = "true"
   org_id            = "${var.phoogle_org_id}"
   folder_id         = "${google_folder.phoogle_cloud_foundation_cicd.name}"
   billing_account   = "${module.variables.phoogle_billing_account}"
-  credentials_path  = "${var.phoogle_credentials_path}"
 
   activate_apis = [
     "compute.googleapis.com",

--- a/infra/terraform/test_fixtures/variables.tf
+++ b/infra/terraform/test_fixtures/variables.tf
@@ -1,9 +1,5 @@
 module "variables" { source = "../variables" }
 
-variable "phoogle_credentials_path" {
-  description = "Path to credentials file for phoogle.net organization."
-}
-
 variable "phoogle_org_id" {
   default = "826592752744"
 }


### PR DESCRIPTION
This PR drops the requirement for Terraform credentials to be downloaded and hard-coded. Instead, environment/application default credentials can be used.

Updates needed:
- [x] Test fixtures
- [ ] Remove workspaces (just use a single one)