### PR TITLE
Pin Google providers to 2.7.0

### DIFF
--- a/infra/terraform/test_fixtures/main.tf
+++ b/infra/terraform/test_fixtures/main.tf
@@ -1,25 +1,25 @@
 provider "google" {
   project = "${module.variables.project_id}"
   region  = "${module.variables.region[terraform.workspace]}"
-  version = "~> 1.20"
+  version = "~> 2.7.0"
 }
 
 provider "google-beta" {
   project = "${module.variables.project_id}"
   region  = "${module.variables.region[terraform.workspace]}"
-  version = "~> 1.20"
+  version = "~> 2.7.0"
 }
 
 provider "google" {
   alias       = "phoogle"
   credentials = "${var.phoogle_credentials_path}"
-  version     = "~> 1.20"
+  version     = "~> 2.7.0"
 }
 
 provider "google-beta" {
   alias       = "phoogle"
   credentials = "${var.phoogle_credentials_path}"
-  version     = "~> 1.20"
+  version     = "~> 2.7.0"
 }
 
 terraform {


### PR DESCRIPTION
This change is necessary to maintain compatibilty with the newer
releases of Project Factory.