### PR TITLE
Fixes #55: DM/folder: refactoring

### DIFF
--- a/dm/templates/folder/folder.py
+++ b/dm/templates/folder/folder.py
@@ -16,6 +16,8 @@
     parent folder.
 """
 
+from hashlib import sha1
+
 
 def generate_config(context):
     """ Entry point for the deployment resources. """
@@ -23,14 +25,20 @@ def generate_config(context):
     resources = []
     out = {}
     for folder in context.properties.get('folders', []):
+        if folder.get('parent'):
+            parent = '{}s/{}'.format(folder['parent']['type'], folder['parent']['id'])
+        else:
+            parent = folder.get('orgId', folder.get('folderId'))
 
-        create_folder = folder['name']
-
-        parent = folder.get('orgId', folder.get('folderId'))
-
+        suffix = folder.get(
+            'resourceNameSuffix',
+            sha1('{}/folders/{}'.format(parent, folder.get('displayName'))).hexdigest()[:10]
+        )
+        create_folder = '{}-{}'.format(context.env['name'], suffix)
         resources.append(
             {
                 'name': create_folder,
+                # https://cloud.google.com/resource-manager/reference/rest/v2/folders
                 'type': 'gcp-types/cloudresourcemanager-v2:folders',
                 'properties':
                     {

--- a/dm/templates/folder/folder.py.schema
+++ b/dm/templates/folder/folder.py.schema
@@ -14,9 +14,18 @@
 
 info:
   title: Folder
+  author: Sourced Group Inc.
+  version: 1.0.0
   description: |
     Creates a folder under an organization or under a parent
     folder.
+
+    For more information on this resource:
+    https://cloud.google.com/resource-manager/
+
+    APIs endpoints used by this template:
+    - gcp-types/cloudresourcemanager-v2:folders =>
+        https://cloud.google.com/resource-manager/reference/rest/v2/folders
 
 imports:
   - path: folder.py
@@ -29,29 +38,72 @@ required:
 properties:
   folders:
     type: array
-    description: List of folders to create.
+    description: |
+      List of folders to create.
+    minItems: 1
+    uniqueItems: True
     items:
-      orgId:
-        type: string
-        pattern: ^organization\/[0-9]{8,25}$
-        description: |
-          The organization ID. If this field is set, the folder is
-          created under the organization. The value must conform to the
-          format `organizations/<orgId>`. For example,
-          `organizations/111122223333`.
-      folderId:
-        type: string
-        pattern: ^folder\/[0-9]{8,25}$
-        description: |
-          The folder ID. If this field is set, the folder is created
-          under the folder specified by the ID. The value must conform
-          to the format `folders/<folderId>`. For example,
-          `folders/1234567890`.
-      displayName:
-        type: string
-        description: The display name of the folder.
-        pattern: |
-          [\p{L}\p{N}]({\p{L}\p{N}_- ]{0,28}[\p{L}\p{N}])?
+      type: object
+      oneOf:
+        - required:
+            - orgId
+        - required:
+            - folderId
+        - required:
+            - parent
+      required:
+        - displayName
+      properties:
+        resourceNameSuffix:
+          type: string
+          description: |
+            Optional resource name suffix
+        orgId:
+          type: string
+          pattern: ^organizations\/[0-9]{8,25}$
+          description: |
+            The organization ID. If this field is set, the folder is
+            created under the organization. The value must conform to the
+            format `organizations/<orgId>`. For example,
+            `organizations/111122223333`.
+            DEPRECATED. Please use "parent"
+        folderId:
+          type: string
+          pattern: ^folders\/[0-9]{8,25}$
+          description: |
+            The folder ID. If this field is set, the folder is created
+            under the folder specified by the ID. The value must conform
+            to the format `folders/<folderId>`. For example,
+            `folders/1234567890`.
+            DEPRECATED. Please use "parent"
+        parent:
+          type: object
+          additionalProperties: false
+          description: The parent of the folder.
+          required:
+            - type
+            - id
+          properties:
+            type:
+              type: string
+              decription: The parent type (organization or folder).
+              enum:
+                - organization
+                - folder
+              default: organization
+            id:
+              type: [integer, string]
+              description: |
+                The ID of the folder's parent.
+              pattern: ^[0-9]{8,25}$
+        displayName:
+          type: string
+          pattern: ^[a-zA-Z0-9]([a-zA-Z0-9_\- ]{0,28}[a-zA-Z0-9])?$
+          description: |
+            The folder’s display name. A folder’s display name must be unique amongst its siblings, e.g. no two folders
+            with the same parent can share the same display name. The display name must start and end with
+            a letter or digit, may contain letters, digits, spaces, hyphens and underscores and
+            can be no longer than 30 characters.
 
 outputs:
   properties:


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/55

- added version, links to docs
- fixed folder resource names: use base resource name as a template
- added oneOf check for folderId/orgId + fix incorrect schema for array
- fixed "displayName" regex
- made "name" field optional
- using the same format for parent as in project + fixed name prefix to
plural