### PR TITLE
Fixes #56: DM/network: refactoring

### DIFF
--- a/dm/templates/network/network.py
+++ b/dm/templates/network/network.py
@@ -14,48 +14,65 @@
 """ This template creates a network, optionally with subnetworks. """
 
 
+def append_optional_property(res, properties, prop_name):
+    """ If the property is set, it is added to the resource. """
+
+    val = properties.get(prop_name)
+    if val:
+        res['properties'][prop_name] = val
+    return
+
+
 def generate_config(context):
     """ Entry point for the deployment resources. """
 
-    name = context.properties.get('name') or context.env['name']
-    network_self_link = '$(ref.{}.selfLink)'.format(name)
-    auto_create_subnetworks = context.properties.get(
-        'autoCreateSubnetworks',
-        False
-    )
+    properties = context.properties
+    name = properties.get('name', context.env['name'])
+    network_self_link = '$(ref.{}.selfLink)'.format(context.env['name'])
 
-    resources = [
-        {
-            'type': 'compute.v1.network',
-            'name': name,
-            'properties':
-                {
-                    'name': name,
-                    'autoCreateSubnetworks': auto_create_subnetworks
-                }
-        }
+    network_resource = {
+        # https://cloud.google.com/compute/docs/reference/rest/v1/networks/insert
+        'type': 'gcp-types/compute-v1:networks',
+        'name': context.env['name'],
+        'properties':
+            {
+                'name': name,
+                'autoCreateSubnetworks': properties.get('autoCreateSubnetworks', False)
+            }
+    }
+    optional_properties = [
+        'description',
+        'routingConfig',
+        'project',
     ]
+    for prop in optional_properties:
+        append_optional_property(network_resource, properties, prop)
+    resources = [network_resource]
 
     # Subnetworks:
     out = {}
-    for subnetwork in context.properties.get('subnetworks', []):
+    for i, subnetwork in enumerate(
+        properties.get('subnetworks', []), 1
+    ):
         subnetwork['network'] = network_self_link
+        if properties.get('project'):
+            subnetwork['project'] = properties.get('project')
+
+        subnetwork_name = 'subnetwork-{}'.format(i)
         resources.append(
             {
-                'name': subnetwork['name'],
+                'name': subnetwork_name,
                 'type': 'subnetwork.py',
                 'properties': subnetwork
             }
         )
 
-        out[subnetwork['name']] = {
-            'selfLink': '$(ref.{}.selfLink)'.format(subnetwork['name']),
-            'ipCidrRange': '$(ref.{}.ipCidrRange)'.format(subnetwork['name']),
-            'region': '$(ref.{}.region)'.format(subnetwork['name']),
-            'network': '$(ref.{}.network)'.format(subnetwork['name']),
-            'gatewayAddress': '$(ref.{}.gatewayAddress)'.format(
-                subnetwork['name']
-            )
+        out[subnetwork_name] = {
+            'selfLink': '$(ref.{}.selfLink)'.format(subnetwork_name),
+            'ipCidrRange': '$(ref.{}.ipCidrRange)'.format(subnetwork_name),
+            'region': '$(ref.{}.region)'.format(subnetwork_name),
+            'network': '$(ref.{}.network)'.format(subnetwork_name),
+            'gatewayAddress': '$(ref.{}.gatewayAddress)'.format(subnetwork_name)
         }
 
     return {

--- a/dm/templates/network/network.py.schema
+++ b/dm/templates/network/network.py.schema
@@ -15,24 +15,65 @@
 info:
   title: Network
   author: Sourced Group Inc.
+  version: 1.0.0
   description: |
     Creates a network.
 
     For more information on this resource:
-      - https://cloud.google.com/compute/docs/reference/rest/v1/networks
+      - https://cloud.google.com/vpc/docs/vpc
+
+    APIs endpoints used by this template:
+    - gcp-types/compute-v1:networks =>
+        https://cloud.google.com/compute/docs/reference/rest/v1/networks/insert
 
 imports:
   - path: subnetwork.py
 
 additionalProperties: false
 
-# required:
-#  - name
+oneOf:
+  - properties:
+      autoCreateSubnetworks:
+        enum:
+         - true
+  - properties:
+      subnetworks:
+        type: array
+        default: []
+        minItems: 1
 
 properties:
   name:
     type: string
-    description: Name of the network resource.
+    description: |
+      Name of the network resource. Resource name would be used if omitted.
+  project:
+    type: string
+    description: |
+      The project ID of the project containing the Cloud Router instance. The
+      Google apps domain is prefixed if applicable.
+  description:
+    type: string
+    description: |
+      An optional description of this resource. Provide this property when you create the resource.
+  routingConfig:
+    type: object
+    additionalProperties: false
+    description: |
+      The network-level routing configuration for this network. Used by Cloud Router to determine what type
+      of network-wide routing behavior to enforce.
+    required:
+      - routingMode
+    properties:
+      routingMode:
+        type: string
+        description: |
+          The network-wide routing mode to use. If set to REGIONAL, this network's cloud routers will only advertise
+          routes with subnets of this network in the same region as the router. If set to GLOBAL, this network's
+          cloud routers will advertise routes with all subnets of this network, across regions.
+        enum:
+          - GLOBAL
+          - REGIONAL
   autoCreateSubnetworks:
     type: boolean
     default: false
@@ -41,6 +82,7 @@ properties:
       10.128.0.0/9; and (b) one subnetwork per region is created automatically.
   subnetworks:
     type: array
+    default: []
     description: |
       An array of subnetworks, as defined in the `subnetwork.py` template.
       Example:
@@ -54,6 +96,15 @@ properties:
               ipCidrRange: 172.16.0.0/24
             - rangeName: my-secondary-range-2
               ipCidrRange: 172.16.1.0/24
+    items:
+      type: object
+      allOf:
+        - not:
+            required:
+              - project
+        - not:
+            required:
+              - network
 
 outputs:
   properties:

--- a/dm/templates/network/subnetwork.py
+++ b/dm/templates/network/subnetwork.py
@@ -17,28 +17,31 @@
 def generate_config(context):
     """ Entry point for the deployment resources. """
 
-    name = context.properties.get('name', context.env['name'])
-    required_properties = ['network', 'ipCidrRange', 'region']
+    props = context.properties
+    props['name'] = props.get('name', context.env['name'])
+    required_properties = ['name', 'network', 'ipCidrRange', 'region']
     optional_properties = [
+        'project',
         'enableFlowLogs',
         'privateIpGoogleAccess',
         'secondaryIpRanges'
     ]
 
     # Load the mandatory properties, then the optional ones (if specified).
-    properties = {p: context.properties[p] for p in required_properties}
+    properties = {p: props[p] for p in required_properties}
     properties.update(
         {
-            p: context.properties[p]
+            p: props[p]
             for p in optional_properties
-            if p in context.properties
+            if p in props
         }
     )
 
     resources = [
         {
-            'type': 'compute.v1.subnetwork',
-            'name': name,
+            # https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks/insert
+            'type': 'gcp-types/compute-v1:subnetworks',
+            'name': context.env['name'],
             'properties': properties
         }
     ]
@@ -46,27 +49,27 @@ def generate_config(context):
     output = [
         {
             'name': 'name',
-            'value': name
+            'value': properties['name']
         },
         {
             'name': 'selfLink',
-            'value': '$(ref.{}.selfLink)'.format(name)
+            'value': '$(ref.{}.selfLink)'.format(context.env['name'])
         },
         {
             'name': 'ipCidrRange',
-            'value': '$(ref.{}.ipCidrRange)'.format(name)
+            'value': '$(ref.{}.ipCidrRange)'.format(context.env['name'])
         },
         {
             'name': 'region',
-            'value': '$(ref.{}.region)'.format(name)
+            'value': '$(ref.{}.region)'.format(context.env['name'])
         },
         {
             'name': 'network',
-            'value': '$(ref.{}.network)'.format(name)
+            'value': '$(ref.{}.network)'.format(context.env['name'])
         },
         {
             'name': 'gatewayAddress',
-            'value': '$(ref.{}.gatewayAddress)'.format(name)
+            'value': '$(ref.{}.gatewayAddress)'.format(context.env['name'])
         }
     ]
 

--- a/dm/templates/network/subnetwork.py.schema
+++ b/dm/templates/network/subnetwork.py.schema
@@ -15,7 +15,16 @@
 info:
   title: Subnet
   author: Sourced Group Inc.
-  description: Creates a subnetwork.
+  version: 1.0.0
+  description: |
+    Creates a subnetwork.
+
+    For more information on this resource:
+      - https://cloud.google.com/vpc/docs/vpc
+
+    APIs endpoints used by this template:
+    - gcp-types/compute-v1:subnetworks =>
+        https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks/insert
 
 additionalProperties: false
 
@@ -28,7 +37,17 @@ properties:
   name:
     type: string
     description: |
-      Name of the subnetwork. If not specified, the DM resource name is used.
+      The name of the resource, provided by the client when initially creating the resource. The name must
+      be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and
+      match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a lowercase
+      letter, and all following characters must be a dash, lowercase letter, or digit, except the last character,
+      which cannot be a dash.
+      If not specified, the DM resource name is used.
+  project:
+    type: string
+    description: |
+      The project ID of the project containing the Cloud Router instance. The
+      Google apps domain is prefixed if applicable.
   network:
     type: string
     description: |
@@ -62,6 +81,25 @@ properties:
           ipCidrRange: 172.16.0.0/24
         - rangeName: my-secondary-range-2
           ipCidrRange: 172.16.1.0/24
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - rangeName
+        - ipCidrRange
+      properties:
+        rangeName:
+          type: string
+          description: |
+            The name associated with this subnetwork secondary range, used when adding an alias IP range
+            to a VM instance. The name must be 1-63 characters long, and comply with RFC1035.
+            The name must be unique within the subnetwork.
+        ipCidrRange:
+          type: string
+          description: |
+            The range of IP addresses belonging to this subnetwork secondary range. Provide this property
+            when you create the subnetwork. Ranges must be unique and non-overlapping with all primary
+            and secondary IP ranges within a network. Only IPv4 is supported.
   enableFlowLogs:
     type: boolean
     description: If "true", enables flow logging for the subnetwork.

--- a/dm/templates/network/tests/schemas/invalid_subnets.yaml
+++ b/dm/templates/network/tests/schemas/invalid_subnets.yaml
@@ -1,0 +1,15 @@
+autoCreateSubnetworks: true
+subnetworks:
+  - name: test-subnetwork-1
+    region: us-east1
+    ipCidrRange: 10.0.0.0/24
+    privateIpGoogleAccess: false
+    enableFlowLogs: true
+    secondaryIpRanges:
+      - rangeName: my-secondary-range-1
+        ipCidrRange: 10.0.1.0/24
+      - rangeName: my-secondary-range-2
+        ipCidrRange: 10.0.2.0/24
+      - name: test-subnetwork-2
+        region: us-east1
+        ipCidrRange: 192.168.0.0/24

--- a/dm/templates/network/tests/schemas/valid_auto.yaml
+++ b/dm/templates/network/tests/schemas/valid_auto.yaml
@@ -1,0 +1,1 @@
+autoCreateSubnetworks: true

--- a/dm/templates/network/tests/schemas/valid_subnets.yaml
+++ b/dm/templates/network/tests/schemas/valid_subnets.yaml
@@ -1,0 +1,15 @@
+autoCreateSubnetworks: false
+subnetworks:
+  - name: test-subnetwork-1
+    region: us-east1
+    ipCidrRange: 10.0.0.0/24
+    privateIpGoogleAccess: false
+    enableFlowLogs: true
+    secondaryIpRanges:
+      - rangeName: my-secondary-range-1
+        ipCidrRange: 10.0.1.0/24
+      - rangeName: my-secondary-range-2
+        ipCidrRange: 10.0.2.0/24
+      - name: test-subnetwork-2
+        region: us-east1
+        ipCidrRange: 192.168.0.0/24


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/56

- Added version, links to docs
- Switched to using type provider
- Added support for cross-project resource creation (both network and
subnetwork)
- Added oneOf check for subnets: autoCreateSubnetworks should be exclusive
with subnet list
- Fixed network & subnetworks resources names
- Added support for "description", "routingConfig" to network
- Fixed "secondaryIpRanges" definition in subnetwork
- Added basic schema unit tests