### PR TITLE
Fixes #53: DM/cloud_spanner: refactoring

### DIFF
--- a/dm/templates/cloud_spanner/cloud_spanner.py.schema
+++ b/dm/templates/cloud_spanner/cloud_spanner.py.schema
@@ -15,6 +15,7 @@
 info:
   title: Cloud Spanner
   author: Sourced Group Inc.
+  version: 1.0.0
   description: Creates a Cloud Spanner instance and database.
 
 additionalProperties: false
@@ -25,11 +26,24 @@ required:
   - instanceConfig
 
 properties:
+  name:
+    type: string
+    description: |
+      A unique identifier for the instance, which cannot be changed after the instance is created.Values are
+      of the form projects/<project>/instances/[a-z][-a-z0-9]*[a-z0-9]. The final segment of the name must be
+      between 2 and 64 characters in length.
+      This does not include the project ID. Resource name would be used if omitted.
+  project:
+    type: string
+    description: |
+      The project ID of the project containing the Cloud Spanner instance. The
+      Google apps domain is prefixed if applicable.
   displayName:
     type: string
     description: The cluster display name in GCP Console.
   nodeCount:
     type: integer
+    minimum: 1
     description: The number of instances allocated to your node.
   instanceConfig:
     type: string
@@ -42,6 +56,7 @@ properties:
       - regional-asia-east1
       - regional-asia-east2
       - regional-asia-northeast1
+      - regional-asia-northeast2
       - regional-asia-south1
       - regional-asia-southeast1
       - regional-australia-southeast1
@@ -49,17 +64,27 @@ properties:
       - regional-europe-west1
       - regional-europe-west2
       - regional-europe-west4
+      - regional-europe-west6
       - regional-northamerica-northeast1
       - regional-us-central1
       - regional-us-east1
       - regional-us-east4
       - regional-us-west1
       - regional-us-west2
+  labels:
+    type: object
+    description: |
+      Map labels associated with this Cloud spanner instance.
+      Example:
+        name: wrench
+        mass: 1.3kg
+        count: 3
   bindings:
     type: array
     description: IAM policies applied at the CLUSTER level.
     items:
       type: object
+      additionalProperties: false
       required:
         - role
         - members
@@ -82,6 +107,7 @@ properties:
     description: A list of databases created under the instance cluster.
     items:
       type: object
+      additionalProperties: false
       required:
         - name
       properties:
@@ -93,6 +119,7 @@ properties:
           description: A list of IAM policies applied at the DATABASE level.
           items:
             type: object
+            additionalProperties: false
             required:
               - role
               - members
@@ -131,6 +158,7 @@ outputs:
         patternProperties:
           ".*":
             type: object
+            additionalProperties: false
             description: Details for an address resource.
             properties:
               state:

--- a/dm/templates/cloud_spanner/tests/schemas/invalid_additional_options.yaml
+++ b/dm/templates/cloud_spanner/tests/schemas/invalid_additional_options.yaml
@@ -1,0 +1,4 @@
+displayName: "Spanner Cluster 1"
+nodeCount: 2
+instanceConfig: nam3
+foo: bar

--- a/dm/templates/cloud_spanner/tests/schemas/valid_basic.yaml
+++ b/dm/templates/cloud_spanner/tests/schemas/valid_basic.yaml
@@ -1,0 +1,5 @@
+displayName: "Spanner Cluster 1"
+nodeCount: 2
+instanceConfig: nam3
+name: foo
+project: foo

--- a/dm/templates/cloud_spanner/tests/schemas/valid_complex.yaml
+++ b/dm/templates/cloud_spanner/tests/schemas/valid_complex.yaml
@@ -1,0 +1,13 @@
+displayName: "Spanner Cluster 1"
+nodeCount: 2
+instanceConfig: nam3
+bindings:
+  - role: "roles/spanner.admin"
+    members:
+      - "user:myuser@mycompany.com"
+databases:
+  - name: "spannerdb1"
+    bindings:
+      - role: "roles/spanner.databaseAdmin"
+        members:
+          - "user:myotheruser@mycompany.com"


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/53

- Added version, links to docs
- Added support for "labels"
- Switched to using type provider
- Made "name" optional, correctly handle it
- Added support for cross-project resource creation
- Updated "instanceConfig" enum with new values
- Added basic schema unit tests
- Added additionalProperties: false for nested objects