### PR TITLE
Fixes #51: DM/cloud_router: refactoring

### DIFF
--- a/dm/templates/cloud_router/cloud_router.py.schema
+++ b/dm/templates/cloud_router/cloud_router.py.schema
@@ -15,11 +15,16 @@
 info:
   title: Cloud Router
   author: Sourced Group Inc.
+  version: 1.0.0
   description: |
     Deploys a Cloud Router.
 
     For more information on this resource:
     https://cloud.google.com/router/docs/
+
+    APIs endpoints used by this template:
+    - gcp-types/compute-v1:routers =>
+        https://cloud.google.com/compute/docs/reference/rest/v1/routers
 
 imports:
   - path: cloud_router.py
@@ -29,25 +34,347 @@ additionalProperties: false
 required:
   - network
   - region
-  - asn
+
+oneOf:
+  - required:
+      - asn
+  - required:
+      - bgp
 
 properties:
   name:
     type: string
-    description: The name of Cloud Router the resource.
-  network:
+    description: |
+      Must comply with RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a lowercase letter,
+      and all following characters must be a dash, lowercase letter, or digit, except the last character,
+      which cannot be a dash.
+      Resource name would be used if omitted.
+  description:
     type: string
-    description: The name of the network to which the Cloud Router belongs.
+    description: |
+      An optional description of this resource. Provide this property when you create the resource.
+  project:
+    type: string
+    description: |
+      The project ID of the project containing the Cloud Router instance. The
+      Google apps domain is prefixed if applicable.
   region:
     type: string
     description: The URI of the region where the Cloud Router resides.
+  network:
+    type: string
+    description: The name of the network to which the Cloud Router belongs (without project prefix).
+  bgp:
+    type: object
+    additionalProperties: false
+    description: |
+      BGP information specific to this router.
+    required:
+      - asn
+    properties:
+      asn:
+        type: integer
+        description: |
+          The local BGP Autonomous System Number (ASN). Must be an RFC6996 private ASN,
+          either 16-bit or 32-bit. The value will be fixed for this router.
+          All VPN tunnels that link to this router will have the same
+          local ASN.
+      advertiseMode:
+        type: string
+        description: |
+          User-specified flag to indicate which mode to use for advertisement. The options are DEFAULT or CUSTOM.
+        enum:
+          - DEFAULT
+          - CUSTOM
+      advertisedGroups:
+        type: array
+        description: |
+          User-specified list of prefix groups to advertise in custom mode. This field can only be populated if
+          advertiseMode is CUSTOM and is advertised to all peers of the router. These groups will be advertised
+          in addition to any specified prefixes. Leave this field blank to advertise no custom groups.
+        uniqueItems: True
+        items:
+          type: string
+          enum:
+            - ALL_SUBNETS
+      advertisedIpRanges:
+        type: array
+        description: |
+          User-specified list of individual IP ranges to advertise in custom mode. This field can only be populated
+          if advertiseMode is CUSTOM and is advertised to all peers of the router. These IP ranges will be advertised
+          in addition to any specified groups. Leave this field blank to advertise no custom IP ranges.
+        uniqueItems: True
+        items:
+          type: object
+          additionalProperties: false
+          required:
+            - range
+          properties:
+            range:
+              type: string
+              description: |
+                The IP range to advertise. The value must be a CIDR-formatted string.
+            description:
+              type: string
+              description: |
+                User-specified description for the IP range.
+  bgpPeers:
+    type: array
+    description: |
+      BGP information that must be configured into the routing stack to establish BGP peering. This information
+      must specify the peer ASN and either the interface name, IP address, or peer IP address. Please refer to RFC4273.
+    uniqueItems: True
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - interfaceName
+        - ipAddress
+        - peerIpAddress
+      properties:
+        name:
+          type: string
+          description: |
+            Name of this BGP peer. The name must be 1-63 characters long and comply with RFC1035.
+        interfaceName:
+          type: string
+          description: |
+            Name of the interface the BGP peer is associated with.
+        ipAddress:
+          type: string
+          description: |
+            IP address of the interface inside Google Cloud Platform. Only IPv4 is supported.
+        peerIpAddress:
+          type: string
+          description: |
+            IP address of the BGP interface outside Google Cloud Platform. Only IPv4 is supported.
+        peerAsn:
+          type: string
+          description: |
+            Peer BGP Autonomous System Number (ASN). Each BGP interface may use a different value.
+        advertisedRoutePriority:
+          type: string
+          description: |
+            The priority of routes advertised to this BGP peer. Where there is more than one matching
+            route of maximum length, the routes with the lowest priority value win.
+        advertiseMode:
+          type: string
+          description: |
+            User-specified flag to indicate which mode to use for advertisement.
+        advertisedGroups:
+          type: array
+          description: |
+            User-specified list of prefix groups to advertise in custom mode, which can take
+            one of the following options:
+
+            - ALL_SUBNETS: Advertises all available subnets, including peer VPC subnets.
+            - ALL_VPC_SUBNETS: Advertises the router's own VPC subnets.
+            - ALL_PEER_VPC_SUBNETS: Advertises peer subnets of the router's VPC network.
+            Note that this field can only be populated if advertiseMode is CUSTOM and overrides the list
+            defined for the router (in the "bgp" message). These groups are advertised in addition
+            to any specified prefixes. Leave this field blank to advertise no custom groups.
+          uniqueItems: True
+          items:
+            type: string
+            enum:
+              - ALL_SUBNETS
+              - ALL_VPC_SUBNETS
+              - ALL_PEER_VPC_SUBNETS
+        advertisedIpRanges:
+          type: array
+          description: |
+            User-specified list of individual IP ranges to advertise in custom mode. This field can only
+            be populated if advertiseMode is CUSTOM and overrides the list defined for
+            the router (in the "bgp" message). These IP ranges are advertised in addition to any specified groups.
+            Leave this field blank to advertise no custom IP ranges.
+          uniqueItems: True
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - range
+            properties:
+              range:
+                type: string
+                description: |
+                  The IP range to advertise. The value must be a CIDR-formatted string.
+              randescriptionge:
+                type: string
+                description: |
+                  User-specified description for the IP range.
+  interfaces:
+    type: array
+    description: |
+      Router interfaces. Each interface requires either one linked resource, (for example, linkedVpnTunnel),
+      or IP address and IP address range (for example, ipRange), or both.
+    uniqueItems: True
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+      oneOf:
+        - allOf:
+            - required:
+                - linkedVpnTunnel
+            - not:
+                required:
+                  - linkedInterconnectAttachment
+        - allOf:
+            - required:
+                - linkedInterconnectAttachment
+            - not:
+                required:
+                  - linkedVpnTunnel
+      properties:
+        name:
+          type: string
+          description: |
+            Name of this interface entry. The name must be 1-63 characters long and comply with RFC1035.
+        linkedVpnTunnel:
+          type: string
+          description: |
+            URI of the linked VPN tunnel, which must be in the same region as the router. Each interface can have
+            one linked resource, which can be either a VPN tunnel or an Interconnect attachment.
+        linkedInterconnectAttachment:
+          type: string
+          description: |
+            URI of the linked Interconnect attachment. It must be in the same region as the router. Each interface
+            can have one linked resource, which can be either be a VPN tunnel or an Interconnect attachment.
+        ipRange:
+          type: string
+          description: |
+            IP address and range of the interface. The IP range must be in the RFC3927 link-local IP address space.
+            The value must be a CIDR-formatted string, for example: 169.254.0.1/30. NOTE: Do not truncate the address
+            as it represents the IP address of the interface.
+  nats:
+    type: array
+    description: |
+      A list of NAT services created in this router.
+    uniqueItems: True
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - sourceSubnetworkIpRangesToNat
+      properties:
+        name:
+          type: string
+          description: |
+            Unique name of this Nat service. The name must be 1-63 characters long and comply with RFC1035.
+        sourceSubnetworkIpRangesToNat:
+          type: string
+          description: |
+            Specify the Nat option, which can take one of the following values:
+
+            - ALL_SUBNETWORKS_ALL_IP_RANGES: All of the IP ranges in every Subnetwork are allowed to Nat.
+            - ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES: All of the primary IP ranges in every Subnetwork are allowed to Nat.
+            - LIST_OF_SUBNETWORKS: A list of Subnetworks are allowed to Nat (specified in the field subnetwork below)
+            The default is SUBNETWORK_IP_RANGE_TO_NAT_OPTION_UNSPECIFIED. Note that if this field contains
+            ALL_SUBNETWORKS_ALL_IP_RANGES or ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES, then there should not be any
+            other Router.Nat section in any Router for this network in this region.
+          enum:
+            - ALL_SUBNETWORKS_ALL_IP_RANGES
+            - ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES
+            - LIST_OF_SUBNETWORKS
+        subnetworks:
+          type: array
+          description: |
+            A list of Subnetwork resources whose traffic should be translated by NAT Gateway. It is used only
+            when LIST_OF_SUBNETWORKS is selected for the SubnetworkIpRangeToNatOption above.
+          uniqueItems: True
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - name
+            properties:
+              name:
+                type: string
+                description: |
+                  URL for the subnetwork resource that will use NAT.
+              sourceIpRangesToNat:
+                type: array
+                description: |
+                  Specify the options for NAT ranges in the Subnetwork. All options of a single value
+                  are valid except NAT_IP_RANGE_OPTION_UNSPECIFIED. The only valid option with
+                  multiple values is: ["PRIMARY_IP_RANGE", "LIST_OF_SECONDARY_IP_RANGES"] Default: [ALL_IP_RANGES]
+                uniqueItems: True
+                items:
+                  type: string
+              secondaryIpRangeNames:
+                type: array
+                description: |
+                  A list of the secondary ranges of the Subnetwork that are allowed to use NAT.
+                  This can be populated only if "LIST_OF_SECONDARY_IP_RANGES" is
+                  one of the values in sourceIpRangesToNat.
+                uniqueItems: True
+                items:
+                  type: string
+              natIps:
+                type: array
+                description: |
+                  A list of URLs of the IP resources used for this Nat service. These IP addresses must
+                  be valid static external IP addresses assigned to the project.
+                uniqueItems: True
+                items:
+                  type: string
+              natIpAllocateOption:
+                type: string
+                description: |
+                  Specify the NatIpAllocateOption, which can take one of the following values:
+
+                  - MANUAL_ONLY: Uses only Nat IP addresses provided by customers.
+                      When there are not enough specified Nat IPs, the Nat service fails for new VMs.
+                  - AUTO_ONLY: Nat IPs are allocated by Google Cloud Platform; customers can't specify any Nat IPs.
+                      When choosing AUTO_ONLY, then natIp should be empty.
+                enum:
+                  - MANUAL_ONLY
+                  - AUTO_ONLY
+              minPortsPerVm:
+                type: integer
+                description: |
+                  Minimum number of ports allocated to a VM from this NAT config. If not set, a default
+                  number of ports is allocated to a VM. This is rounded up to the nearest power of 2.
+                  For example, if the value of this field is 50, at least 64 ports are allocated to a VM.
+              udpIdleTimeoutSec:
+                type: integer
+                description: |
+                  Timeout (in seconds) for UDP connections. Defaults to 30s if not set.
+              icmpIdleTimeoutSec:
+                type: integer
+                description: |
+                  Timeout (in seconds) for ICMP connections. Defaults to 30s if not set.
+              tcpEstablishedIdleTimeoutSec:
+                type: integer
+                description: |
+                  Timeout (in seconds) for TCP established connections. Defaults to 1200s if not set.
+              tcpTransitoryIdleTimeoutSec:
+                type: integer
+                description: |
+                  Timeout (in seconds) for TCP transitory connections. Defaults to 30s if not set.
+              logConfig:
+                type: object
+                additionalProperties: false
+                description: |
+                  Configure logging on this NAT.
+                properties:
+                  enable:
+                    type: boolean
+                    description: |
+                      Indicates whether or not to export logs. This is false by default.
+                  filter:
+                    type: string
+                    description: |
+                      Specifies the desired filtering of logs on this NAT. If unspecified, logs are exported
+                      for all connections handled by this NAT.
   asn:
     type: integer
     description: |
-      The local BGP Autonomous System Number (ASN). Must be an RFC6996 private ASN,
-      either 16-bit or 32-bit. The value will be fixed for this router.
-      All VPN tunnels that link to this router will have the same
-      local ASN.
+      DEPRECATED. Alias for bgp->asn
 
 outputs:
   properties:

--- a/dm/templates/cloud_router/tests/schemas/invalid_additional_options.yaml
+++ b/dm/templates/cloud_router/tests/schemas/invalid_additional_options.yaml
@@ -1,0 +1,4 @@
+network: asd
+region: us-east1
+asn: 65001
+foo: bar

--- a/dm/templates/cloud_router/tests/schemas/valid_basic.yaml
+++ b/dm/templates/cloud_router/tests/schemas/valid_basic.yaml
@@ -1,0 +1,5 @@
+network: asd
+region: us-east1
+asn: 65001
+name: foo
+project: foo


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/51

- Added version, links to docs
- Added support for "description"
- Switched to using type provider
- Added support for cross-project resource creation
- Added missing fields:
  - bgp (only asn is supported now)
  - nats
  - bgpPeers
  - interfaces
- Added basic schema unit tests