### PR TITLE
Update firewall.py to accept resource name being set

### DIFF
--- a/dm/templates/firewall/firewall.py
+++ b/dm/templates/firewall/firewall.py
@@ -58,6 +58,7 @@ def generate_config(context):
                                  + '.creationTimestamp)',
         }
 
-    outputs = [{'name': 'rules', 'value': out}]
+    name = context.properties.get('name', 'rules')
+    outputs = [{'name': name, 'value': out}]
 
     return {'resources': resources, 'outputs': outputs}

--- a/dm/templates/firewall/firewall.py.schema
+++ b/dm/templates/firewall/firewall.py.schema
@@ -23,6 +23,11 @@ required:
   - rules
 
 properties:
+  name:
+    type: string
+    description: |
+      The (optional) firewall name. This is only for documentation purposes and
+      is used as the Deployment Manager resource name if set.
   network:
     type: string
     description: |


### PR DESCRIPTION
It isn't desirable to always have a hard coded resource name.