### PR TITLE
Don't require logObjectPrefix for buckets

### DIFF
--- a/dm/templates/gcs_bucket/gcs_bucket.py.schema
+++ b/dm/templates/gcs_bucket/gcs_bucket.py.schema
@@ -92,7 +92,6 @@ properties:
     type: object
     required:
       - logBucket
-      - logObjectPrefix
     properties:
       logBucket:
         type: string


### PR DESCRIPTION
https://cloud.google.com/storage/docs/access-logs
> Optionally, you can set the log_object_prefix object prefix for your log objects. The object prefix forms the beginning of the log object name. It can be at most 900 characters and must be a valid object name. By default, the object prefix is the name of the bucket for which the logs are enabled.

The default is fairly sane and not all users will want to override it.