### PR TITLE
Fixes #66: DM/gcs_bucket: refactoring

### DIFF
--- a/dm/templates/gcs_bucket/gcs_bucket.py
+++ b/dm/templates/gcs_bucket/gcs_bucket.py
@@ -18,16 +18,18 @@ def generate_config(context):
     """ Entry point for the deployment resources. """
 
     resources = []
-    project_id = context.env['project']
-    bucket_name = context.properties.get('name', context.env['name'])
+    properties = context.properties
+    project_id = properties.get('project', context.env['project'])
+    bucket_name = properties.get('name', context.env['name'])
 
     # output variables
-    bucket_selflink = '$(ref.{}.selfLink)'.format(bucket_name)
+    bucket_selflink = '$(ref.{}.selfLink)'.format(context.env['name'])
     bucket_uri = 'gs://' + bucket_name + '/'
 
     bucket = {
-        'name': bucket_name,
-        'type': 'storage.v1.bucket',
+        'name': context.env['name'],
+        # https://cloud.google.com/storage/docs/json_api/v1/buckets
+        'type': 'gcp-types/storage-v1:buckets',
         'properties': {
             'project': project_id,
             'name': bucket_name
@@ -35,6 +37,14 @@ def generate_config(context):
     }
 
     optional_props = [
+        'acl',
+        'iamConfiguration',
+        'retentionPolicy',
+        'encryption',
+        'defaultEventBasedHold',
+        'cors',
+        'defaultObjectAcl',
+        'billing',
         'location',
         'versioning',
         'storageClass',
@@ -47,26 +57,31 @@ def generate_config(context):
     ]
 
     for prop in optional_props:
-        if prop in context.properties:
-            bucket['properties'][prop] = context.properties[prop]
+        if prop in properties:
+            bucket['properties'][prop] = properties[prop]
 
     resources.append(bucket)
 
     # If IAM policy bindings are defined, apply these bindings.
+    # https://cloud.google.com/storage/docs/json_api/v1/buckets/setIamPolicy
     storage_provider_type = 'gcp-types/storage-v1:storage.buckets.setIamPolicy'
-    bindings = context.properties.get('bindings', [])
+    bindings = properties.get('bindings', [])
     if bindings:
         iam_policy = {
-            'name': bucket_name + '-iampolicy',
+            'name': '{}-iampolicy'.format(context.env['name']),
             'action': (storage_provider_type),
             'properties':
                 {
-                    'bucket': '$(ref.' + bucket_name + '.name)',
+                    'bucket': '$(ref.{}.name)'.format(context.env['name']),
                     'project': project_id,
                     'bindings': bindings
                 }
         }
         resources.append(iam_policy)
+
+    if properties.get('billing', {}).get('requesterPays'):
+        for resource in resources:
+            resource['properties']['userProject'] = properties.get('userProject', context.env['project'])
 
     return {
         'resources':

--- a/dm/templates/gcs_bucket/gcs_bucket.py.schema
+++ b/dm/templates/gcs_bucket/gcs_bucket.py.schema
@@ -15,27 +15,87 @@
 info:
   title: Google Cloud Storage Bucket
   author: Sourced Group Inc.
+  version: 1.0.0
   description: |
     Supports creation of a Google Cloud Storage bucket.
+
     For more information on this resource:
     https://cloud.google.com/storage/docs/json_api/.
+
+    APIs endpoints used by this template:
+    - gcp-types/storage-v1:buckets =>
+        https://cloud.google.com/storage/docs/json_api/v1/buckets
+    - gcp-types/storage-v1:storage.buckets.setIamPolicy =>
+        https://cloud.google.com/storage/docs/json_api/v1/buckets/setIamPolicy
 
 imports:
   - path: gcs_bucket.py
 
 additionalProperties: false
 
-required:
-  - name
+allOf:
+  - oneOf:
+      - properties:
+          iamConfiguration:
+            properties:
+              bucketPolicyOnly:
+                properties:
+                  enabled:
+                    enum: [False]
+      - allOf:
+          - not:
+              required:
+                - acl
+          - not:
+              required:
+                - defaultObjectAcl
+          - required:
+              - iamConfiguration
+            properties:
+              iamConfiguration:
+                properties:
+                  bucketPolicyOnly:
+                    properties:
+                      enabled:
+                        enum: [True]
+  - oneOf:
+      - allOf:
+          - not:
+              required:
+                - userProject
+          - properties:
+              billing:
+                properties:
+                  requesterPays:
+                    enum: [False]
+      - allOf:
+          - required:
+              - billing
+          - properties:
+              billing:
+                properties:
+                  requesterPays:
+                    enum: [True]
 
 properties:
   name:
     type: string
-    description: The name of the bucket.
+    description: The name of the bucket. Resource name would be used if omitted.
+  project:
+    type: string
+    description: |
+      The project ID of the project containing the bucket.
+  userProject:
+    type: string
+    description: |
+      The project to be billed for this request. Current project is used if not set.
   location:
     type: string
     default: us-east1
     description: The region name where the bucket is deployed.
+  defaultEventBasedHold:
+    type: boolean
+    description: Whether or not to automatically apply an eventBasedHold to new objects added to the bucket.
   storageClass:
     type: string
     default: STANDARD
@@ -52,6 +112,7 @@ properties:
       - DURABLE_REDUCED_AVAILABILITY
   versioning:
     type: object
+    additionalProperties: false
     description: Enables/disables object versioning.
     required:
       - enabled
@@ -88,8 +149,73 @@ properties:
       an alias for a set of specific ACL entries that you can use to quickly
       apply multiple ACL entries to a bucket or object in a single operation.
       Ref: https://cloud.google.com/storage/docs/access-control/lists.
+  encryption:
+    type: object
+    additionalProperties: false
+    description: |
+      Encryption configuration for a bucket.
+    required:
+      - defaultKmsKeyName
+    properties:
+      defaultKmsKeyName:
+        type: string
+        description: |
+          A Cloud KMS key that will be used to encrypt objects inserted into this bucket,
+          if no encryption method is specified.
+  retentionPolicy:
+    type: object
+    additionalProperties: false
+    description: |
+      The bucket's retention policy, which defines the minimum age an object in the bucket
+      must have to be deleted or overwritten.
+    required:
+      - retentionPeriod
+    properties:
+      retentionPeriod:
+        type: integer
+        maximum: 3155760000
+        exclusiveMaximum: True
+        description: |
+          The period of time, in seconds, that objects in the bucket must be retained and cannot be deleted,
+          overwritten, or archived. The value must be less than 3,155,760,000 seconds.
+  iamConfiguration:
+    type: object
+    additionalProperties: false
+    description: |
+      The bucket's IAM configuration.
+    required:
+      - bucketPolicyOnly
+    properties:
+      bucketPolicyOnly:
+        type: object
+        additionalProperties: false
+        description: |
+          The bucket's Bucket Policy Only configuration.
+        required:
+          - enabled
+        properties:
+          enabled:
+            type: boolean
+            default: False
+            description: |
+              Whether or not the bucket uses Bucket Policy Only.
+              If set, access checks only use bucket-level IAM policies or above.
+  billing:
+    type: object
+    additionalProperties: false
+    description: |
+      The bucket's billing configuration.
+    required:
+      - requesterPays
+    properties:
+      requesterPays:
+        type: boolean
+        default: False
+        description: |
+          When set to true, Requester Pays is enabled for this bucket.
   logging:
     type: object
+    additionalProperties: false
     required:
       - logBucket
       - logObjectPrefix
@@ -97,48 +223,184 @@ properties:
       logBucket:
         type: string
         description: |
-          The destination bucket where the current bucket's logs 
+          The destination bucket where the current bucket's logs
           must be placed.
       logObjectPrefix:
         type: string
         description: The prefix for log object names.
+  cors:
+    type: array
+    uniqueItems: true
+    description: |
+      The bucket's Cross-Origin Resource Sharing (CORS) configuration.
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - method
+        - origin
+      properties:
+        maxAgeSeconds:
+          type: integer
+          description: |
+            The value, in seconds, to return in the Access-Control-Max-Age header used in preflight responses.
+        method:
+          type: array
+          uniqueItems: true
+          description: |
+            The list of HTTP methods on which to include CORS response headers, (GET, OPTIONS, POST, etc)
+            Note: "*" is permitted in the list of methods, and means "any method".
+          items:
+            type: string
+        origin:
+          type: array
+          uniqueItems: true
+          description: |
+            The list of Origins eligible to receive CORS response headers.
+            Note: "*" is permitted in the list of origins, and means "any Origin".
+          items:
+            type: string
+        responseHeader:
+          type: array
+          uniqueItems: true
+          description: |
+            The list of HTTP headers other than the simple response headers to give permission
+            for the user-agent to share across domains.
+          items:
+            type: string
+  defaultObjectAcl:
+    type: array
+    uniqueItems: true
+    description: |
+      Default access controls to apply to new objects when no ACL is provided.
+      This list defines an entity and role for one or more defaultObjectAccessControls Resources.
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - role
+        - entity
+      properties:
+        role:
+          type: string
+          description: |
+            The access permission for the entity.
+
+            Acceptable values are:
+            "OWNER"
+            "READER"
+          enum:
+            - OWNER
+            - READER
+        entity:
+          type: string
+          description: |
+            The entity holding the permission, in one of the following forms:
+            - user-userId
+            - user-email
+            - group-groupId
+            - group-email
+            - domain-domain
+            - project-team-projectId
+            - allUsers
+            - allAuthenticatedUsers
+
+            Examples:
+            - The user liz@example.com would be user-liz@example.com.
+            - The group example@googlegroups.com would be group-example@googlegroups.com.
+            - To refer to all members of the G Suite for Business domain example.com, the entity would be domain-example.com.
+  acl:
+    type: array
+    uniqueItems: true
+    description: |
+      Access controls on the bucket, containing one or more bucketAccessControls Resources.
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - role
+        - entity
+      properties:
+        role:
+          type: string
+          description: |
+            The access permission for the entity.
+          enum:
+            - OWNER
+            - READER
+            - WRITER
+        entity:
+          type: string
+          description: |
+            The entity holding the permission, in one of the following forms:
+            - user-userId
+            - user-email
+            - group-groupId
+            - group-email
+            - domain-domain
+            - project-team-projectId
+            - allUsers
+            - allAuthenticatedUsers
+
+            Examples:
+            - The user liz@example.com would be user-liz@example.com.
+            - The group example@googlegroups.com would be group-example@googlegroups.com.
+            - To refer to all members of the G Suite for Business domain example.com, the entity would be domain-example.com.
   bindings:
     type: array
+    uniqueItems: true
     description: IAM bindings for the bucket.
     items:
       type: object
+      additionalProperties: false
       required:
         - role
         - members
       properties:
         role:
           type: string
-          pattern: ^roles\/
+          pattern: ^roles\/storage\.
           description: The role to assign to members.
         members:
           type: array
+          uniqueItems: true
           items:
             type: string
             description: |
-              The member to add the binding for. Must be in the form user|
-              group|serviceAccount:email or domain:domain.
-              Can also be one of the following special values: allUsers,
-              allAuthenticatedUsers.
+              A collection of identifiers for members who may assume the provided role.
+              Recognized identifiers are as follows:
+              allUsers — A special identifier that represents anyone on the internet; with or without a Google account.
+              allAuthenticatedUsers — A special identifier that represents anyone who is authenticated with
+                a Google account or a service account.
+              user:emailid — An email address that represents a specific account. For example,
+                user:alice@gmail.com or user:joe@example.com.
+              serviceAccount:emailid — An email address that represents a service account. For example,
+                serviceAccount:my-other-app@appspot.gserviceaccount.com .
+              group:emailid — An email address that represents a Google group. For example, group:admins@example.com.
+              domain:domain — A G Suite domain name that represents all the users of that domain.
+                For example, domain:google.com or domain:example.com.
+              projectOwner:projectid — Owners of the given project. For example, projectOwner:my-example-project
+              projectEditor:projectid — Editors of the given project. For example, projectEditor:my-example-project
+              projectViewer:projectid — Viewers of the given project. For example, projectViewer:my-example-project
   lifecycle:
     type: object
+    additionalProperties: false
     description: The storage object's lifecycle actions and conditions.
     properties:
       rule:
         type: array
+        uniqueItems: true
         description: The lifecycle action and condition.
         items:
           type: object
+          additionalProperties: false
           required:
             - action
             - condition
           properties:
             action:
               type: object
+              additionalProperties: false
               description: The action to be taken if the condition is met.
               required:
                 - type
@@ -158,6 +420,7 @@ properties:
                     - Delete
             condition:
               type: object
+              additionalProperties: false
               description: The lifecycle condition.
               properties:
                 age:
@@ -171,6 +434,7 @@ properties:
                     For example, "2013-01-15".
                 matchesStorageClass:
                   type: array
+                  uniqueItems: true
                   description: |
                     All objects with any of the selected storage classes.
                   items:
@@ -198,6 +462,7 @@ properties:
     description: User-provided labels in key/value pairs.
   website:
     type: object
+    additionalProperties: false
     description: |
       The bucket's website configuration, controlling how the service behaves
       when accessing the bucket contents as a web site.


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/66

- Added version, links to docs
- Added uniqueItems: true to lists
- Switched to using type provider
- Added cross-project creation support
- Added additionalProperties: false for nested object
- Fixed "bindings" schema
- Added support for "requesterPays"
- Added support for "acl", "billing", "cors", "defaultEventBasedHold", "defaultObjectAcl", "encryption", "iamConfiguration", "retentionPolicy"
- Fixed resource name