### PR TITLE
Fixes #70: DM/instance: refactoring

### DIFF
--- a/dm/templates/instance/examples/instance.yaml
+++ b/dm/templates/instance/examples/instance.yaml
@@ -15,7 +15,9 @@ resources:
       machineType: f1-micro
       diskType: pd-ssd
       networks:
-        - name: default
+        - network: default
+          accessConfigs:
+            - type: ONE_TO_ONE_NAT
       metadata:
         items:
           - key: startup-script

--- a/dm/templates/instance/instance.py
+++ b/dm/templates/instance/instance.py
@@ -49,36 +49,31 @@ def get_network_interfaces(properties):
     """
     network_interfaces = []
 
-    networks = properties.get('networks', [{
-        "name": properties.get('network'),
-        "hasExternalIp": properties.get('hasExternalIp'),
-        "natIP": properties.get('natIP'),
-        "subnetwork": properties.get('subnetwork'),
-        "networkIP": properties.get('networkIP'),
-    }])
+    networks = properties.get('networks', [])
+    if len(networks) == 0 and properties.get('network'):
+        network = {
+            "network": properties.get('network'),
+            "subnetwork": properties.get('subnetwork'),
+            "networkIP": properties.get('networkIP'),
+        }
+        networks.append(network)
+        if (properties.get('hasExternalIp')):
+            network['accessConfigs'] = [{
+                "type": "ONE_TO_ONE_NAT",
+                "natIP": properties.get('natIP'),
+            }]
 
     for network in networks:
-        if not '.' in network['name'] and not '/' in network['name']:
-            network_name = 'global/networks/{}'.format(network['name'])
+        if not '.' in network['network'] and not '/' in network['network']:
+            network_name = 'global/networks/{}'.format(network['network'])
         else:
-            network_name = network['name']
+            network_name = network['network']
 
         network_interface = {
             'network': network_name,
         }
 
-        if network['hasExternalIp']:
-            access_configs = {
-                'name': 'External NAT',
-                'type': 'ONE_TO_ONE_NAT'
-            }
-
-            if network.get('natIP'):
-                access_configs['natIP'] = network['natIP']
-
-            network_interface['accessConfigs'] = [access_configs]
-
-        netif_optional_props = ['subnetwork', 'networkIP']
+        netif_optional_props = ['subnetwork', 'networkIP', 'aliasIpRanges', 'accessConfigs']
         for prop in netif_optional_props:
             if network.get(prop):
                 network_interface[prop] = network[prop]
@@ -90,39 +85,61 @@ def get_network_interfaces(properties):
 def generate_config(context):
     """ Entry point for the deployment resources. """
 
-    zone = context.properties['zone']
-    vm_name = context.properties.get('name', context.env['name'])
-    machine_type = context.properties['machineType']
+    properties = context.properties
+    zone = properties['zone']
+    vm_name = properties.get('name', context.env['name'])
+    project_id = properties.get('project', context.env['project'])
+    machine_type = properties['machineType']
 
-    boot_disk = create_boot_disk(context.properties, zone, vm_name)
-    network_interfaces = get_network_interfaces(context.properties)
+    network_interfaces = get_network_interfaces(properties)
     instance = {
-        'name': vm_name,
-        'type': 'compute.v1.instance',
+        'name': context.env['name'],
+        # https://cloud.google.com/compute/docs/reference/rest/v1/instances
+        'type': 'gcp-types/compute-v1:instances',
         'properties':{
+            'name': vm_name,
             'zone': zone,
+            'project': project_id,
             'machineType': 'zones/{}/machineTypes/{}'.format(zone,
                                                              machine_type),
-            'disks': [boot_disk],
             'networkInterfaces': network_interfaces
         }
     }
 
-    for name in ['metadata', 'serviceAccounts', 'canIpForward', 'tags']:
-        set_optional_property(instance['properties'], context.properties, name)
+    optionalProperties = [
+        'description',
+        'scheduling',
+        'disks',
+        'minCpuPlatform',
+        'guestAccelerators',
+        'deletionProtection',
+        'hostname',
+        'shieldedInstanceConfig',
+        'shieldedInstanceIntegrityPolicy',
+        'labels',
+        'metadata',
+        'serviceAccounts',
+        'canIpForward',
+        'tags',
+    ]
+    for name in optionalProperties:
+        set_optional_property(instance['properties'], properties, name)
+
+    if not properties.get('disks'):
+        instance['properties']['disks'] = [create_boot_disk(properties, zone, vm_name)]
 
     outputs = [
         {
             'name': 'networkInterfaces',
-            'value': '$(ref.{}.networkInterfaces)'.format(vm_name)
+            'value': '$(ref.{}.networkInterfaces)'.format(context.env['name'])
         },
         {
             'name': 'name',
-            'value': '$(ref.{}.name)'.format(vm_name)
+            'value': '$(ref.{}.name)'.format(context.env['name'])
         },
         {
             'name': 'selfLink',
-            'value': '$(ref.{}.selfLink)'.format(vm_name)
+            'value': '$(ref.{}.selfLink)'.format(context.env['name'])
         }
     ]
 

--- a/dm/templates/instance/instance.py.schema
+++ b/dm/templates/instance/instance.py.schema
@@ -15,8 +15,16 @@
 info:
   title: Compute Instance
   author: Sourced Group Inc.
+  version: 1.0.0
   description: |
     Deploys a Compute Instance connected to a custom (or default) network.
+
+    For more information on this resource:
+    https://cloud.google.com/compute/
+
+    APIs endpoints used by this template:
+    - gcp-types/compute-v1:instances =>
+        https://cloud.google.com/compute/docs/reference/rest/v1/instances
 
 imports:
   - path: instance.py
@@ -71,41 +79,65 @@ definitions:
         specify a static external IP address, it must live in the same region
         as the zone of the instance.
         If hasExternalIp is false this field is ignored.
+    network:
+      type: string
+      description: |
+        URL of the network resource for this instance. When creating an instance, if neither the network
+        nor the subnetwork is specified, the default network global/networks/default is used;
+        if the network is not specified but the subnetwork is specified, the network is inferred.
+
+        If you specify this property, you can specify the network as a full or partial URL.
+        For example, the following are all valid URLs:
+
+        - https://www.googleapis.com/compute/v1/projects/project/global/networks/network
+        - projects/project/global/networks/network
+        - global/networks/default
+        Authorization requires one or more of the following Google IAM permissions on the specified resource network:
+
+        - compute.networks.use
+        - compute.networks.useExternalIp
     subnetwork:
       type: string
       description: |
-        The URL of the Subnetwork resource for this instance. If the network
-        resource is in legacy mode, do not provide this property. If the network
-        is in auto subnet mode, providing the subnetwork is optional. If the
-        network is in custom subnet mode, then this field should be specified.
-        If you specify this property, you can specify the subnetwork as a full
-        or partial URL. For example, the following are all valid URLs:
-          - https://www.googleapis.com/compute/v1/projects/project/regions/region/subnetworks/subnetwork
-          - regions/region/subnetworks/subnetwork
+        The URL of the Subnetwork resource for this instance. If the network resource is in legacy mode,
+        do not specify this field. If the network is in auto subnet mode, specifying the subnetwork is optional.
+        If the network is in custom subnet mode, specifying the subnetwork is required.
+        If you specify this field, you can specify the subnetwork as a full or partial URL. For example, the following are all valid URLs:
+
+        - https://www.googleapis.com/compute/v1/projects/project/regions/region/subnetworks/subnetwork
+        - regions/region/subnetworks/subnetwork
+        Authorization requires one or more of the following Google IAM permissions on the specified resource subnetwork:
+
+        - compute.subnetworks.use
+        - compute.subnetworks.useExternalIp
     networkIP:
       type: string
       description: |
-        An IPv4 internal network address to assign to the instance for this
-        network interface. If not specified by the user, an unused internal IP
-        is assigned by the system.
+        An IPv4 internal IP address to assign to the instance for this network interface.
+        If not specified by the user, an unused internal IP is assigned by the system.
 
 properties:
   name:
     type: string
-    description: The name of the Instance resource.
-  network:
+    description: The name of the Instance resource. Resource name would be used if omitted.
+  project:
     type: string
     description: |
-      Name of the network the instance will be connected to;
-      e.g., 'my-custom-network' or 'default'.
-  hasExternalIp:
-    $ref: '#/definitions/hasExternalIp'
-  natIP:
-    $ref: '#/definitions/natIP'
+      The project ID of the project containing the instance.
+  description:
+    type: string
+    description: |
+      An optional description of this resource. Provide this property when you create the resource.
+  network:
+    $ref: '#/definitions/network'
   subnetwork:
     $ref: '#/definitions/subnetwork'
   networkIP:
     $ref: '#/definitions/networkIP'
+  hasExternalIp:
+    $ref: '#/definitions/hasExternalIp'
+  natIP:
+    $ref: '#/definitions/natIP'
   networks:
     type: array
     description: |
@@ -115,26 +147,89 @@ properties:
       type: object
       additionalProperties: false
       required:
-        - name
+        - network
       properties:
-        name:
-          type: string
-          description: |
-            Name of the network the instance will be connected to;
-            e.g., 'my-custom-network' or 'default'.
-        hasExternalIp:
-          $ref: '#/definitions/hasExternalIp'
-        natIP:
-          $ref: '#/definitions/natIP'
+        network:
+          $ref: '#/definitions/network'
         subnetwork:
           $ref: '#/definitions/subnetwork'
         networkIP:
           $ref: '#/definitions/networkIP'
+        aliasIpRanges:
+          type: array
+          uniqueItems: true
+          description: |
+            An array of alias IP ranges for this network interface. You can only specify this
+            field for network interfaces in VPC networks.
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              ipCidrRange:
+                type: string
+                description: |
+                  The IP alias ranges to allocate for this interface. This IP CIDR range must belong
+                  to the specified subnetwork and cannot contain IP addresses reserved by system or
+                  used by other network interfaces. This range may be a single IP address (such as 10.2.3.4),
+                  a netmask (such as /24) or a CIDR-formatted string (such as 10.1.2.0/24).
+              subnetworkRangeName:
+                type: string
+                description: |
+                  The name of a subnetwork secondary IP range from which to allocate an IP alias range.
+                  If not specified, the primary range of the subnetwork is used.
+        accessConfigs:
+          type: array
+          uniqueItems: true
+          description: |
+            An array of configurations for this interface. Currently, only one access config, ONE_TO_ONE_NAT,
+            is supported. If there are no accessConfigs specified, then this instance will have no external internet access.
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              type:
+                type: string
+                description: |
+                  The type of configuration. The default and only option is ONE_TO_ONE_NAT.
+                enum:
+                  - ONE_TO_ONE_NAT
+              name:
+                type: string
+                description: |
+                  The name of this access configuration. The default and recommended name is External NAT,
+                  but you can use any arbitrary string, such as My external IP or Network Access.
+              setPublicPtr:
+                type: boolean
+                description: |
+                  Specifies whether a public DNS 'PTR' record should be created to map the external
+                  IP address of the instance to a DNS domain name.
+              publicPtrDomainName:
+                type: string
+                description: |
+                  The DNS domain name for the public PTR record. You can set this field only
+                  if the setPublicPtr field is enabled.
+              networkTier:
+                type: string
+                description: |
+                  This signifies the networking tier used for configuring this access configuration
+                  and can only take the following values: PREMIUM, STANDARD.
+
+                  If an AccessConfig is specified without a valid external IP address, an
+                  ephemeral IP will be created with this networkTier.
+
+                  If an AccessConfig with a valid external IP address is specified, it must match
+                  that of the networkTier associated with the Address resource owning that IP.
+                enum:
+                  - STANDARD
+                  - PREMIUM
+              natIP:
+                $ref: '#/definitions/natIP'
   zone:
     type: string
     description: Availability zone. E.g. 'us-central1-a'
   tags:
     type: object
+    additionalProperties: false
     description: |
       Tags to apply to this instance. Tags are used to identify valid sources
       or targets for network firewalls and are specified by the client during
@@ -144,6 +239,7 @@ properties:
     properties:
       items:
         type: array
+        uniqueItems: true
         description: |
           An array of tags. Each tag must be 1-63 characters long, and comply
           with RFC1035.
@@ -154,6 +250,271 @@ properties:
     description: |
       The Compute Instance type; e.g., 'n1-standard-1'.
       See https://cloud.google.com/compute/docs/machine-types for details.
+  disks:
+    type: array
+    uniqueItems: true
+    description: |
+      Array of disks associated with this instance. Persistent disks must be created before you can assign them.
+    items:
+      type: object
+      additionalProperties: false
+      oneOf:
+        - required:
+            - source
+        - required:
+            - initializeParams
+        - allOf:
+            - not:
+                required:
+                  - source
+            - not:
+                required:
+                  - initializeParams
+      properties:
+        type:
+          type: string
+          description: |
+            Specifies the type of the disk, either SCRATCH or PERSISTENT. If not specified, the default is PERSISTENT.
+          enum:
+            - SCRATCH
+            - PERSISTENT
+        mode:
+          type: string
+          description: |
+            The mode in which to attach this disk, either READ_WRITE or READ_ONLY.
+            If not specified, the default is to attach the disk in READ_WRITE mode.
+          enum:
+            - READ_WRITE
+            - READ_ONLY
+        source:
+          type: string
+          description: |
+            Specifies a valid partial or full URL to an existing Persistent Disk resource.
+            When creating a new instance, one of initializeParams.sourceImage or
+            disks.source is required except for local SSD.
+
+            If desired, you can also attach existing non-root persistent disks using this property.
+            This field is only applicable for persistent disks.
+
+            Note that for InstanceTemplate, specify the disk name, not the URL for the disk.
+
+            Authorization requires one or more of the following Google IAM permissions on the specified resource source:
+
+            compute.disks.use
+            compute.disks.useReadOnly
+        deviceName:
+          type: string
+          description: |
+            Specifies a unique device name of your choice that is reflected into the /dev/disk/by-id/google-*
+            tree of a Linux operating system running within the instance. This name can be used to reference
+            the device for mounting, resizing, and so on, from within the instance.
+
+            If not specified, the server chooses a default device name to apply to this disk, in the
+            form persistent-disk-x, where x is a number assigned by Google Compute Engine.
+            This field is only applicable for persistent disks.
+        boot:
+          type: boolean
+          description: |
+            Indicates that this is a boot disk. The virtual machine will use the first partition
+            of the disk for its root filesystem.
+        initializeParams:
+          type: object
+          additionalProperties: false
+          description: |
+            Specifies the parameters for a new disk that will be created alongside the new instance.
+            Use initialization parameters to create boot disks or local SSDs attached to the new instance.
+
+            This property is mutually exclusive with the source property; you can only define one or the other, but not both.
+          properties:
+            labels:
+              type: object
+              description: |
+                Labels to apply to this disk. These can be later modified by the disks.setLabels method.
+                This field is only applicable for persistent disks.
+
+                An object containing a list of "key": value pairs.
+                Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+
+                Authorization requires the following Google IAM permission on the specified resource labels:
+
+                compute.disks.setLabels
+            diskName:
+              type: string
+              description: |
+                Specifies the disk name. If not specified, the default is to use the name of the instance.
+                If the disk with the instance name exists already in the given zone/region,
+                a new name will be automatically generated.
+            sourceImage:
+              type: string
+              description: |
+                The source image to create this disk. When creating a new instance, one of
+                initializeParams.sourceImage or disks.source is required except for local SSD.
+
+                To create a disk with one of the public operating system images, specify the image by its family name.
+                For example, specify family/debian-9 to use the latest Debian 9 image:
+
+                projects/debian-cloud/global/images/family/debian-9
+
+                Alternatively, use a specific version of a public operating system image:
+
+                projects/debian-cloud/global/images/debian-9-stretch-vYYYYMMDD
+
+                To create a disk with a custom image that you created, specify the image name in the following format:
+
+                global/images/my-custom-image
+
+                You can also specify a custom image by its image family, which returns the latest version of the
+                image in that family. Replace the image name with family/family-name:
+
+                global/images/family/my-image-family
+
+                If the source image is deleted later, this field will not be set.
+
+                Authorization requires the following Google IAM permission on the specified resource sourceImage:
+
+                compute.images.useReadOnly
+            description:
+              type: string
+              description: |
+                An optional description. Provide this property when creating the disk.
+            diskSizeGb:
+              type: number
+              description: |
+                Specifies the size of the disk in base-2 GB.
+            diskType:
+              type: string
+              description: |
+                Specifies the disk type to use to create the instance. If not specified, the default is pd-standard,
+                specified using the full URL. For example:
+
+                https://www.googleapis.com/compute/v1/projects/project/zones/zone/diskTypes/pd-standard
+
+                Other values include pd-ssd and local-ssd. If you define this field, you can provide either the full
+                or partial URL. For example, the following are valid values:
+
+                https://www.googleapis.com/compute/v1/projects/project/zones/zone/diskTypes/diskType
+                projects/project/zones/zone/diskTypes/diskType
+                zones/zone/diskTypes/diskType
+                Note that for InstanceTemplate, this is the name of the disk type, not URL.
+              enum:
+                - pd-standard
+                - pd-ssd
+                - local-ssd
+            sourceImageEncryptionKey:
+              type: object
+              additionalProperties: false
+              description: |
+                The customer-supplied encryption key of the source image. Required if the source image is
+                protected by a customer-supplied encryption key.
+
+                Instance templates do not store customer-supplied encryption keys, so you cannot create disks
+                for instances in a managed instance group if the source images are encrypted with your own keys.
+              properties:
+                rawKey:
+                  type: string
+                  description: |
+                    Specifies a 256-bit customer-supplied encryption key, encoded in RFC 4648 base64
+                    to either encrypt or decrypt this resource.
+                kmsKeyName:
+                  type: string
+                  description: |
+                    The name of the encryption key that is stored in Google Cloud KMS.
+            sourceSnapshot:
+              type: string
+              description: |
+                The source snapshot to create this disk. When creating a new instance, one of
+                initializeParams.sourceSnapshot or disks.source is required except for local SSD.
+
+                To create a disk with a snapshot that you created, specify the snapshot name in the following format:
+
+                global/snapshots/my-backup
+
+                If the source snapshot is deleted later, this field will not be set.
+
+                Authorization requires the following Google IAM permission on the specified resource sourceSnapshot:
+
+                compute.snapshots.useReadOnly
+            sourceSnapshotEncryptionKey:
+              type: object
+              additionalProperties: false
+              description: |
+                The customer-supplied encryption key of the source snapshot.
+              properties:
+                rawKey:
+                  type: string
+                  description: |
+                    Specifies a 256-bit customer-supplied encryption key, encoded in RFC 4648 base64
+                    to either encrypt or decrypt this resource.
+                kmsKeyName:
+                  type: string
+                  description: |
+                    The name of the encryption key that is stored in Google Cloud KMS.
+        autoDelete:
+          type: boolean
+          description: |
+            Specifies whether the disk will be auto-deleted when the instance is deleted
+            (but not when the disk is detached from the instance).
+        interface:
+          type: string
+          description: |
+            Specifies the disk interface to use for attaching this disk, which is either SCSI or NVME.
+            The default is SCSI. Persistent disks must always use SCSI and the request will fail if you
+            attempt to attach a persistent disk in any other format than SCSI. Local SSDs can use either NVME or SCSI.
+            For performance characteristics of SCSI over NVMe, see Local SSD performance.
+          enum:
+            - SCSI
+            - NVME
+        guestOsFeatures:
+          type: array
+          uniqueItems: true
+          description: |
+            A list of features to enable on the guest operating system. Applicable only for bootable images.
+            Read Enabling guest operating system features to see a list of available options.
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              type:
+                type: string
+                description: |
+                  https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#guest-os-features
+                  The ID of a supported feature. Read Enabling guest operating system features
+                  to see a list of available options.
+                enum:
+                  - MULTI_IP_SUBNET
+                  - SECURE_BOOT
+                  - UEFI_COMPATIBLE
+                  - VIRTIO_SCSI_MULTIQUEUE
+                  - WINDOWS
+        diskEncryptionKey:
+          type: object
+          additionalProperties: false
+          description: |
+            The customer-supplied encryption key of the source snapshot.
+          properties:
+            rawKey:
+              type: string
+              description: |
+                Encrypts or decrypts a disk using a customer-supplied encryption key.
+
+                If you are creating a new disk, this field encrypts the new disk using an encryption
+                key that you provide. If you are attaching an existing disk that is already encrypted,
+                this field decrypts the disk using the customer-supplied encryption key.
+
+                If you encrypt a disk using a customer-supplied key, you must provide the same key again when
+                you attempt to use this resource at a later time. For example, you must provide the key when
+                you create a snapshot or an image from the disk or when you attach the disk
+                to a virtual machine instance.
+
+                If you do not provide an encryption key, then the disk will be encrypted using an automatically
+                generated key and you do not need to provide a key to use the disk later.
+
+                Instance templates do not store customer-supplied encryption keys, so you cannot use your own keys
+                to encrypt disks in a managed instance group.
+            kmsKeyName:
+              type: string
+              description: |
+                The name of the encryption key that is stored in Google Cloud KMS.
   canIpForward:
     type: boolean
     default: False
@@ -181,8 +542,116 @@ properties:
   diskSizeGb:
     type: integer
     minimum: 10
+  scheduling:
+    type: object
+    additionalProperties: false
+    description: |
+      Sets the scheduling options for this instance.
+    properties:
+      onHostMaintenance:
+        type: string
+        description: |
+          Defines the maintenance behavior for this instance. For standard instances, the default behavior is MIGRATE.
+          For preemptible instances, the default and only possible behavior is TERMINATE.
+          For more information, see Setting Instance Scheduling Options.
+        enum:
+          - MIGRATE
+          - TERMINATE
+      automaticRestart:
+        type: boolean
+        description: |
+          Specifies whether the instance should be automatically restarted if it is terminated by Compute Engine
+          (not terminated by a user). You can only set the automatic restart option for standard instances.
+          Preemptible instances cannot be automatically restarted.
+
+          By default, this is set to true so an instance is automatically restarted if it is terminated by Compute Engine.
+      preemptible:
+        type: boolean
+        description: |
+          Defines whether the instance is preemptible. This can only be set during instance creation,
+          it cannot be set or changed after the instance has been created.
+      nodeAffinities:
+        type: array
+        uniqueItems: true
+        description: |
+          A set of node affinity and anti-affinity.
+        items:
+          type: object
+          additionalProperties: false
+          properties:
+            key:
+              type: string
+              description: |
+                Corresponds to the label key of Node resource.
+            operator:
+              type: string
+              description: |
+                Defines the operation of node selection.
+            values:
+              type: array
+              uniqueItems: true
+              description: |
+                Corresponds to the label values of Node resource.
+              items:
+                type: string
+  deletionProtection:
+    type: boolean
+    description: |
+      Whether the resource should be protected against deletion.
+
+      Authorization requires the following Google IAM permission on the specified resource deletionProtection:
+
+      compute.instances.setDeletionProtection
+  hostname:
+    type: string
+  labels:
+    type: object
+    description: |
+      Labels to apply to this instance. These can be later modified by the setLabels method.
+
+      An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+
+      Authorization requires the following Google IAM permission on the specified resource labels:
+
+      compute.instances.setLabels
+  minCpuPlatform:
+    type: string
+    description: |
+      Specifies a minimum CPU platform for the VM instance. Applicable values are the friendly names of CPU platforms,
+      such as minCpuPlatform: "Intel Haswell" or minCpuPlatform: "Intel Sandy Bridge".
+    enum:
+      - Intel Sandy Bridge
+      - Intel Ivy Bridge
+      - Intel Haswell
+      - Intel Broadwell
+      - Intel Skylake
+  shieldedInstanceConfig:
+    type: object
+    additionalProperties: false
+    properties:
+      enableSecureBoot:
+        type: boolean
+        description: |
+          Defines whether the instance has Secure Boot enabled.
+      enableVtpm:
+        type: boolean
+        description: |
+          Defines whether the instance has the vTPM enabled.
+      enableIntegrityMonitoring:
+        type: boolean
+        description: |
+          Defines whether the instance has integrity monitoring enabled.
+  shieldedInstanceIntegrityPolicy:
+    type: object
+    additionalProperties: false
+    properties:
+      updateAutoLearnPolicy:
+        type: boolean
+        description: |
+          Updates the integrity policy baseline using the measurements from the VM instance's most recent boot.
   metadata:
     type: object
+    additionalProperties: false
     required:
       - items
     description: |
@@ -194,7 +663,9 @@ properties:
     properties:
       items:
         type: array
-        description: A collection of metadata key-value pairs.
+        uniqueItems: true
+        description: |
+          A collection of metadata key-value pairs.
         items:
           type: object
           additionalProperties: false
@@ -205,6 +676,7 @@ properties:
               type: [string, number, boolean]
   serviceAccounts:
     type: array
+    uniqueItems: true
     description: |
       A list of service accounts, with their specified scopes, authorized for
       this instance. Only one service account per VM instance is supported.
@@ -214,16 +686,37 @@ properties:
       properties:
         email:
           type: string
-          description: Email address of the service account
+          description: |
+            Email address of the service account
         scopes:
           type: array
-          description: The list of scopes to be made available for this service account
+          description: |
+            The list of scopes to be made available for this service account
           items:
             type: string
             description: |
               Access scope, e.g. 'https://www.googleapis.com/auth/compute.readonly'
               Visit https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam
               for more details
+  guestAccelerators:
+    type: array
+    uniqueItems: true
+    description: |
+      A list of the type and count of accelerator cards attached to the instance.
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        acceleratorType:
+          type: string
+          description: |
+            Full or partial URL of the accelerator type resource to attach to this instance. For example: projects/my-project/zones/us-central1-c/acceleratorTypes/nvidia-tesla-p100
+            If you are creating an instance template, specify only the accelerator name.
+            See GPUs on Compute Engine for a full list of accelerator types.
+        acceleratorCount:
+          type: integer
+          description: |
+            The number of the guest accelerator cards exposed to this instance.
 
 outputs:
   properties:


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/70

- Added version, links to docs
- Switched to using type provider
- Added cross-project creation support
- Added additionalProperties: false for nested objects
- Added support for "description", "networkInterfaces[].accessConfigs[]",
"networkInterfaces[].aliasIpRanges[]", "disks", "scheduling", "labels",
"minCpuPlatform", "guestAccelerators", "deletionProtection", "hostname",
"shieldedInstanceConfig", "shieldedInstanceIntegrityPolicy":
[docs](https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert)
- Fixed resource name