### PR TITLE
Fixes #68: DM/instance_template: refactoring

### DIFF
--- a/dm/templates/instance_template/examples/instance_template.yaml
+++ b/dm/templates/instance_template/examples/instance_template.yaml
@@ -12,7 +12,9 @@ resources:
     properties:
       diskImage: projects/ubuntu-os-cloud/global/images/family/ubuntu-1804-lts
       networks:
-        - default
+        - network: default
+          accessConfigs:
+            - type: ONE_TO_ONE_NAT
       machineType: f1-micro
       tags:
         items:

--- a/dm/templates/instance_template/instance_template.py.schema
+++ b/dm/templates/instance_template/instance_template.py.schema
@@ -15,10 +15,16 @@
 info:
   title: Instance Template
   author: Sourced Group Inc.
+  version: 1.0.0
   description: |
     Creates an instance template.
 
-additionalProperties: false
+    For more information on this resource:
+    https://cloud.google.com/compute/
+
+    APIs endpoints used by this template:
+    - gcp-types/compute-v1:instanceTemplates =>
+        https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates
 
 required:
   - diskImage
@@ -49,6 +55,8 @@ oneOf:
        required:
          - networks
 
+additionalProperties: false
+
 definitions:
   hasExternalIp:
     type: boolean
@@ -66,49 +74,70 @@ definitions:
       specify a static external IP address, it must live in the same region
       as the zone of the instance.
       If hasExternalIp is false this field is ignored.
+  network:
+    type: string
+    description: |
+      URL of the network resource for this instance. When creating an instance, if neither the network
+      nor the subnetwork is specified, the default network global/networks/default is used;
+      if the network is not specified but the subnetwork is specified, the network is inferred.
+
+      If you specify this property, you can specify the network as a full or partial URL.
+      For example, the following are all valid URLs:
+
+      - https://www.googleapis.com/compute/v1/projects/project/global/networks/network
+      - projects/project/global/networks/network
+      - global/networks/default
+      Authorization requires one or more of the following Google IAM permissions on the specified resource network:
+
+      - compute.networks.use
+      - compute.networks.useExternalIp
   subnetwork:
     type: string
     description: |
-      The URL of the Subnetwork resource for this instance. If the network
-      resource is in legacy mode, do not provide this property. If the network
-      is in auto subnet mode, providing the subnetwork is optional. If the
-      network is in custom subnet mode, then this field should be specified.
-      If you specify this property, you can specify the subnetwork as a full
-      or partial URL. For example, the following are all valid URLs:
-        - https://www.googleapis.com/compute/v1/projects/project/regions/region/subnetworks/subnetwork
-        - regions/region/subnetworks/subnetwork
+      The URL of the Subnetwork resource for this instance. If the network resource is in legacy mode,
+      do not specify this field. If the network is in auto subnet mode, specifying the subnetwork is optional.
+      If the network is in custom subnet mode, specifying the subnetwork is required.
+      If you specify this field, you can specify the subnetwork as a full or partial URL. For example, the following are all valid URLs:
+
+      - https://www.googleapis.com/compute/v1/projects/project/regions/region/subnetworks/subnetwork
+      - regions/region/subnetworks/subnetwork
+      Authorization requires one or more of the following Google IAM permissions on the specified resource subnetwork:
+
+      - compute.subnetworks.use
+      - compute.subnetworks.useExternalIp
   networkIP:
     type: string
     description: |
-      An IPv4 internal network address to assign to the instance for this
-      network interface. If not specified by the user, an unused internal IP
-      is assigned by the system.
+      An IPv4 internal IP address to assign to the instance for this network interface.
+      If not specified by the user, an unused internal IP is assigned by the system.
 
 properties:
   name:
     type: string
-    description: The name of the instance template resource.
+    description: The name of the instance template resource. Resource name would be used if omitted.
+  project:
+    type: string
+    description: |
+      The project ID of the project containing the instance.
   templateDescription:
     type: string
-    description: The resource description (optional).
+    description: |
+      The resource description (optional).
   instanceDescription:
     type: string
     description: |
       The description of the instance resource the instance template
       will create (optional).
   network:
-    type: string
-    description: |
-      Name of the network the instance will be connected to;
-      e.g., 'my-custom-network' or 'default'.
-  hasExternalIp:
-    $ref: '#/definitions/hasExternalIp'
-  natIP:
-    $ref: '#/definitions/natIP'
+    $ref: '#/definitions/network'
   subnetwork:
     $ref: '#/definitions/subnetwork'
   networkIP:
     $ref: '#/definitions/networkIP'
+  hasExternalIp:
+    $ref: '#/definitions/hasExternalIp'
+  natIP:
+    $ref: '#/definitions/natIP'
   networks:
     type: array
     description: |
@@ -118,27 +147,512 @@ properties:
       type: object
       additionalProperties: false
       required:
-        - name
+        - network
       properties:
-        name:
-          type: string
-          description: |
-            Name of the network the instance will be connected to;
-            e.g., 'my-custom-network' or 'default'.
-        hasExternalIp:
-          $ref: '#/definitions/hasExternalIp'
-        natIP:
-          $ref: '#/definitions/natIP'
+        network:
+          $ref: '#/definitions/network'
         subnetwork:
           $ref: '#/definitions/subnetwork'
         networkIP:
           $ref: '#/definitions/networkIP'
+        aliasIpRanges:
+          type: array
+          uniqueItems: true
+          description: |
+            An array of alias IP ranges for this network interface. You can only specify this
+            field for network interfaces in VPC networks.
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              ipCidrRange:
+                type: string
+                description: |
+                  The IP alias ranges to allocate for this interface. This IP CIDR range must belong
+                  to the specified subnetwork and cannot contain IP addresses reserved by system or
+                  used by other network interfaces. This range may be a single IP address (such as 10.2.3.4),
+                  a netmask (such as /24) or a CIDR-formatted string (such as 10.1.2.0/24).
+              subnetworkRangeName:
+                type: string
+                description: |
+                  The name of a subnetwork secondary IP range from which to allocate an IP alias range.
+                  If not specified, the primary range of the subnetwork is used.
+        accessConfigs:
+          type: array
+          uniqueItems: true
+          description: |
+            An array of configurations for this interface. Currently, only one access config, ONE_TO_ONE_NAT,
+            is supported. If there are no accessConfigs specified, then this instance will have no external internet access.
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              type:
+                type: string
+                description: |
+                  The type of configuration. The default and only option is ONE_TO_ONE_NAT.
+                enum:
+                  - ONE_TO_ONE_NAT
+              name:
+                type: string
+                description: |
+                  The name of this access configuration. The default and recommended name is External NAT,
+                  but you can use any arbitrary string, such as My external IP or Network Access.
+              setPublicPtr:
+                type: boolean
+                description: |
+                  Specifies whether a public DNS 'PTR' record should be created to map the external
+                  IP address of the instance to a DNS domain name.
+              publicPtrDomainName:
+                type: string
+                description: |
+                  The DNS domain name for the public PTR record. You can set this field only
+                  if the setPublicPtr field is enabled.
+              networkTier:
+                type: string
+                description: |
+                  This signifies the networking tier used for configuring this access configuration
+                  and can only take the following values: PREMIUM, STANDARD.
+
+                  If an AccessConfig is specified without a valid external IP address, an
+                  ephemeral IP will be created with this networkTier.
+
+                  If an AccessConfig with a valid external IP address is specified, it must match
+                  that of the networkTier associated with the Address resource owning that IP.
+                enum:
+                  - STANDARD
+                  - PREMIUM
+              natIP:
+                $ref: '#/definitions/natIP'
+  disks:
+    type: array
+    uniqueItems: true
+    description: |
+      Array of disks associated with this instance. Persistent disks must be created before you can assign them.
+    items:
+      type: object
+      additionalProperties: false
+      oneOf:
+        - required:
+            - source
+        - required:
+            - initializeParams
+        - allOf:
+            - not:
+                required:
+                  - source
+            - not:
+                required:
+                  - initializeParams
+      properties:
+        type:
+          type: string
+          description: |
+            Specifies the type of the disk, either SCRATCH or PERSISTENT. If not specified, the default is PERSISTENT.
+          enum:
+            - SCRATCH
+            - PERSISTENT
+        mode:
+          type: string
+          description: |
+            The mode in which to attach this disk, either READ_WRITE or READ_ONLY.
+            If not specified, the default is to attach the disk in READ_WRITE mode.
+          enum:
+            - READ_WRITE
+            - READ_ONLY
+        source:
+          type: string
+          description: |
+            Specifies a valid partial or full URL to an existing Persistent Disk resource.
+            When creating a new instance, one of initializeParams.sourceImage or
+            disks.source is required except for local SSD.
+
+            If desired, you can also attach existing non-root persistent disks using this property.
+            This field is only applicable for persistent disks.
+
+            Note that for InstanceTemplate, specify the disk name, not the URL for the disk.
+
+            Authorization requires one or more of the following Google IAM permissions on the specified resource source:
+
+            compute.disks.use
+            compute.disks.useReadOnly
+        deviceName:
+          type: string
+          description: |
+            Specifies a unique device name of your choice that is reflected into the /dev/disk/by-id/google-*
+            tree of a Linux operating system running within the instance. This name can be used to reference
+            the device for mounting, resizing, and so on, from within the instance.
+
+            If not specified, the server chooses a default device name to apply to this disk, in the
+            form persistent-disk-x, where x is a number assigned by Google Compute Engine.
+            This field is only applicable for persistent disks.
+        boot:
+          type: boolean
+          description: |
+            Indicates that this is a boot disk. The virtual machine will use the first partition
+            of the disk for its root filesystem.
+        initializeParams:
+          type: object
+          additionalProperties: false
+          description: |
+            Specifies the parameters for a new disk that will be created alongside the new instance.
+            Use initialization parameters to create boot disks or local SSDs attached to the new instance.
+
+            This property is mutually exclusive with the source property; you can only define one or the other, but not both.
+          properties:
+            labels:
+              type: object
+              description: |
+                Labels to apply to this disk. These can be later modified by the disks.setLabels method.
+                This field is only applicable for persistent disks.
+
+                An object containing a list of "key": value pairs.
+                Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+
+                Authorization requires the following Google IAM permission on the specified resource labels:
+
+                compute.disks.setLabels
+            diskName:
+              type: string
+              description: |
+                Specifies the disk name. If not specified, the default is to use the name of the instance.
+                If the disk with the instance name exists already in the given zone/region,
+                a new name will be automatically generated.
+            sourceImage:
+              type: string
+              description: |
+                The source image to create this disk. When creating a new instance, one of
+                initializeParams.sourceImage or disks.source is required except for local SSD.
+
+                To create a disk with one of the public operating system images, specify the image by its family name.
+                For example, specify family/debian-9 to use the latest Debian 9 image:
+
+                projects/debian-cloud/global/images/family/debian-9
+
+                Alternatively, use a specific version of a public operating system image:
+
+                projects/debian-cloud/global/images/debian-9-stretch-vYYYYMMDD
+
+                To create a disk with a custom image that you created, specify the image name in the following format:
+
+                global/images/my-custom-image
+
+                You can also specify a custom image by its image family, which returns the latest version of the
+                image in that family. Replace the image name with family/family-name:
+
+                global/images/family/my-image-family
+
+                If the source image is deleted later, this field will not be set.
+
+                Authorization requires the following Google IAM permission on the specified resource sourceImage:
+
+                compute.images.useReadOnly
+            description:
+              type: string
+              description: |
+                An optional description. Provide this property when creating the disk.
+            diskSizeGb:
+              type: number
+              description: |
+                Specifies the size of the disk in base-2 GB.
+            diskType:
+              type: string
+              description: |
+                Specifies the disk type to use to create the instance. If not specified, the default is pd-standard,
+                specified using the full URL. For example:
+
+                https://www.googleapis.com/compute/v1/projects/project/zones/zone/diskTypes/pd-standard
+
+                Other values include pd-ssd and local-ssd. If you define this field, you can provide either the full
+                or partial URL. For example, the following are valid values:
+
+                https://www.googleapis.com/compute/v1/projects/project/zones/zone/diskTypes/diskType
+                projects/project/zones/zone/diskTypes/diskType
+                zones/zone/diskTypes/diskType
+                Note that for InstanceTemplate, this is the name of the disk type, not URL.
+              enum:
+                - pd-standard
+                - pd-ssd
+                - local-ssd
+            sourceImageEncryptionKey:
+              type: object
+              additionalProperties: false
+              description: |
+                The customer-supplied encryption key of the source image. Required if the source image is
+                protected by a customer-supplied encryption key.
+
+                Instance templates do not store customer-supplied encryption keys, so you cannot create disks
+                for instances in a managed instance group if the source images are encrypted with your own keys.
+              properties:
+                rawKey:
+                  type: string
+                  description: |
+                    Specifies a 256-bit customer-supplied encryption key, encoded in RFC 4648 base64
+                    to either encrypt or decrypt this resource.
+                kmsKeyName:
+                  type: string
+                  description: |
+                    The name of the encryption key that is stored in Google Cloud KMS.
+            sourceSnapshot:
+              type: string
+              description: |
+                The source snapshot to create this disk. When creating a new instance, one of
+                initializeParams.sourceSnapshot or disks.source is required except for local SSD.
+
+                To create a disk with a snapshot that you created, specify the snapshot name in the following format:
+
+                global/snapshots/my-backup
+
+                If the source snapshot is deleted later, this field will not be set.
+
+                Authorization requires the following Google IAM permission on the specified resource sourceSnapshot:
+
+                compute.snapshots.useReadOnly
+            sourceSnapshotEncryptionKey:
+              type: object
+              additionalProperties: false
+              description: |
+                The customer-supplied encryption key of the source snapshot.
+              properties:
+                rawKey:
+                  type: string
+                  description: |
+                    Specifies a 256-bit customer-supplied encryption key, encoded in RFC 4648 base64
+                    to either encrypt or decrypt this resource.
+                kmsKeyName:
+                  type: string
+                  description: |
+                    The name of the encryption key that is stored in Google Cloud KMS.
+        autoDelete:
+          type: boolean
+          description: |
+            Specifies whether the disk will be auto-deleted when the instance is deleted
+            (but not when the disk is detached from the instance).
+        interface:
+          type: string
+          description: |
+            Specifies the disk interface to use for attaching this disk, which is either SCSI or NVME.
+            The default is SCSI. Persistent disks must always use SCSI and the request will fail if you
+            attempt to attach a persistent disk in any other format than SCSI. Local SSDs can use either NVME or SCSI.
+            For performance characteristics of SCSI over NVMe, see Local SSD performance.
+          enum:
+            - SCSI
+            - NVME
+        guestOsFeatures:
+          type: array
+          uniqueItems: true
+          description: |
+            A list of features to enable on the guest operating system. Applicable only for bootable images.
+            Read Enabling guest operating system features to see a list of available options.
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              type:
+                type: string
+                description: |
+                  https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#guest-os-features
+                  The ID of a supported feature. Read Enabling guest operating system features
+                  to see a list of available options.
+                enum:
+                  - MULTI_IP_SUBNET
+                  - SECURE_BOOT
+                  - UEFI_COMPATIBLE
+                  - VIRTIO_SCSI_MULTIQUEUE
+                  - WINDOWS
+        diskEncryptionKey:
+          type: object
+          additionalProperties: false
+          description: |
+            The customer-supplied encryption key of the source snapshot.
+          properties:
+            rawKey:
+              type: string
+              description: |
+                Encrypts or decrypts a disk using a customer-supplied encryption key.
+
+                If you are creating a new disk, this field encrypts the new disk using an encryption
+                key that you provide. If you are attaching an existing disk that is already encrypted,
+                this field decrypts the disk using the customer-supplied encryption key.
+
+                If you encrypt a disk using a customer-supplied key, you must provide the same key again when
+                you attempt to use this resource at a later time. For example, you must provide the key when
+                you create a snapshot or an image from the disk or when you attach the disk
+                to a virtual machine instance.
+
+                If you do not provide an encryption key, then the disk will be encrypted using an automatically
+                generated key and you do not need to provide a key to use the disk later.
+
+                Instance templates do not store customer-supplied encryption keys, so you cannot use your own keys
+                to encrypt disks in a managed instance group.
+            kmsKeyName:
+              type: string
+              description: |
+                The name of the encryption key that is stored in Google Cloud KMS.
   machineType:
     type: string
     default: n1-standard-1
     description: |
       The Compute Instance type; e.g., 'n1-standard-1'.
       See https://cloud.google.com/compute/docs/machine-types for details.
+  scheduling:
+    type: object
+    additionalProperties: false
+    description: |
+      Sets the scheduling options for this instance.
+    properties:
+      onHostMaintenance:
+        type: string
+        description: |
+          Defines the maintenance behavior for this instance. For standard instances, the default behavior is MIGRATE.
+          For preemptible instances, the default and only possible behavior is TERMINATE.
+          For more information, see Setting Instance Scheduling Options.
+        enum:
+          - MIGRATE
+          - TERMINATE
+      automaticRestart:
+        type: boolean
+        description: |
+          Specifies whether the instance should be automatically restarted if it is terminated by Compute Engine
+          (not terminated by a user). You can only set the automatic restart option for standard instances.
+          Preemptible instances cannot be automatically restarted.
+
+          By default, this is set to true so an instance is automatically restarted if it is terminated by Compute Engine.
+      preemptible:
+        type: boolean
+        description: |
+          Defines whether the instance is preemptible. This can only be set during instance creation,
+          it cannot be set or changed after the instance has been created.
+      nodeAffinities:
+        type: array
+        uniqueItems: true
+        description: |
+          A set of node affinity and anti-affinity.
+        items:
+          type: object
+          additionalProperties: false
+          properties:
+            key:
+              type: string
+              description: |
+                Corresponds to the label key of Node resource.
+            operator:
+              type: string
+              description: |
+                Defines the operation of node selection.
+            values:
+              type: array
+              uniqueItems: true
+              description: |
+                Corresponds to the label values of Node resource.
+              items:
+                type: string
+  minCpuPlatform:
+    type: string
+    description: |
+      Specifies a minimum CPU platform for the VM instance. Applicable values are the friendly names of CPU platforms,
+      such as minCpuPlatform: "Intel Haswell" or minCpuPlatform: "Intel Sandy Bridge".
+    enum:
+      - Intel Sandy Bridge
+      - Intel Ivy Bridge
+      - Intel Haswell
+      - Intel Broadwell
+      - Intel Skylake
+  sourceInstance:
+    type: string
+    description: |
+      The source instance used to create the template. You can provide this as a partial or full URL to the resource.
+      For example, the following are valid values:
+
+      - https://www.googleapis.com/compute/v1/projects/project/zones/zone/instances/instance
+      - projects/project/zones/zone/instances/instance
+
+      Authorization requires the following Google IAM permission on the specified resource sourceInstance:
+      - compute.instances.get
+  sourceInstanceParams:
+    type: object
+    additionalProperties: false
+    description: |
+      The source instance params to use to create this instance template.
+    properties:
+      diskConfigs:
+        type: array
+        uniqueItems: true
+        description: |
+          Attached disks configuration. If not provided, defaults are applied: For boot disk and any other R/W disks,
+          new custom images will be created from each disk. For read-only disks, they will be attached
+          in read-only mode. Local SSD disks will be created as blank volumes.
+        items:
+          type: object
+          additionalProperties: false
+          properties:
+            deviceName:
+              type: string
+              description: |
+                Specifies the device name of the disk to which the configurations apply to.
+            instantiateFrom:
+              type: string
+              description: |
+                Specifies whether to include the disk and what image to use. Possible values are:
+
+                - source-image: to use the same image that was used to create the source instance's corresponding disk.
+                  Applicable to the boot disk and additional read-write disks.
+                - source-image-family: to use the same image family that was used to create the source instance's
+                  corresponding disk. Applicable to the boot disk and additional read-write disks.
+                - custom-image: to use a user-provided image url for disk creation. Applicable to the boot disk and
+                  additional read-write disks.
+                - attach-read-only: to attach a read-only disk. Applicable to read-only disks.
+                - do-not-include: to exclude a disk from the template. Applicable to additional read-write disks,
+                  local SSDs, and read-only disks.
+              enum:
+                - source-image
+                - source-image-family
+                - custom-image
+                - attach-read-only
+            autoDelete:
+              type: boolean
+              description: |
+                Specifies whether the disk will be auto-deleted when the instance is deleted
+                (but not when the disk is detached from the instance).
+            customImage:
+              type: string
+              description: |
+                The custom source image to be used to restore this disk when instantiating this instance template..
+  shieldedInstanceConfig:
+    type: object
+    additionalProperties: false
+    properties:
+      enableSecureBoot:
+        type: boolean
+        description: |
+          Defines whether the instance has Secure Boot enabled.
+      enableVtpm:
+        type: boolean
+        description: |
+          Defines whether the instance has the vTPM enabled.
+      enableIntegrityMonitoring:
+        type: boolean
+        description: |
+          Defines whether the instance has integrity monitoring enabled.
+  guestAccelerators:
+    type: array
+    uniqueItems: true
+    description: |
+      A list of the type and count of accelerator cards attached to the instance.
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        acceleratorType:
+          type: string
+          description: |
+            Full or partial URL of the accelerator type resource to attach to this instance. For example: projects/my-project/zones/us-central1-c/acceleratorTypes/nvidia-tesla-p100
+            If you are creating an instance template, specify only the accelerator name.
+            See GPUs on Compute Engine for a full list of accelerator types.
+        acceleratorCount:
+          type: integer
+          description: |
+            The number of the guest accelerator cards exposed to this instance.
   canIpForward:
     type: boolean
     description: |
@@ -167,6 +681,7 @@ properties:
     minimum: 10
   metadata:
     type: object
+    additionalProperties: false
     description: |
       Instance metadata.
       For example:
@@ -177,9 +692,14 @@ properties:
     properties:
       items:
         type: array
+        uniqueItems: true
         description: The metadata key-value pairs.
         items:
           type: object
+          additionalProperties: false
+          required:
+            - key
+            - value
           properties:
             key:
               type: string
@@ -187,17 +707,20 @@ properties:
               type: string
   serviceAccounts:
     type: array
+    uniqueItems: true
     description: |
       The list of service accounts, with their specified scopes, authorized for
       this instance. Only one service account per VM instance is supported.
     items:
       type: object
+      additionalProperties: false
       properties:
         email:
           type: string
           description: The email address of the service account.
         scopes:
           type: array
+          uniqueItems: true
           description: |
             The list of scopes to be made available to the service account.
           items:
@@ -209,6 +732,7 @@ properties:
               for details
   tags:
     type: object
+    additionalProperties: false
     description: |
       The list of tags to apply to the instances that are created from the
       template. The tags identify valid sources or targets for network
@@ -216,6 +740,7 @@ properties:
     properties:
       items:
         type: array
+        uniqueItems: true
         description: The array of tags.
         items:
           type: string

--- a/dm/templates/instance_template/tests/integration/instance_template.bats
+++ b/dm/templates/instance_template/tests/integration/instance_template.bats
@@ -111,7 +111,6 @@ function teardown() {
         --format "yaml(properties.networkInterfaces[0])" \
         --project "${CLOUD_FOUNDATION_PROJECT_ID}"
     [[ "$status" -eq 0 ]]
-    [[ "$output" =~ "name: External NAT" ]]
     [[ "$output" =~ "type: ONE_TO_ONE_NAT" ]]
     [[ "$output" =~ "network: ${NET}" ]]
 }

--- a/dm/templates/instance_template/tests/integration/instance_template.yaml
+++ b/dm/templates/instance_template/tests/integration/instance_template.yaml
@@ -15,7 +15,10 @@ resources:
       name: it-${RAND}
       instanceDescription: Instance description
       templateDescription: Template description
-      network: $(ref.test-network-${RAND}.selfLink)
+      networks:
+        - network: $(ref.test-network-${RAND}.selfLink)
+          accessConfigs:
+            - type: ONE_TO_ONE_NAT
       diskImage: ${IMAGE}
       machineType: f1-micro
       canIpForward: true

--- a/dm/templates/instance_template/tests/integration/instance_template_networks.yaml
+++ b/dm/templates/instance_template/tests/integration/instance_template_networks.yaml
@@ -16,10 +16,14 @@ resources:
       instanceDescription: Instance description
       templateDescription: Template description
       networks:
-        - name: $(ref.test-network-0-${RAND}.selfLink)
+        - network: $(ref.test-network-0-${RAND}.selfLink)
           subnetwork: $(ref.test-subnetwork-0-${RAND}.selfLink)
-        - name: $(ref.test-network-1-${RAND}.selfLink)
+          accessConfigs:
+            - type: ONE_TO_ONE_NAT
+        - network: $(ref.test-network-1-${RAND}.selfLink)
           subnetwork: $(ref.test-subnetwork-1-${RAND}.selfLink)
+          accessConfigs:
+            - type: ONE_TO_ONE_NAT
       diskImage: ${IMAGE}
       machineType: f1-micro
       canIpForward: true


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/68

- Added version, links to docs
- Switched to using type provider
- Added cross-project creation support
- Added additionalProperties: false for nested objects
- Added support for "networkInterfaces[].accessConfigs[]", "disks",
"scheduling", "minCpuPlatform", "guestAccelerators",
"shieldedInstanceConfig", "sourceInstance", "sourceInstanceParams"
- Fixed resource name