### PR TITLE
Add compute.instanceAdmin.v1 for host project

### DIFF
--- a/infra/terraform/test_fixtures/terraform-google-forseti.tf
+++ b/infra/terraform/test_fixtures/terraform-google-forseti.tf
@@ -8,6 +8,7 @@ locals {
   forseti_host_project_required_roles = [
     "roles/compute.networkAdmin",
     "roles/compute.securityAdmin",
+    "roles/compute.instanceAdmin.v1",
   ]
 
   forseti_project_required_roles = [

--- a/infra/terraform/test_fixtures/terraform-google-forseti.tf
+++ b/infra/terraform/test_fixtures/terraform-google-forseti.tf
@@ -6,9 +6,7 @@ locals {
   ]
 
   forseti_host_project_required_roles = [
-    "roles/compute.networkAdmin",
-    "roles/compute.securityAdmin",
-    "roles/compute.instanceAdmin.v1",
+    "roles/compute.admin",
   ]
 
   forseti_project_required_roles = [


### PR DESCRIPTION
This patch fixes the error `google_compute_instance.main: Error loading machine type: googleapi: Error 403: Required 'compute.machineTypes.get' permission for 'projects/ci-forseti-host-6f38/zones/us-central1-f/machineTypes/f1-micro', forbidden`.