### PR TITLE
Fixes #99: DM/firewall: refactoring

### DIFF
--- a/dm/templates/firewall/firewall.py
+++ b/dm/templates/firewall/firewall.py
@@ -13,48 +13,43 @@
 # limitations under the License.
 """ This template creates firewall rules for a network. """
 
-
-def get_network(properties):
-    """ Gets a network name. """
-
-    network_name = properties.get('network')
-    if network_name:
-        is_self_link = '/' in network_name or '.' in network_name
-
-        if is_self_link:
-            network_url = network_name
-        else:
-            network_url = 'global/networks/{}'.format(network_name)
-
-    return network_url
+from hashlib import sha1
 
 
 def generate_config(context):
     """ Entry point for the deployment resources. """
 
-    network = context.properties.get('network')
+    properties = context.properties
+    project_id = properties.get('project', context.env['project'])
+    network = properties.get('network')
+    if network:
+        if not '/' in network or '.' in network:
+            network = 'global/networks/{}'.format(network)
+    else:
+        network = 'projects/{}/global/networks/{}'.format(
+            project_id,
+            properties.get('networkName', 'default')
+        )
 
     resources = []
     out = {}
-    for i, rule in enumerate(context.properties['rules'], 1000):
-        # Use VPC if specified in the properties. Otherwise, specify
-        # the network URL in the config. If the network is not specified in
-        # the config, the API defaults to 'global/networks/default'.
-        if network and not rule.get('network'):
-            rule['network'] = get_network(context.properties)
+    for i, rule in enumerate(properties['rules'], 1000):
+        res_name = sha1(rule['name']).hexdigest()[:10]
 
+        rule['network'] = network
         rule['priority'] = rule.get('priority', i)
+        rule['project'] = project_id
         resources.append(
             {
-                'name': rule['name'],
-                'type': 'compute.beta.firewall',
+                'name': res_name,
+                'type': 'gcp-types/compute-v1:firewalls',
                 'properties': rule
             }
         )
 
-        out[rule['name']] = {
-            'selfLink': '$(ref.' + rule['name'] + '.selfLink)',
-            'creationTimestamp': '$(ref.' + rule['name']
+        out[res_name] = {
+            'selfLink': '$(ref.' + res_name + '.selfLink)',
+            'creationTimestamp': '$(ref.' + res_name
                                  + '.creationTimestamp)',
         }
 

--- a/dm/templates/firewall/firewall.py.schema
+++ b/dm/templates/firewall/firewall.py.schema
@@ -15,56 +15,244 @@
 info:
   title: Firewall
   author: Sourced Group Inc.
-  description: Deploys firewall rules
+  version: 1.0.0
+  description: |
+    Deploys firewall rules.
+
+    For more information on this resource:
+    https://cloud.google.com/vpc/docs/firewalls
+
+    APIs endpoints used by this template:
+    - gcp-types/compute-v1:firewalls =>
+        https://cloud.google.com/compute/docs/reference/rest/v1/firewalls
 
 additionalProperties: false
 
 required:
   - rules
 
+allOf:
+  - oneOf:
+      - required:
+          - project
+      - required:
+          - network
+      - allOf:
+          - not:
+              required:
+                - project
+          - not:
+              required:
+                - network
+  - oneOf:
+      - required:
+          - networkName
+      - required:
+          - network
+      - allOf:
+          - not:
+              required:
+                - networkName
+          - not:
+              required:
+                - network
+
 properties:
+  project:
+    type: string
+    description: |
+      The project ID of the project containing firewall rules.
   network:
     type: string
     description: |
-      The network name. Defaults to 'global/networks/default'.
+      URL of the network resource for this firewall rule. If not specified when creating a firewall rule,
+      the default network is used.
+      This is deprecated and not compatible with setting "project", please use networkName
+  networkName:
+    type: string
+    description: |
+      The name of network to create firewalls in.
   rules:
     type: array
+    uniqueItems: True
     description: |
-      An array of firewall rules as defined in the documentation:
-      https://cloud.google.com/compute/docs/reference/rest/beta/firewalls.
+      An array of firewall rules.
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: |
+            Name of the resource; provided by the client when the resource is created. The name must be 1-63
+            characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match
+            the regular expression `a-z?. The first character must be a lowercase letter, and all following
+            characters (except for the last character) must be a dash, lowercase letter, or digit. The last character
+            must be a lowercase letter or digit.
+            Resource name would be used if omitted.
+        description:
+          type: string
+          description: |
+            An optional description of this resource. Provide this field when you create the resource.
+        priority:
+          type: integer
+          description: |
+            Priority for this rule. This is an integer between 0 and 65535, both inclusive.
+            Relative priorities determine which rule takes effect if multiple rules apply. Lower values indicate
+            higher priority. For example, a rule with priority 0 has higher precedence than a rule with priority 1.
+            DENY rules take precedence over ALLOW rules if they have equal priority. Note that VPC networks have
+            implied rules with a priority of 65535. To avoid conflicts with the implied rules, use a priority
+            number less than 65535.
 
-      If the 'priority' field value is set in a rule, that value is used "as is".
-      If the 'priority' field value is not set in the rule, the template sets
-      the priority to the same value as the rule's index in the array +1000.
-      For example, the priority for the first rule in the array becomes '1000', 
-      for the second rule '1001', and so on. If the 'priority' field is not set in 
-      any of the rules in the array, the ruleset is sorted by priority automatically. 
-      We strongly advise being consistent in your use of the 'priority' field: 
-      either provide or skip values in all instances throughout the ruleset.
+            If the 'priority' field value is not set in the rule, the template sets
+            the priority to the same value as the rule's index in the array +1000.
+            For example, the priority for the first rule in the array becomes '1000',
+            for the second rule '1001', and so on. If the 'priority' field is not set in
+            any of the rules in the array, the ruleset is sorted by priority automatically.
+            We strongly advise being consistent in your use of the 'priority' field:
+            either provide or skip values in all instances throughout the ruleset.
+        sourceRanges:
+          type: array
+          uniqueItems: True
+          description: |
+            If source ranges are specified, the firewall rule applies only to traffic that has a source IP address in
+            these ranges. These ranges must be expressed in CIDR format. One or both of sourceRanges and sourceTags
+            may be set. If both fields are set, the rule applies to traffic that has a source IP address within
+            sourceRanges OR a source IP from a resource with a matching tag listed in the sourceTags field.
+            The connection does not need to match both fields for the rule to apply. Only IPv4 is supported.
+          items:
+            type: string
+        destinationRanges:
+          type: array
+          uniqueItems: True
+          description: |
+            If destination ranges are specified, the firewall rule applies only to traffic that has destination IP
+            address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
+          items:
+            type: string
+        sourceTags:
+          type: array
+          uniqueItems: True
+          description: |
+            If source tags are specified, the firewall rule applies only to traffic with source IPs that match the
+            primary network interfaces of VM instances that have the tag and are in the same VPC network. Source tags
+            cannot be used to control traffic to an instance's external IP address, it only applies to traffic between
+            instances in the same virtual network. Because tags are associated with instances, not IP addresses.
+            One or both of sourceRanges and sourceTags may be set. If both fields are set, the firewall applies to
+            traffic that has a source IP address within sourceRanges OR a source IP from a resource with a matching
+            tag listed in the sourceTags field. The connection does not need to match both fields
+            for the firewall to apply.
+          items:
+            type: string
+        targetTags:
+          type: array
+          uniqueItems: True
+          description: |
+            A list of tags that controls which instances the firewall rule applies to. If targetTags are specified,
+            then the firewall rule applies only to instances in the VPC network that have one of those tags.
+            If no targetTags are specified, the firewall rule applies to all instances on the specified network.
+          items:
+            type: string
+        sourceServiceAccounts:
+          type: array
+          uniqueItems: True
+          description: |
+            If source service accounts are specified, the firewall rules apply only to traffic originating from
+            an instance with a service account in this list. Source service accounts cannot be used to control
+            traffic to an instance's external IP address because service accounts are associated with an instance,
+            not an IP address. sourceRanges can be set at the same time as sourceServiceAccounts. If both are set,
+            the firewall applies to traffic that has a source IP address within the sourceRanges OR a source IP
+            that belongs to an instance with service account listed in sourceServiceAccount. The connection does
+            not need to match both fields for the firewall to apply. sourceServiceAccounts cannot be used
+            at the same time as sourceTags or targetTags.
+          items:
+            type: string
+        allowed:
+          type: array
+          uniqueItems: True
+          description: |
+            The list of ALLOW rules specified by this firewall. Each rule specifies a protocol and
+            port-range tuple that describes a permitted connection.
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - IPProtocol
+            properties:
+              IPProtocol:
+                type: string
+                description: |
+                  The IP protocol to which this rule applies. The protocol type is required when creating
+                  a firewall rule. This value can either be one of the following well known protocol strings
+                  (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
+              ports:
+                type: array
+                uniqueItems: True
+                description: |
+                  An optional list of ports to which this rule applies. This field is only applicable for
+                  the UDP or TCP protocol. Each entry must be either an integer or a range.
+                  If not specified, this rule applies to connections through any port.
 
-      Example:
-        - name: allow-proxy-from-inside
-          allowed:
-            - IPProtocol: tcp
+                  Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
+                items:
+                  type: string
+        denied:
+          type: array
+          uniqueItems: True
+          description: |
+            The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range
+            tuple that describes a denied connection.
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - IPProtocol
+            properties:
+              IPProtocol:
+                type: string
+                description: |
+                  The IP protocol to which this rule applies. The protocol type is required when creating
+                  a firewall rule. This value can either be one of the following well known protocol strings
+                  (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
               ports:
-                - "80"
-                - "443"
-          description: This rule allows connectivity to HTTP proxies.
-          direction: INGRESS
-          sourceRanges:
-            - 10.0.0.0/8
-        - name: allow-dns-from-inside
-          allowed:
-            - IPProtocol: udp
-              ports:
-                - "53"
-            - IPProtocol: tcp
-              ports:
-                - "53"
-          description: This rule allows DNS queries to Google's 8.8.8.8
-          direction: EGRESS
-          destinationRanges:
-            - 8.8.8.8/32
+                type: array
+                uniqueItems: True
+                description: |
+                  An optional list of ports to which this rule applies. This field is only applicable for
+                  the UDP or TCP protocol. Each entry must be either an integer or a range.
+                  If not specified, this rule applies to connections through any port.
+
+                  Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
+                items:
+                  type: string
+        direction:
+          type: string
+          description: |
+            Direction of traffic to which this firewall applies, either INGRESS or EGRESS.
+            The default is INGRESS. For INGRESS traffic, you cannot specify the destinationRanges field,
+            and for EGRESS traffic, you cannot specify the sourceRanges or sourceTags fields.
+          enum:
+            - INGRESS
+            - EGRESS
+        logConfig:
+          type: object
+          description: |
+            This field denotes the logging options for a particular firewall rule.
+            If logging is enabled, logs will be exported to Stackdriver.
+          required:
+            - enable
+          properties:
+            enable:
+              type: boolean
+              description: |
+                This field denotes whether to enable logging for a particular firewall rule.
+        disabled:
+          type: boolean
+          description: |
+            Denotes whether the firewall rule is disabled. When set to true, the firewall rule is not
+            enforced and the network behaves as if it did not exist. If this is unspecified, the firewall rule will be enabled.
+
+
 
 outputs:
   properties:


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/99
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/91

- Added version, links to docs
- Switched to using type provider
- Added support for cross-project resource creation
- Upgraded compute-beta to compute-v1
- Fixed resource names
- Added schema to "rules": "name", "description", "priority",
"sourceRanges", "destinationRanges", "sourceTags", "targetTags",
"sourceServiceAccounts", "targetServiceAccounts", "allowed", "denied",
"direction", "logConfig", "disabled"