### PR TITLE
Fixes #118: DM/pubsub: refactoring

### DIFF
--- a/dm/templates/pubsub/examples/pubsub.yaml
+++ b/dm/templates/pubsub/examples/pubsub.yaml
@@ -11,7 +11,7 @@ resources:
   - name: test-pubsub
     type: pubsub.py
     properties:
-      topic: test-topic
+      name: test-topic
       accessControl:
         - role: roles/pubsub.subscriber
           members:

--- a/dm/templates/pubsub/examples/pubsub_push.yaml
+++ b/dm/templates/pubsub/examples/pubsub_push.yaml
@@ -12,7 +12,7 @@ resources:
   - name: test-push-pubsub
     type: pubsub.py
     properties:
-      topic: test-topic
+      name: test-topic
       subscriptions:
         - name: push-subscription
           pushEndpoint: <FIXME:pushEndpointUrl>

--- a/dm/templates/pubsub/pubsub.py.schema
+++ b/dm/templates/pubsub/pubsub.py.schema
@@ -14,40 +14,189 @@
 
 info:
   title: Pub/Sub (publish-subscribe) service
+  version: 1.0.0
   author: Sourced Group Inc.
   description: |
     Creates a topic, optionally with multiple subscriptions.
 
+    For more information on this resource:
+      - https://cloud.google.com/pubsub/
+
+    APIs endpoints used by this template:
+    - gcp-types/pubsub-v1:projects.subscriptions =>
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions
+    - gcp-types/pubsub-v1:projects.topics =>
+        https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics
+
 additionalProperties: false
 
+oneOf:
+  - required:
+      - name
+  - required:
+      - topic
+
 properties:
+  name:
+    type: string
+    description: |
+      The name of the topic that will publish messages. Resource name would be used if omitted.
   topic:
     type: string
     description: |
       The name of the topic that will publish messages. If not specified,
       the deployment name is used.
+      DEPRECATED.
+  project:
+    type: string
+    description: |
+      The project ID of the project containing PubSub resources. The
+      Google apps domain is prefixed if applicable.
+  labels:
+    type: object
+    description: |
+      An object containing a list of "key": value pairs.
+
+      Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
   subscriptions:
     type: array
-    description: A list of topic's subscriptions.
+    uniqueItems: True
+    description: |
+      A list of topic's subscriptions.
     item:
       type: object
-      description: The topic's subscription.
+      additionalProperties: false
+      description: |
+        The topic's subscription.
+      oneOf:
+        - required:
+            - pushEndpoint
+        - required:
+            - pushConfig
       properties:
         name:
           type: string
-          description: The subscription name.
+          description: |
+            The subscription name. Resource name would be used if omitted.
         pushEndpoint:
           type: string
           description: |
             The URL of the endpoint to push the messages to.
+        pushConfig:
+          type: object
+          additionalProperties: false
+          description: |
+            If push delivery is used with this subscription, this field is used to configure it.
+            An empty pushConfig signifies that the subscriber will pull and ack messages using API methods.
+          required:
+            - pushEndpoint
+          properties:
+            pushEndpoint:
+              type: string
+              description: |
+                A URL locating the endpoint to which messages should be pushed.
+                For example, a Webhook endpoint might use "https://example.com/push".
+            oidcToken:
+              type: object
+              description: |
+                If specified, Pub/Sub will generate and attach an OIDC JWT token as an Authorization header
+                in the HTTP request for every pushed message.
+              properties:
+                serviceAccountEmail:
+                  type: string
+                  description: |
+                    Service account email to be used for generating the OIDC token. The caller
+                    (for subscriptions.create, subscriptions.patch, and subscriptions.modifyPushConfig RPCs)
+                    must have the iam.serviceAccounts.actAs permission for the service account.
+                audience:
+                  type: string
+                  description: |
+                    Audience to be used when generating OIDC token. The audience claim identifies the recipients
+                    that the JWT is intended for. The audience value is a single case-sensitive string.
+                    Having multiple values (array) for the audience field is not supported.
+                    More info about the OIDC JWT token audience here: https://tools.ietf.org/html/rfc7519#section-4.1.3
+                    Note: if not specified, the Push endpoint URL will be used.
+            attributes:
+              type: object
+              description: |
+                Endpoint configuration attributes.
+
+                Every endpoint has a set of API supported attributes that can be used to control different
+                aspects of the message delivery.
+
+                The currently supported attribute is x-goog-version, which you can use to change the format
+                of the pushed message. This attribute indicates the version of the data expected by the endpoint.
+                This controls the shape of the pushed message (i.e., its fields and metadata).
+                The endpoint version is based on the version of the Pub/Sub API.
+
+                If not present during the subscriptions.create call, it will default to the version of the
+                API used to make such call. If not present during a subscriptions.modifyPushConfig call,
+                its value will not be changed. subscriptions.get calls will always return a valid version,
+                even if the subscription was created without this attribute.
+
+                The possible values for this attribute are:
+
+                v1beta1: uses the push format defined in the v1beta1 Pub/Sub API.
+                v1 or v1beta2: uses the push format defined in the v1 Pub/Sub API.
+                An object containing a list of "key": value pairs.
+                Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
         ackDeadlineSeconds:
           type: integer
           description: |
-            The maximum time to acknowledge a message receipt before retry.
-          minimum: 10
+            The approximate amount of time (on a best-effort basis) Pub/Sub waits for the subscriber to acknowledge
+            receipt before resending the message. In the interval after the message is delivered and
+            before it is acknowledged, it is considered to be outstanding.
+            During that time period, the message will not be redelivered (on a best-effort basis).
+
+            For pull subscriptions, this value is used as the initial value for the ack deadline. To override this
+            value for a given message, call subscriptions.modifyAckDeadline with the corresponding ackId if using
+            non-streaming pull or send the ackId in a StreamingModifyAckDeadlineRequest if using streaming pull.
+            The minimum custom deadline you can specify is 10 seconds. The maximum custom deadline you can specify
+            is 600 seconds (10 minutes). If this parameter is 0, a default value of 10 seconds is used.
+
+            For push delivery, this value is also used to set the request timeout for the call to the push endpoint.
+
+            If the subscriber never acknowledges the message, the Pub/Sub system will eventually redeliver the message.
+          minimum: 0
           maximum: 600
+        retainAckedMessages:
+          type: bool
+          description: |
+            Indicates whether to retain acknowledged messages. If true, then messages are not expunged from the
+            subscription's backlog, even if they are acknowledged, until they fall out of the
+            messageRetentionDuration window. This must be true if you would like to subscriptions.seek to a timestamp.
+        messageRetentionDuration:
+          type: string
+          description: |
+            How long to retain unacknowledged messages in the subscription's backlog, from the moment a message
+            is published. If retainAckedMessages is true, then this also configures the retention of
+            acknowledged messages, and thus configures how far back in time a subscriptions.seek can be done.
+            Defaults to 7 days. Cannot be more than 7 days or less than 10 minutes.
+
+            A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
+        expirationPolicy:
+          type: object
+          description: |
+            A policy that specifies the conditions for this subscription's expiration. A subscription is
+            considered active as long as any connected subscriber is successfully consuming messages from
+            the subscription or is issuing operations on the subscription. If expirationPolicy is not set,
+            a default policy with ttl of 31 days will be used. The minimum allowed value
+            for expirationPolicy.ttl is 1 day.
+          required:
+            - ttl
+          properties:
+            ttl:
+              type: string
+              description: |
+                Specifies the "time-to-live" duration for an associated resource. The resource expires if it is
+                not active for a period of ttl. The definition of "activity" depends on the type of
+                the associated resource. The minimum and maximum allowed values for ttl depend on the type
+                of the associated resource, as well. If ttl is not set, the associated resource never expires.
+
+                A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
         accessControl:
           type: array
+          uniqueItems: True
           description: |
             The subscription's IAM policy.
             For details, see https://cloud.google.com/pubsub/docs/reference/rest/v1/Policy.
@@ -66,8 +215,9 @@ properties:
                   type: string
   accessControl:
     type: array
+    uniqueItems: True
     description: |
-      The subscription's IAM policy.
+      The topic's IAM policy.
       For details, see https://cloud.google.com/pubsub/docs/reference/rest/v1/Policy
     item:
       type: object

--- a/dm/templates/pubsub/tests/integration/pubsub.yaml
+++ b/dm/templates/pubsub/tests/integration/pubsub.yaml
@@ -11,7 +11,7 @@ resources:
   - name: test-pubsub-${RAND}
     type: pubsub.py
     properties:
-      topic: test-topic-${RAND}
+      name: test-topic-${RAND}
       accessControl:
         - role: roles/pubsub.subscriber
           members:


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/118

- Added version, links to docs
- Switched to using type provider
- Added support for cross-project resource creation
- Fixed resource names
- Added topic fields: "labels"
- Added subscription fields: "pushConfig", "retainAckedMessages",
"messageRetentionDuration", "labels", "expirationPolicy"