### PR TITLE
Fixes #132: DM/ip_reservation: refactoring

### DIFF
--- a/dm/templates/ip_reservation/ip_address.py
+++ b/dm/templates/ip_reservation/ip_address.py
@@ -27,35 +27,48 @@ def get_resource_type(ip_type):
     """ Return the address resource type. """
 
     if ip_type == 'GLOBAL':
-        return 'compute.v1.globalAddress'
+        # https://cloud.google.com/compute/docs/reference/rest/v1/globalAddresses
+        return 'gcp-types/compute-v1:globalAddresses'
 
-    return 'compute.v1.address'
+    # https://cloud.google.com/compute/docs/reference/rest/v1/addresses
+    return 'gcp-types/compute-v1:addresses'
 
 
 def generate_config(context):
     """ Entry point for the deployment resources. """
 
-
+    properties = context.properties
     resource_type = get_resource_type(context.properties['ipType'])
     address_type = get_address_type(context.properties['ipType'])
     name = context.properties.get('name', context.env['name'])
+    project_id = properties.get('project', context.env['project'])
 
-    properties = {
+    res_properties = {
         'addressType': address_type,
         'resourceType': 'addresses',
+        'project': project_id,
     }
 
-    optional_properties = ['subnetwork', 'address', 'description', 'region']
+    optional_properties = [
+        'subnetwork',
+        'address',
+        'description',
+        'region',
+        'networkTier',
+        'prefixLength',
+        'ipVersion',
+        'purpose',
+    ]
 
     for prop in optional_properties:
         if prop in context.properties:
-            properties[prop] = str(context.properties[prop])
+            res_properties[prop] = str(context.properties[prop])
 
     resources = [
         {
             'name': name,
             'type': resource_type,
-            'properties': properties
+            'properties': res_properties
         }
     ]
 

--- a/dm/templates/ip_reservation/ip_address.py.schema
+++ b/dm/templates/ip_reservation/ip_address.py.schema
@@ -15,7 +15,18 @@
 info:
   title: IP Address
   author: Sourced Group Inc.
-  description: Creates an internal, external, or global IP address.
+  version: 1.0.0
+  description: |
+    Creates an internal, external, or global IP address.
+
+    For more information on this resource:
+    https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+
+    APIs endpoints used by this template:
+    - gcp-types/compute-v1:globalAddresses =>
+        https://cloud.google.com/compute/docs/reference/rest/v1/globalAddresses
+    - gcp-types/compute-v1:addresses =>
+        https://cloud.google.com/compute/docs/reference/rest/v1/addresses
 
 additionalProperties: false
 
@@ -23,11 +34,102 @@ required:
   - name
   - ipType
 
+allOf:
+  - anyOf:
+      - allOf:
+          - properties:
+              purpose:
+                enum: ["GCE_ENDPOINT", "DNS_RESOLVER"]
+          - required:
+              - purpose
+      - allOf:
+          - properties:
+              ipType:
+                enum: ["INTERNAL"]
+          - required:
+              - ipType
+      - not:
+          required:
+            - subnetwork
+  - anyOf:
+      - allOf:
+          - properties:
+              purpose:
+                enum: ["VPC_PEERING"]
+          - required:
+              - purpose
+      - not:
+          required:
+            - network
+  - anyOf:
+      - allOf:
+          - properties:
+              ipType:
+                enum: ["REGIONAL", "INTERNAL"]
+          - required:
+              - ipType
+      - not:
+          required:
+            - region
+  - anyOf:
+      - allOf:
+          - properties:
+              ipType:
+                enum: ["GLOBAL"]
+          - required:
+              - ipType
+      - not:
+          required:
+            - ipVersion
+
+
 properties:
   name:
     type: string
     description: |
       Name of the reserved IP; unique within the context of the project.
+      Resource name would be used if omitted.
+  project:
+    type: string
+    description: |
+      The project ID of the project containing the IP. The
+      Google apps domain is prefixed if applicable.
+  prefixLength:
+    type: number
+    description: |
+      The prefix length if the resource reprensents an IP range.
+  networkTier:
+    type: string
+    description: |
+      This signifies the networking tier used for configuring this address and can only take the following
+      values: PREMIUM or STANDARD. Global forwarding rules can only be Premium Tier. Regional forwarding rules
+      can be either Premium or Standard Tier. Standard Tier addresses applied to regional forwarding rules
+      can be used with any external load balancer. Regional forwarding rules in Premium Tier can only
+      be used with a network load balancer.
+
+      If this field is not specified, it is assumed to be PREMIUM.
+  ipVersion:
+    type: string
+    description: |
+      The IP version that will be used by this address. Valid options are IPV4 or IPV6.
+      This can only be specified for a global address.
+    enum:
+      - IPV4
+      - IPV6
+  purpose:
+    type: string
+    description: |
+      The purpose of this resource, which can be one of the following values:
+
+      GCE_ENDPOINT for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
+      DNS_RESOLVER for a DNS resolver address in a subnetwork
+      VPC_PEERING for addresses that are reserved for VPC peer networks.
+      NAT_AUTO for addresses that are external IP addresses automatically reserved for Cloud NAT.
+    enum:
+      - GCE_ENDPOINT
+      - DNS_RESOLVER
+      - VPC_PEERING
+      - NAT_AUTO
   ipType:
     type: string
     description: |
@@ -44,24 +146,29 @@ properties:
   description:
     type: string
     description: |
-      Descriptive information for the reserved IP.
+      An optional description of this resource. Provide this field when you create the resource.
   address:
     type: string
     description: |
-      [OPTIONAL] If the field value (IP address) is provided, Deployment
+      If the field value (IP address) is provided, Deployment
       Manager tries to reserve the specified IP address. If the field is
       not set, Deployment Manager reserves an internal IP address that
       is part of the subnet definition.
+  network:
+    type: string
+    description: |
+      The URL of the network in which to reserve the address.
+      This field can only be used with INTERNAL type with the VPC_PEERING purpose.
   subnetwork:
     type: string
     description: |
-      [REQUIRED FOR INTERNAL ADDRESSES] The subnet from whose range the
-      IP address is reserved.
+      The URL of the subnetwork in which to reserve the address. If an IP address is specified,
+      it must be within the subnetwork's IP range. This field can only be used with INTERNAL type with
+      a GCE_ENDPOINT or DNS_RESOLVER purpose.
   region:
     type: string
     description: |
-      [REQUIRED FOR INTERNAL ADDRESSES] The region where the regional
-      address resides.
+      The region where the regional address resides.
 
 outputs:
   properties:

--- a/dm/templates/ip_reservation/ip_reservation.py.schema
+++ b/dm/templates/ip_reservation/ip_reservation.py.schema
@@ -15,7 +15,18 @@
 info:
   title: IP Reservation
   author: Sourced Group Inc.
-  description: Reservers internal, external, or global IP address.
+  version: 1.0.0
+  description: |
+    Reservers internal, external, or global IP address.
+
+    For more information on this resource:
+    https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+
+    APIs endpoints used by this template:
+    - gcp-types/compute-v1:globalAddresses =>
+        https://cloud.google.com/compute/docs/reference/rest/v1/globalAddresses
+    - gcp-types/compute-v1:addresses =>
+        https://cloud.google.com/compute/docs/reference/rest/v1/addresses
 
 imports:
   - path: ../ip_reservation/ip_address.py
@@ -29,6 +40,7 @@ required:
 properties:
   ipAddresses:
     type: array
+    uniqueItems: true
     description: |
       An array of IPs to create as defined by the `ip_address.py` template.
       Example:
@@ -36,6 +48,95 @@ properties:
           ipType: regional
           region: <FIXME:region>
           description: 'my static external ip'
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: |
+            Name of the reserved IP; unique within the context of the project.
+            Resource name would be used if omitted.
+        project:
+          type: string
+          description: |
+            The project ID of the project containing the IP. The
+            Google apps domain is prefixed if applicable.
+        prefixLength:
+          type: number
+          description: |
+            The prefix length if the resource reprensents an IP range.
+        networkTier:
+          type: string
+          description: |
+            This signifies the networking tier used for configuring this address and can only take the following
+            values: PREMIUM or STANDARD. Global forwarding rules can only be Premium Tier. Regional forwarding rules
+            can be either Premium or Standard Tier. Standard Tier addresses applied to regional forwarding rules
+            can be used with any external load balancer. Regional forwarding rules in Premium Tier can only
+            be used with a network load balancer.
+
+            If this field is not specified, it is assumed to be PREMIUM.
+        ipVersion:
+          type: string
+          description: |
+            The IP version that will be used by this address. Valid options are IPV4 or IPV6.
+            This can only be specified for a global address.
+          enum:
+            - IPV4
+            - IPV6
+        purpose:
+          type: string
+          description: |
+            The purpose of this resource, which can be one of the following values:
+
+            GCE_ENDPOINT for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
+            DNS_RESOLVER for a DNS resolver address in a subnetwork
+            VPC_PEERING for addresses that are reserved for VPC peer networks.
+            NAT_AUTO for addresses that are external IP addresses automatically reserved for Cloud NAT.
+          enum:
+            - GCE_ENDPOINT
+            - DNS_RESOLVER
+            - VPC_PEERING
+            - NAT_AUTO
+        ipType:
+          type: string
+          description: |
+            The IP types the user can reserve.
+            - GLOBAL - for global entities; the IPs can only be used with global
+              forwarding rules (GLB)
+            - REGIONAL - static external IPs that reside in a region
+            - INTERNAL - static internal (RFC1918) IPs that reside in a region on a
+              subnet
+          enum:
+            - GLOBAL
+            - REGIONAL
+            - INTERNAL
+        description:
+          type: string
+          description: |
+            An optional description of this resource. Provide this field when you create the resource.
+        address:
+          type: string
+          description: |
+            If the field value (IP address) is provided, Deployment
+            Manager tries to reserve the specified IP address. If the field is
+            not set, Deployment Manager reserves an internal IP address that
+            is part of the subnet definition.
+        network:
+          type: string
+          description: |
+            The URL of the network in which to reserve the address.
+            This field can only be used with INTERNAL type with the VPC_PEERING purpose.
+        subnetwork:
+          type: string
+          description: |
+            The URL of the subnetwork in which to reserve the address. If an IP address is specified,
+            it must be within the subnetwork's IP range. This field can only be used with INTERNAL type with
+            a GCE_ENDPOINT or DNS_RESOLVER purpose.
+        region:
+          type: string
+          description: |
+            The region where the regional address resides.
 
 outputs:
   properties:


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/132

- Addde version, links to docs
- Switched to using type provider
- Added support for cross-project resource creation
- Added missing fields: "prefixLength", "networkTier"
- Fixed field checks