### PR TITLE
Fixes #141: DM/forwarding_rule: refactoring

### DIFF
--- a/dm/templates/forwarding_rule/forwarding_rule.py
+++ b/dm/templates/forwarding_rule/forwarding_rule.py
@@ -14,8 +14,10 @@
 """ This template creates a forwarding rule. """
 
 REGIONAL_GLOBAL_TYPE_NAMES = {
-    True: 'compute.v1.forwardingRule',
-    False: 'compute.v1.globalForwardingRule'
+    # https://cloud.google.com/compute/docs/reference/rest/v1/forwardingRules
+    True: 'gcp-types/compute-v1:forwardingRules',
+    # https://cloud.google.com/compute/docs/reference/rest/v1/globalForwardingRules
+    False: 'gcp-types/compute-v1:globalForwardingRules'
 }
 
 
@@ -55,12 +57,16 @@ def generate_config(context):
 
     properties = context.properties
     name = properties.get('name', context.env['name'])
+    project_id = properties.get('project', context.env['project'])
     is_regional = 'region' in properties
     region = properties.get('region')
-    rule_properties = {'name': name}
+    rule_properties = {
+        'name': name,
+        'project': project_id,
+    }
 
     resource = {
-        'name': name,
+        'name': context.env['name'],
         'type': REGIONAL_GLOBAL_TYPE_NAMES[is_regional],
         'properties': rule_properties
     }
@@ -77,12 +83,15 @@ def generate_config(context):
         'subnetwork',
         'network',
         'backendService',
-        'ipVersion'
+        'ipVersion',
+        'serviceLabel',
+        'networkTier',
+        'allPorts',
     ]
 
     for prop in optional_properties:
         set_optional_property(rule_properties, properties, prop)
 
-    outputs = get_forwarding_rule_outputs(name, region)
+    outputs = get_forwarding_rule_outputs(context.env['name'], region)
 
     return {'resources': [resource], 'outputs': outputs}

--- a/dm/templates/forwarding_rule/forwarding_rule.py.schema
+++ b/dm/templates/forwarding_rule/forwarding_rule.py.schema
@@ -15,17 +15,147 @@
 info:
   title: Forwarding Rule
   author: Sourced Group Inc.
+  version: 1.0.0
   description: |
-    Creates a forwrding rule.
-    See https://cloud.google.com/load-balancing/docs/forwarding-rules for
-    details.
+    Creates a forwarding rule.
+
+    For more information on this resource:
+    https://cloud.google.com/load-balancing/docs/forwarding-rules
+
+    APIs endpoints used by this template:
+    - gcp-types/compute-v1:forwardingRules =>
+        https://cloud.google.com/compute/docs/reference/rest/v1/forwardingRules
+    - gcp-types/compute-v1:globalForwardingRules =>
+        https://cloud.google.com/compute/docs/reference/rest/v1/globalForwardingRules
 
 additionalProperties: false
+
+allOf:
+  - oneOf:
+      - properties:
+          loadBalancingScheme:
+            enum:
+              - INTERNAL
+          IPProtocol:
+            enum:
+              - TCP
+              - UDP
+      - not:
+          properties:
+            loadBalancingScheme:
+              enum:
+                - INTERNAL
+  - oneOf:
+      - allOf:
+          - required:
+              - region
+          - properties:
+              networkTier:
+                enum:
+                  - PREMIUM
+                  - STANDARD
+      - allOf:
+          - not:
+              required:
+                - region
+          - properties:
+              networkTier:
+                enum:
+                  - PREMIUM
+  - oneOf:
+      - properties:
+          loadBalancingScheme:
+            enum:
+              - INTERNAL_SELF_MANAGED
+          IPProtocol:
+            enum:
+              - TCP
+      - not:
+          properties:
+            loadBalancingScheme:
+              enum:
+                - INTERNAL_SELF_MANAGED
+  - oneOf:
+      - allOf:
+          - properties:
+              IPProtocol:
+                enum:
+                  - TCP
+                  - UDP
+                  - SCTP
+          - required:
+              - portRange
+      - not:
+          required:
+            - portRange
+  - oneOf:
+      - allOf:
+          - properties:
+              loadBalancingScheme:
+                enum:
+                  - INTERNAL
+          - anyOf:
+              - required:
+                  - ports
+              - required:
+                  - backendService
+              - required:
+                  - subnetwork
+              - required:
+                  - serviceLabel
+      - allOf:
+          - not:
+              required:
+                - ports
+          - not:
+              required:
+                - backendService
+          - not:
+              required:
+                - subnetwork
+          - not:
+              required:
+                - serviceLabel
+  - oneOf:
+      - allOf:
+          - properties:
+              loadBalancingScheme:
+                enum:
+                  - INTERNAL
+                  - INTERNAL_SELF_MANAGED
+          - required:
+              - network
+      - not:
+          required:
+            - network
+  - oneOf:
+      - allOf:
+          - loadBalancingScheme:
+              enum:
+                - EXTERNAL
+          - not:
+              required:
+                - region
+          - required:
+              - ipVersion
+      - not:
+          required:
+            - ipVersion
 
 properties:
   name:
     type: string
-    description: The resource name.
+    description: |
+      Must comply with RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a lowercase letter,
+      and all following characters must be a dash, lowercase letter, or digit, except the last character,
+      which cannot be a dash.
+      Resource name would be used if omitted.
+  project:
+    type: string
+    description: |
+      The project ID of the project containing the forwarding rule. The
+      Google apps domain is prefixed if applicable.
   description:
     type: string
     description: The resource description (optional).
@@ -37,15 +167,39 @@ properties:
   IPAddress:
     type: string
     description: |
-      The IP address on behalf of which the forwarding rule serves. The
-      address can be specified either by a literal IP address or by a URL
-      reference to an existing Address resource.
+      The IP address that this forwarding rule is serving on behalf of.
+
+      Addresses are restricted based on the forwarding rule's load balancing scheme
+      (EXTERNAL or INTERNAL) and scope (global or regional).
+
+      When the load balancing scheme is EXTERNAL, for global forwarding rules, the address must be a global IP,
+      and for regional forwarding rules, the address must live in the same region as the forwarding rule.
+      If this field is empty, an ephemeral IPv4 address from the same scope (global or regional) will be assigned.
+      A regional forwarding rule supports IPv4 only. A global forwarding rule supports either IPv4 or IPv6.
+
+      When the load balancing scheme is INTERNAL_SELF_MANAGED, this must be a URL reference to an existing Address
+      resource ( internal regional static IP address), with a purpose of GCE_END_POINT and addressType of INTERNAL.
+
+      When the load balancing scheme is INTERNAL, this can only be an RFC 1918 IP address belonging to the
+      network/subnet configured for the forwarding rule. By default, if this field is empty, an ephemeral
+      internal IP address will be automatically allocated from the IP range of the subnet or network
+      configured for this forwarding rule.
+
+      An address can be specified either by a literal IP address or a URL reference to an existing Address resource.
+      The following examples are all valid:
+      - 100.1.2.3
+      - https://www.googleapis.com/compute/v1/projects/project/regions/region/addresses/address
+      - projects/project/regions/region/addresses/address
+      - regions/region/addresses/address
+      - global/addresses/address
+      - address
   IPProtocol:
     type: string
     description: |
-      The IP protocol to which the rule applies. If the load balancing scheme
-      is INTERNAL, the valid valuse are TCP and UDP. For the INTERNAL_SELF_MANAGED
-      load balancing scheme, only TCP is valid.
+      The IP protocol to which this rule applies. Valid options are TCP, UDP, ESP, AH, SCTP or ICMP.
+
+      When the load balancing scheme is INTERNAL, only TCP and UDP are valid.
+      When the load balancing scheme is INTERNAL_SELF_MANAGED, only TCPis valid.
     enum:
       - TCP
       - UDP
@@ -63,10 +217,16 @@ properties:
       when IPProtocol is TCP, UDP, or SCTP.
   ports:
     type: array
+    uniqItems: true
     description: |
-      The list of ports; only packets addressed to these ports are forwarded
-      to the backends configured with the forwarding rule. Used in conjunction with
-      the backendService field for INTERNAL load balancing.
+      This field is used along with the backendService field for internal load balancing.
+
+      When the load balancing scheme is INTERNAL, a list of ports can be configured, for example,
+      ['80'], ['8000','9000'] etc. Only packets addressed to these ports will be forwarded to the
+      backends configured with this forwarding rule.
+
+      You may specify a maximum of up to 5 ports.
+    maxItems: 5
     items:
       type: integer
       minimum: 1
@@ -74,11 +234,19 @@ properties:
   target:
     type: string
     description: |
-      The URL of the target resource to receive the matched traffic. For
-      regional forwarding rules, this target must be located in the same region
-      as the forwarding rule. For global forwarding rules, this target must be a
-      global load balancing resource.
-      For example: https://www.googleapis.com/compute/v1/projects/{project}/global/{targetType}/{targetName}
+      The URL of the target resource to receive the matched traffic. For regional forwarding rules,
+      this target must live in the same region as the forwarding rule. For global forwarding rules, this
+      target must be a global load balancing resource. The forwarded traffic must be of a type appropriate
+      to the target object. For INTERNAL_SELF_MANAGED load balancing, only HTTP and HTTPS targets are valid.
+
+      Authorization requires one or more of the following Google IAM permissions on the specified resource target:
+      - compute.targetHttpProxies.use
+      - compute.targetHttpsProxies.use
+      - compute.targetInstances.use
+      - compute.targetPools.use
+      - compute.targetSslProxies.use
+      - compute.targetTcpProxies.use
+      - compute.targetVpnGateways.use
   loadBalancingScheme:
     type: string
     description: |
@@ -97,6 +265,32 @@ properties:
     description: |
       The subnetwork the load-balanced IP must belong to for the forwarding rule.
       Used only for INTERNAL load balancing.
+  serviceLabel:
+    type: string
+    description: |
+      An optional prefix to the service name for this Forwarding Rule. If specified, will be the first label
+      of the fully qualified service name.
+
+      The label must be 1-63 characters long, and comply with RFC1035. Specifically, the label must be 1-63 characters
+      long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a
+      lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except
+      the last character, which cannot be a dash.
+
+      This field is only used for internal load balancing.
+  networkTier:
+    type: string
+    description: |
+      This signifies the networking tier used for configuring this load balancer and can only
+      take the following values: PREMIUM , STANDARD.
+
+      For regional ForwardingRule, the valid values are PREMIUM and STANDARD. For GlobalForwardingRule,
+      the valid value is PREMIUM.
+
+      If this field is not specified, it is assumed to be PREMIUM. If IPAddress is specified,
+      this value must be equal to the networkTier of the Address.
+    enum:
+      - STANDARD
+      - PREMIUM
   network:
     type: string
     description: |
@@ -117,6 +311,14 @@ properties:
     enum:
       - IPV4
       - IPV6
+  allPorts:
+    type: boolean
+    description: |
+      This field is used along with the backendService field for internal load balancing or with the target
+      field for internal TargetInstance. This field cannot be used with port or portRange fields.
+
+      When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets
+      addressed to any ports will be forwarded to the backends configured with this forwarding rule.
 
 outputs:
   properties:


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/141

- Added version, links to docs
- Switched to using type provider
- Added support for cross-project resource creation
- Fixed resource names
- Fixed descriptions
- Added support for fields: "serviceLabel", "networkTier", "allPorts"