### PR TITLE
Fixes #137: DM/dataproc: refactoring

### DIFF
--- a/dm/templates/dataproc/dataproc.py.schema
+++ b/dm/templates/dataproc/dataproc.py.schema
@@ -15,19 +15,109 @@
 info:
   title: Dataproc
   author: Sourced Group Inc.
+  version: 1.0.0
   description: |
     Creates a Dataproc cluster.
+
+    For more information on this resource:
+    https://cloud.google.com/compute/
+
+    APIs endpoints used by this template:
+    - gcp-types/dataproc-v1:projects.regions.clusters =>
+        https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters
 
 imports:
   - path: dataproc.py
 
 additionalProperties: false
 
+definitions:
+  nodeConfig:
+    properties:
+      numInstances:
+        type: integer
+        description: The number of VM instances in the instance group.
+      isPreemptible:
+        type: boolean
+        description: |
+          If True, specifies that the instance group consists of preemptible
+          instances.
+      imageUri:
+        type: string
+        description: |
+          The Compute Engine image resource used for cluster instances.
+          It can be specified or may be inferred from SoftwareConfig.image_version.
+      machineType:
+        type: string
+        description: |
+          The Compute Engine machine type used for the cluster instances.
+          A full URL, partial URI, or short name are valid. Examples:
+            - https://www.googleapis.com/compute/v1/projects/[projectId]/zones/us-east1-a/machineTypes/n1-standard-2
+            - projects/[projectId]/zones/us-east1-a/machineTypes/n1-standard-2
+            - n1-standard-2
+      diskType:
+        type: string
+        default: pd-standard
+        description: The boot disk type.
+        enum:
+          - pd-standard
+          - pd-ssd
+      diskSizeGb:
+        type: integer
+        default: 500
+        description: The boot disk size in GB.
+      numLocalSsds:
+        type: integer
+        default: 0
+        description: The number of attached SSDs.
+        minimum: 0
+        maximum: 4
+      accelerators:
+        type: array
+        uniqItems: true
+        description: |
+          The Compute Engine accelerator configuration for these instances.
+
+          Beta Feature: This feature is still under development. It may be changed before final release
+        items:
+          type: object
+          additionalProperties: false
+          properties:
+            acceleratorTypeUri:
+              type: string
+              description: |
+                Full URL, partial URI, or short name of the accelerator type resource to expose to this instance.
+                See Compute Engine AcceleratorTypes.
+
+                Examples:
+
+                https://www.googleapis.com/compute/beta/projects/[projectId]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80
+                projects/[projectId]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80
+                nvidia-tesla-k80
+                Auto Zone Exception: If you are using the Cloud Dataproc Auto Zone Placement feature,
+                you must use the short name of the accelerator type resource, for example, nvidia-tesla-k80.
+            acceleratorCount:
+              type: number
+              description: |
+                The number of the accelerator cards of this type exposed to this instance.
+
 properties:
   name:
     type: string
     description: |
-      The cluster name. If not provided, the resource name is used.
+      The cluster name. Resource name would be used if omitted.
+  project:
+    type: string
+    description: |
+      The project ID of the project containing the service.
+  labels:
+    type: object
+    description: |
+      Optional. The labels to associate with this cluster. Label keys must contain 1 to 63 characters,
+      and must conform to RFC 1035. Label values may be empty, but, if present, must contain 1 to 63 characters,
+      and must conform to RFC 1035. No more than 32 labels can be associated with a cluster.
+
+      An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
   region:
     type: string
     default: global
@@ -56,6 +146,7 @@ properties:
       Engine service account.
   serviceAccountScopes:
     type: array
+    uniqItems: true
     description: |
       A list of URIs of service account scopes to be included in the Compute
       Engine instances.
@@ -94,6 +185,7 @@ properties:
       and config.
   softwareConfig:
     type: object
+    additionalProperties: false
     description: |
       The selection and config of software inside the cluster.
     properties:
@@ -107,12 +199,27 @@ properties:
         type: object
         description: |
           The key-value pairs for properties to set on the daemon config files.
+      optionalComponents:
+        type: array
+        uniqItems: true
+        description: |
+          The set of optional components to activate on the cluster.
+        items:
+          type: string
+          enum:
+            - COMPONENT_UNSPECIFIED
+            - ANACONDA
+            - HIVE_WEBHCAT
+            - JUPYTER
+            - ZEPPELIN
   initializationActions:
     type: array
+    uniqItems: true
     description: |
       A list of commands to execute on each node after the config is completed.
     items:
       type: object
+      additionalProperties: false
       description: |
         The executable to run on a fully configured node + the timeout
         period for the executable completion.
@@ -125,87 +232,38 @@ properties:
           description: |
             The executable completion timeout, e.g. "3.5s". The default value
             is 10 minutes.
+  encryptionConfig:
+    type: object
+    additionalProperties: false
+    description: |
+      Encryption settings for the cluster.
+    required:
+      - gcePdKmsKeyName
+    properties:
+      gcePdKmsKeyName:
+        type: string
+        descritption: |
+          The Cloud KMS key name to use for PD disk encryption for all instances in the cluster.
   master:
     type: object
+    additionalProperties: false
     description: |
       The Compute Engine config settings for the master instance in the
       cluster.
-    properties:
-      numInstances:
-        type: integer
-        description: The number of VM instances in the instance group.
-      machineType:
-        type: string
-        description: |
-          The Compute Engine machine type used for the cluster instances.
-          A full URL, partial URI, or short name are valid. Examples:
-            - https://www.googleapis.com/compute/v1/projects/[projectId]/zones/us-east1-a/machineTypes/n1-standard-2
-            - projects/[projectId]/zones/us-east1-a/machineTypes/n1-standard-2
-            - n1-standard-2
-      diskType:
-        type: string
-        default: pd-standard
-        description: The boot disk type.
-        enum:
-          - pd-standard
-          - pd-ssd
-      diskSizeGb:
-        type: integer
-        default: 500
-        description: The boot disk size in GB.
-      numLocalSsds:
-        type: integer
-        default: 0
-        description: The number of attached SSDs.
-        minimum: 0
-        maximum: 4
+    $ref: '#/definitions/nodeConfig'
   worker:
     type: object
+    additionalProperties: false
     description: |
       The Compute Engine config settings for worker instances in the cluster.
-    properties:
-      numInstances:
-        type: integer
-        description: The number of VM instances in the instance group.
-      machineType:
-        type: string
-        description: |
-          The Compute Engine machine type used for cluster instances.
-          A full URL, partial URI, or short name are valid. Examples:
-            - https://www.googleapis.com/compute/v1/projects/[projectId]/zones/us-east1-a/machineTypes/n1-standard-2
-            - projects/[projectId]/zones/us-east1-a/machineTypes/n1-standard-2
-            - n1-standard-2
-      diskType:
-        type: string
-        default: pd-standard
-        description: The boot disk type.
-        enum:
-          - pd-standard
-          - pd-ssd
-      diskSizeGb:
-        type: integer
-        default: 500
-        description: The boot disk size in GB.
-      numLocalSsds:
-        type: integer
-        default: 0
-        description: The number of attached SSDs.
-        minimum: 0
-        maximum: 4
+    $ref: '#/definitions/nodeConfig'
   secondaryWorker:
     type: object
+    additionalProperties: false
     description: |
       The Compute Engine config settings for additional worker instances in
       the cluster.
-    properties:
-      numInstances:
-        type: integer
-        description: The number of VM instances in the instance group.
-      isPreemptible:
-        type: boolean
-        description: |
-          If True, specifies that the instance group consists of preemptible
-          instances.
+    $ref: '#/definitions/nodeConfig'
 outputs:
   properties:
     - masterInstanceNames:


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/137

- Added version, links to docs
- Switched to using type provider
- Added support for cross-project resource creation
- Fixed resource names
- Added missing fields: "labels", "<nodes>.imageUri",
"<nodes>.isPreemptible", "<nodes>.accelerators",
"softwareConfig.optionalComponents", "encryptionConfig"
- Mergeed master, nodes and secondary nodes