### PR TITLE
DM/dns_managed_zone: refactoring #138

### DIFF
--- a/dm/templates/dns_managed_zone/README.md
+++ b/dm/templates/dns_managed_zone/README.md
@@ -12,7 +12,7 @@ This template creates a managed zone in the Cloud DNS (Domain Name System).
 
 ### Resources
 
-- [dns.v1.managedZone](https://cloud.google.com/dns/docs/)
+- [gcp-types/dns-v1:managedZones](https://cloud.google.com/dns/docs/reference/v1/managedZones)
 
 ### Properties
 
@@ -59,5 +59,14 @@ See the `properties` section in the schema file(s):
 ```
 
 ## Examples
-
 - [Cloud DNS Managed Zone](examples/dns_managed_zone.yaml)
+- [Managed Zone with `public visibility`](examples/dns_managed_zone_public.yaml)
+- [Managed Zone with `private visibility`](examples/dns_managed_zone_private.yaml)
+- [Managed Zone with `private visibility config`](examples/dns_managed_zone_private_visibility_config.yaml)
+
+## Tests Cases
+- [Simple Managed Zone Test](tests/integration/dns_mz_simple.bats)
+- [Managed Zone with `public visibility`](tests/integration/dns_mz_public.bats)
+- [Managed Zone with `private visibility`](tests/integration/dns_mz_private.bats)
+- [Managed Zone with `private visibility config`](tests/integration/dns_mz_prvt_vsblt_cfg.bats)
+- [Managed Zone with `cross-project reference`](tests/integration/dns_mz_cross_project.bats)

--- a/dm/templates/dns_managed_zone/dns_managed_zone.py
+++ b/dm/templates/dns_managed_zone/dns_managed_zone.py
@@ -17,46 +17,54 @@
 def generate_config(context):
     """ Entry point for the deployment resources. """
 
-    resources = []
-
-    managed_zone_name = context.properties.get('zoneName')
+    managed_zone_name = context.properties.get('name', context.env['name'])
     dnsname = context.properties['dnsName']
     managed_zone_description = context.properties['description']
     name_servers = '$(ref.' + context.env['name'] + '.nameServers)'
+    project_id = context.properties.get('project', context.env['project'])
+
+    resources = []
+    outputs = [
+        {
+            'name': 'dnsName',
+            'value': dnsname
+        },
+        {
+            'name': 'managedZoneDescription',
+            'value': managed_zone_description
+        },
+        {
+            'name': 'nameServers',
+            'value': name_servers
+        },
+        {
+            'name': 'managedZoneName',
+            'value': managed_zone_name
+        }
+    ]
 
     managed_zone = {
         'name': context.env['name'],
-        'type': 'dns.v1.managedZone',
-        'properties':
-            {
-                'name': managed_zone_name,
-                'dnsName': dnsname,
-                'description': managed_zone_description
-            }
+        # https://cloud.google.com/dns/docs/reference/v1/managedZones
+        'type': 'gcp-types/dns-v1:managedZones',
+        'properties': {
+            'name': managed_zone_name,
+            'dnsName': dnsname,
+            'description': managed_zone_description,
+            'project_id': project_id
+        }
     }
 
+    # making resources and outputs additional properties
+    for prop in context.properties:
+        if prop not in managed_zone['properties']:
+            managed_zone['properties'][prop] = context.properties[prop]
+            outputs.append(
+                {
+                    'name': prop,
+                    'value': context.properties[prop]
+                }
+            )
     resources.append(managed_zone)
 
-    return {
-        'resources':
-            resources,
-        'outputs':
-            [
-                {
-                    'name': 'dnsName',
-                    'value': dnsname
-                },
-                {
-                    'name': 'managedZoneDescription',
-                    'value': managed_zone_description
-                },
-                {
-                    'name': 'nameServers',
-                    'value': name_servers
-                },
-                {
-                    'name': 'managedZoneName',
-                    'value': managed_zone_name
-                }
-            ]
-    }
+    return {'resources': resources, 'outputs': outputs}

--- a/dm/templates/dns_managed_zone/dns_managed_zone.py.schema
+++ b/dm/templates/dns_managed_zone/dns_managed_zone.py.schema
@@ -15,42 +15,194 @@
 info:
   title: Cloud DNS Managed Zone
   author: Source Group Inc.
+  version: 1.0.0
   description: |
     Creates a managed zone in the Cloud DNS.
-    For more information on this resource
+
+    For more information on this resource:
     - https://cloud.google.com/dns/zones/
+
+    APIs endpoints used by this template:
+    - gcp-types/dns-v1:managedZones =>
+        https://cloud.google.com/dns/docs/reference/v1/managedZones
 
 imports:
   - path: dns_managed_zone.py
 
+required:
+  - dnsName
+  - name
+
 additionalProperties: false
 
-required:
-  - zoneName
-  - dnsName
-
 properties:
-  zoneName:
+  project:
     type: string
-    pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$
     description: |
-      A user-assigned name for the managed zone.
-      This is required by the Cloud DNS.
-      Must be 1-63 characters long, must begin with a letter,
-      end with a letter or digit, and only contain lowercase letters, digits or dashes.
+      The project ID of for Managed Zone to be associated with.
+  description:
+    type: string
+    pattern: ^.{0,1023}
+    description: |
+      A description of the managed zone. A mutable string, max 1024 characters
+      long. Associated with the resource for users' convenience; does not affect
+      managed zone's function.
   dnsName:
     type: string
-    pattern: \.$
+    pattern: \.
     description: |
       The DNS name of the managed zone; for example, "example.com."
       Make sure that the value ends with a period "."
-  description:
+  dnssecConfig:
+    type: object
+    description: DNSSEC configuration.
+    additionalProperties: false
+    required:
+      - kind
+      - state
+      - defaultKeySpecs
+    proeprties:
+      defaultKeySpecs:
+        type: array
+        uniqueItems: true
+        description: |
+          Specifies parameters that will be used for generating initial DnsKeys
+          for this ManagedZone. Output only while state is not OFF.
+        items:
+          type: object
+          additionalProperties: false
+          required:
+            - kind
+            - algorithm
+            - keyType
+            - keyLength
+          properties:
+            algorithm:
+              oneOf:
+                - type: string
+                  pattern: ^ecdsap(256|384)sha(256|384)
+                - type: string
+                  pattern: ^rsasha(1|256|512)
+              description: |
+                String mnemonic specifying the DNSSEC algorithm of this key.
+                Acceptable values are:
+                  - "ecdsap256sha256"
+                  - "ecdsap384sha384"
+                  - "rsasha1"
+                  - "rsasha256"
+                  - "rsasha512"
+            keyLength:
+              type: integer
+              description: Length of the keys in bits.
+            keyType:
+              type: string
+              pattern: ^(key|zone)Signing
+              description: |
+                Specifies whether this is a key signing key (KSK) or a zone
+                signing key (ZSK). Key signing keys have the Secure Entry Point
+                flag set and, when active, will only be used to sign resource
+                record sets of type DNSKEY. Zone signing keys do not have the
+                Secure Entry Point flag set and will be used to sign all other
+                types of resource record sets.
+                Acceptable values are:
+                  - "keySigning"
+                  - "zoneSigning"
+            kind:
+              type: string
+              pattern: ^dns#managedZoneDnsSecConfig
+              default: "dns#managedZoneDnsSecConfig"
+              description: |
+                Identifies what kind of resource this is.
+                Value: the fixed string "dns#managedZoneDnsSecConfig".
+  nonExistence:
     type: string
-    pattern: ^.{0,1023}$
     description: |
-      A description of the managed zone. A mutable string, max 1024 characters 
-      long. Associated with the resource for users' convenience; does not affect 
-      managed zone's function.
+      Specifies the mechanism used to provide authenticated
+      denial-of-existence responses. Output only while state is not OFF.
+      Acceptable values are:
+        - "nsec"
+        - "nsec3"
+    pattern: ^nsec3?
+  state:
+    type: string
+    pattern: ^(on|off|transfer)
+    description: |
+      Specifies whether DNSSEC is enabled, and what mode it is in.
+      Acceptable values are:
+      - "off"
+      - "on"
+      - "transfer"
+  kind:
+    type: string
+    pattern: ^dns#managedZone
+    default: "dns#managedZone"
+    description: |
+      Identifies what kind of resource this is.
+      Value is the fixed string "dns#managedZone".
+  labels:
+    type: object
+    description: User labels.
+    propertyNames:
+      type: string
+  name:
+    type: string
+    pattern: ^[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?
+    description: |
+      User assigned name for this resource. Must be unique within the project.
+      The name must be 1-63 characters long, must begin with a letter, end
+      with a letter or digit, and only contain lowercase letters, digits or dashes.
+  nameServerSet:
+    type: string
+    description: |
+      Optionally specifies the NameServerSet for this ManagedZone. A
+      NameServerSet is a set of DNS name servers that all host the same
+      ManagedZones. Most users will leave this field unset.
+  nameServers:
+    type: array
+    description: |
+      Delegate your managed_zone to these virtual name servers; defined by the
+      server (output only)
+  privateVisibilityConfig:
+    type: object
+    description: |
+      For privately visible zones, the set of Virtual Private Cloud resources
+      that the zone is visible from.
+    additionalProperties: false
+    properties:
+      kind:
+        type: string
+        pattern: ^dns#managedZonePrivateVisibilityConfig
+        description: |
+          Identifies what kind of resource this is.
+          Value: the fixed string "dns#managedZonePrivateVisibilityConfig"
+      networks:
+        type: array
+        items:
+          type: object
+          additionalProperties: false
+          required:
+            - kind
+            - networkUrl
+          properties:
+            kind:
+              type: string
+              pattern: ^dns#managedZonePrivateVisibilityConfigNetwork
+              description: |
+                Identifies what kind of resource this is.
+                Value: the fixed string "dns#managedZonePrivateVisibilityConfigNetwork".
+            networkUrl:
+              type: string
+              pattern: ^https:\/\/www.googleapis.com\/compute\/v1\/projects\/[a-zA-Z0-9_-]+\/global\/networks\/[a-zA-Z0-9_-]+
+              description: |
+                The fully qualified URL of the VPC network to bind to. This should be formatted
+                like https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{network}
+  visibility:
+    type: string
+    pattern: ^(public|private)
+    description: |
+      The zone's visibility. Public zones are exposed to the Internet, while
+      private zones are visible only to Virtual Private Cloud resources.
+      Acceptable values are "private" and "public".
 
 outputs:
   properties:
@@ -67,9 +219,25 @@ outputs:
     - managedZoneName:
         type: string
         description: The managed zone's resource name.
-
+    - visibility:
+        type: string
+        description: |
+          The zone's visibility. Public zones are exposed to the Internet,
+          while private zones are visible only to Virtual Private Cloud
+          resources.
+    - privateVisibilityConfig:
+        type: object
+        description: |
+          For privately visible zones, the set of Virtual Private Cloud
+          resources that the zone is visible from.
+    - dnssecConfig:
+        type: object
+        description: DNSSEC configuration.
 documentation:
   - templates/dns_managed_zone/README.md
 
 examples:
   - templates/dns_managed_zone/examples/dns_managed_zone.yaml
+  - templates/dns_managed_zone/examples/dns_managed_zone_private.yaml
+  - templates/dns_managed_zone/examples/dns_managed_zone_private_visibility_config.yaml
+  - templates/dns_managed_zone/examples/dns_managed_zone_public.yaml

--- a/dm/templates/dns_managed_zone/examples/dns_managed_zone.yaml
+++ b/dm/templates/dns_managed_zone/examples/dns_managed_zone.yaml
@@ -1,7 +1,7 @@
 # Example of the DNS managed zone template usage.
 #
 # In this example, a DNS managed zone is created with the use of
-# the `zoneName` and `dnsName` properties. 
+# the `name` and `dnsName` properties.
 
 imports:
   - path: templates/dns_managed_zone/dns_managed_zone.py
@@ -11,6 +11,6 @@ resources:
   - name: test-managed-zone
     type: dns_managed_zone.py
     properties:
-      zoneName: test-managed-zone
+      name: test-managed-zone
       dnsName: foobar.local.
       description: 'My foobar DNS Managed Zone'

--- a/dm/templates/dns_managed_zone/examples/dns_managed_zone_private.yaml
+++ b/dm/templates/dns_managed_zone/examples/dns_managed_zone_private.yaml
@@ -1,0 +1,17 @@
+# Example of the DNS managed zone template usage.
+#
+# In this example, a private DNS managed zone is created with the use of
+# the `visibility` and `dnsName` properties.
+
+imports:
+  - path: templates/dns_managed_zone/dns_managed_zone.py
+    name: dns_managed_zone.py
+
+resources:
+  - name: private-mz
+    type: dns_managed_zone.py
+    properties:
+      name: private-mz
+      dnsName: private-mz.local.
+      description: "Private DNS Managed Zone"
+      visibility: private

--- a/dm/templates/dns_managed_zone/examples/dns_managed_zone_private_visibility_config.yaml
+++ b/dm/templates/dns_managed_zone/examples/dns_managed_zone_private_visibility_config.yaml
@@ -1,0 +1,22 @@
+# Example of the DNS managed zone template usage.
+#
+# In this example, a private DNS managed zone is created with the use of
+# the `visibility` and `privateVisibilityConfig` properties.
+
+imports:
+  - path: templates/dns_managed_zone/dns_managed_zone.py
+    name: dns_managed_zone.py
+
+resources:
+  - name: private-mz-with-visibility
+    type: dns_managed_zone.py
+    properties:
+      name: private-mz-with-visibility
+      dnsName: private-visibility.local.
+      description: "Private DNS Managed Zone with visibility config"
+      visibility: private
+      privateVisibilityConfig:
+        kind: "dns#managedZonePrivateVisibilityConfig"
+        networks:
+          - kind: "dns#managedZonePrivateVisibilityConfigNetwork"
+            networkUrl: "https://www.googleapis.com/compute/v1/projects/<PROJECT_ID>/global/networks/<NETWORK_ID>"

--- a/dm/templates/dns_managed_zone/examples/dns_managed_zone_public.yaml
+++ b/dm/templates/dns_managed_zone/examples/dns_managed_zone_public.yaml
@@ -1,0 +1,17 @@
+# Example of the DNS managed zone template usage.
+#
+# In this example, a Public DNS managed zone is created with the use of
+# the `zoneName`, `dnsName` and `visibility` properties.
+
+imports:
+  - path: templates/dns_managed_zone/dns_managed_zone.py
+    name: dns_managed_zone.py
+
+resources:
+  - name: public-mz
+    type: dns_managed_zone.py
+    properties:
+      name: public-mz
+      dnsName: public-test.local.
+      description: "Public DNS Managed Zone"
+      visibility: public

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_cross_project.bats
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_cross_project.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+
+source tests/helpers.bash
+
+TEST_NAME=$(basename "${BATS_TEST_FILENAME}" | cut -d '.' -f 1)
+
+# Create a random 10-char string and save it in a file.
+RANDOM_FILE="/tmp/${CLOUD_FOUNDATION_ORGANIZATION_ID}-${TEST_NAME}.txt"
+if [[ ! -e "${RANDOM_FILE}" ]]; then
+    RAND=$(head /dev/urandom | LC_ALL=C tr -dc a-z0-9 | head -c 10)
+    echo ${RAND} > "${RANDOM_FILE}"
+fi
+
+# Set variables based on the random string saved in the file.
+# envsubst requires all variables used in the example/config to be exported.
+if [[ -e "${RANDOM_FILE}" ]]; then
+    export RAND=$(cat "${RANDOM_FILE}")
+    DEPLOYMENT_NAME="${CLOUD_FOUNDATION_PROJECT_ID}-${TEST_NAME}-${RAND}"
+    # Replace underscores in the deployment name with dashes.
+    DEPLOYMENT_NAME=${DEPLOYMENT_NAME//_/-}
+    CONFIG=".${DEPLOYMENT_NAME}.yaml"
+    export CLOUDDNS_ZONE_NAME="test-managed-zone-${RAND}"
+    export CLOUDDNS_DNS_NAME="${RAND}.com."
+    export CLOUDDNS_DESCRIPTION="Managed DNS Zone for Testing"
+fi
+
+########## HELPER FUNCTIONS ##########
+
+function create_config() {
+    echo "Creating ${CONFIG}"
+    envsubst < templates/dns_managed_zone/tests/integration/${TEST_NAME}.yaml > "${CONFIG}"
+}
+
+function delete_config() {
+    echo "Deleting ${CONFIG}"
+    rm -f "${CONFIG}"
+}
+
+function setup() {
+    # Global setup; this is executed once per test file.
+    if [ ${BATS_TEST_NUMBER} -eq 1 ]; then
+        create_config
+    fi
+
+    # Per-test setup steps.
+}
+
+function teardown() {
+    # Global teardown; this is executed once per test file.
+    if [[ "$BATS_TEST_NUMBER" -eq "${#BATS_TEST_NAMES[@]}" ]]; then
+        delete_config
+        rm -f "${RANDOM_FILE}"
+    fi
+
+    # Per-test teardown steps.
+}
+
+
+########## TESTS ##########
+
+@test "Creating deployment ${DEPLOYMENT_NAME} from ${CONFIG}" {
+    gcloud deployment-manager deployments create "${DEPLOYMENT_NAME}" \
+        --config "${CONFIG}" --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "Verify if a managed zone with name $CLOUDDNS_ZONE_NAME was created" {
+    run gcloud dns managed-zones list --format=flattened \
+        --project "${CLOUDDNS_CROSS_PROJECT_ID}"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
+}
+
+@test "Verify if a DNS named ${CLOUDDNS_DNS_NAME} was created" {
+    run gcloud dns managed-zones list --project "${CLOUDDNS_CROSS_PROJECT_ID}"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ "${CLOUDDNS_DNS_NAME}" ]]
+}
+
+@test "Deleting deployment ${DEPLOYMENT_NAME}" {
+    gcloud deployment-manager deployments delete "${DEPLOYMENT_NAME}" \
+        -q --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+
+    run gcloud dns managed-zones list
+    [[ "$status" -eq 0 ]]
+    [[ ! "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
+}

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_cross_project.yaml
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_cross_project.yaml
@@ -1,0 +1,15 @@
+# Test of the DNS managed zone template.
+#
+
+imports:
+  - path: templates/dns_managed_zone/dns_managed_zone.py
+    name: dns_managed_zone.py
+
+resources:
+  - name: ${CLOUDDNS_ZONE_NAME}-resource
+    type: dns_managed_zone.py
+    properties:
+      name: ${CLOUDDNS_ZONE_NAME}
+      dnsName: ${CLOUDDNS_DNS_NAME}
+      description: ${CLOUDDNS_DESCRIPTION}
+      project: ${CLOUDDNS_CROSS_PROJECT_ID}

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_private.bats
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_private.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+source tests/helpers.bash
+
+TEST_NAME=$(basename "${BATS_TEST_FILENAME}" | cut -d '.' -f 1)
+
+# Create a random 10-char string and save it in a file.
+RANDOM_FILE="/tmp/${CLOUD_FOUNDATION_ORGANIZATION_ID}-${TEST_NAME}.txt"
+if [[ ! -e "${RANDOM_FILE}" ]]; then
+    RAND=$(head /dev/urandom | LC_ALL=C tr -dc a-z0-9 | head -c 10)
+    echo ${RAND} > "${RANDOM_FILE}"
+fi
+
+# Set variables based on the random string saved in the file.
+# envsubst requires all variables used in the example/config to be exported.
+if [[ -e "${RANDOM_FILE}" ]]; then
+    export RAND=$(cat "${RANDOM_FILE}")
+    DEPLOYMENT_NAME="${CLOUD_FOUNDATION_PROJECT_ID}-${TEST_NAME}-${RAND}"
+    # Replace underscores in the deployment name with dashes.
+    DEPLOYMENT_NAME=${DEPLOYMENT_NAME//_/-}
+    CONFIG=".${DEPLOYMENT_NAME}.yaml"
+    export CLOUDDNS_ZONE_NAME="test-managed-zone-${RAND}"
+    export CLOUDDNS_DNS_NAME="${RAND}.com."
+    export CLOUDDNS_DESCRIPTION="Managed DNS Zone for Testing"
+    export CLOUDDNS_VISIBILITY="private"
+fi
+
+########## HELPER FUNCTIONS ##########
+
+function create_config() {
+    echo "Creating ${CONFIG}"
+    envsubst < templates/dns_managed_zone/tests/integration/${TEST_NAME}.yaml > "${CONFIG}"
+}
+
+function delete_config() {
+    echo "Deleting ${CONFIG}"
+    rm -f "${CONFIG}"
+}
+
+function setup() {
+    # Global setup; this is executed once per test file.
+    if [ ${BATS_TEST_NUMBER} -eq 1 ]; then
+        create_config
+    fi
+
+    # Per-test setup steps.
+}
+
+function teardown() {
+    # Global teardown; this is executed once per test file.
+    if [[ "$BATS_TEST_NUMBER" -eq "${#BATS_TEST_NAMES[@]}" ]]; then
+        delete_config
+        rm -f "${RANDOM_FILE}"
+    fi
+
+    # Per-test teardown steps.
+}
+
+
+########## TESTS ##########
+
+@test "Creating deployment ${DEPLOYMENT_NAME} from ${CONFIG}" {
+   gcloud deployment-manager deployments create "${DEPLOYMENT_NAME}" \
+       --config "${CONFIG}" --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+   [[ "$status" -eq 0 ]]
+}
+
+@test "Verify if a managed zone with name $CLOUDDNS_ZONE_NAME was created" {
+   run gcloud dns managed-zones list --format=flattened
+   [[ "$status" -eq 0 ]]
+   [[ "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
+}
+
+@test "Verify if a DNS named ${CLOUDDNS_DNS_NAME} was created" {
+    run gcloud dns managed-zones list
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ "${CLOUDDNS_DNS_NAME}" ]]
+}
+
+@test "Verify if visibility is ${CLOUDDNS_VISIBILITY}" {
+    run gcloud dns managed-zones describe ${CLOUDDNS_ZONE_NAME}
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ "visibility: ${CLOUDDNS_VISIBILITY}" ]]
+}
+
+@test "Deleting deployment ${DEPLOYMENT_NAME}" {
+    gcloud deployment-manager deployments delete "${DEPLOYMENT_NAME}" \
+        -q --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+
+    run gcloud dns managed-zones list
+    [[ "$status" -eq 0 ]]
+    [[ ! "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
+}

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_private.yaml
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_private.yaml
@@ -1,0 +1,19 @@
+# Test of the DNS managed zone template.
+#
+
+imports:
+  - path: templates/dns_managed_zone/dns_managed_zone.py
+    name: dns_managed_zone.py
+
+resources:
+  - name: ${CLOUDDNS_ZONE_NAME}-resource
+    type: dns_managed_zone.py
+    properties:
+      name: ${CLOUDDNS_ZONE_NAME}
+      dnsName: ${CLOUDDNS_DNS_NAME}
+      description: ${CLOUDDNS_DESCRIPTION}
+      visibility: ${CLOUDDNS_VISIBILITY}
+      # nameServers: ${CLOUDDNS_NAME_SERVERS}
+      # nameServerSet: ${CLOUDDNS_NAME_SEVER_SET}
+      # privateVisibilityConfig: ${CLOUDDNS_PRIVATE_VISIBILITY_CONFIG}
+      # dnssecConfig: ${CLOUDDNS_DNS_SEC_CONFIG}

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_prvt_vsblt_cfg.bats
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_prvt_vsblt_cfg.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+source tests/helpers.bash
+
+TEST_NAME=$(basename "${BATS_TEST_FILENAME}" | cut -d '.' -f 1)
+
+# Create a random 10-char string and save it in a file.
+RANDOM_FILE="/tmp/${CLOUD_FOUNDATION_ORGANIZATION_ID}-${TEST_NAME}.txt"
+if [[ ! -e "${RANDOM_FILE}" ]]; then
+    RAND=$(head /dev/urandom | LC_ALL=C tr -dc a-z0-9 | head -c 10)
+    echo ${RAND} > "${RANDOM_FILE}"
+fi
+
+# Set variables based on the random string saved in the file.
+# envsubst requires all variables used in the example/config to be exported.
+if [[ -e "${RANDOM_FILE}" ]]; then
+    export RAND=$(cat "${RANDOM_FILE}")
+    DEPLOYMENT_NAME="${CLOUD_FOUNDATION_PROJECT_ID}-${TEST_NAME}-${RAND}"
+    # Replace underscores in the deployment name with dashes.
+    DEPLOYMENT_NAME=${DEPLOYMENT_NAME//_/-}
+    CONFIG=".${DEPLOYMENT_NAME}.yaml"
+    export CLOUDDNS_ZONE_NAME="test-managed-zone-${RAND}"
+    export CLOUDDNS_DNS_NAME="${RAND}.com."
+    export CLOUDDNS_DESCRIPTION="Managed DNS Zone for Testing"
+    export CLOUDDNS_VISIBILITY="private"
+    export CLOUDDNS_NETWORK_URL="https://www.googleapis.com/compute/v1/projects/${CLOUD_FOUNDATION_PROJECT_ID}/global/networks/default"
+fi
+
+########## HELPER FUNCTIONS ##########
+
+function create_config() {
+    echo "Creating ${CONFIG}"
+    envsubst < templates/dns_managed_zone/tests/integration/${TEST_NAME}.yaml > "${CONFIG}"
+}
+
+function delete_config() {
+    echo "Deleting ${CONFIG}"
+    rm -f "${CONFIG}"
+}
+
+function setup() {
+    # Global setup; this is executed once per test file.
+    if [ ${BATS_TEST_NUMBER} -eq 1 ]; then
+        create_config
+    fi
+
+    # Per-test setup steps.
+}
+
+function teardown() {
+    # Global teardown; this is executed once per test file.
+    if [[ "$BATS_TEST_NUMBER" -eq "${#BATS_TEST_NAMES[@]}" ]]; then
+        delete_config
+        rm -f "${RANDOM_FILE}"
+    fi
+
+    # Per-test teardown steps.
+}
+
+
+########## TESTS ##########
+
+@test "Creating deployment ${DEPLOYMENT_NAME} from ${CONFIG}" {
+   gcloud deployment-manager deployments create "${DEPLOYMENT_NAME}" \
+       --config "${CONFIG}" --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+   [[ "$status" -eq 0 ]]
+}
+
+@test "Verify if a managed zone with name $CLOUDDNS_ZONE_NAME was created" {
+   run gcloud dns managed-zones list --format=flattened
+   [[ "$status" -eq 0 ]]
+   [[ "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
+}
+
+@test "Verify if a DNS named ${CLOUDDNS_DNS_NAME} was created" {
+    run gcloud dns managed-zones list
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ "${CLOUDDNS_DNS_NAME}" ]]
+}
+
+@test "Verify if visibility is ${CLOUDDNS_VISIBILITY}" {
+    run gcloud dns managed-zones describe ${CLOUDDNS_ZONE_NAME}
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ "visibility: ${CLOUDDNS_VISIBILITY}" ]]
+}
+
+@test "Verify if networkUrl is ${CLOUDDNS_NETWORK_URL}" {
+    run gcloud dns managed-zones describe ${CLOUDDNS_ZONE_NAME}
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ "networkUrl: ${CLOUDDNS_NETWORK_URL}" ]]
+}
+
+@test "Deleting deployment ${DEPLOYMENT_NAME}" {
+    gcloud deployment-manager deployments delete "${DEPLOYMENT_NAME}" \
+        -q --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+
+    run gcloud dns managed-zones list
+    [[ "$status" -eq 0 ]]
+    [[ ! "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
+}

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_prvt_vsblt_cfg.yaml
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_prvt_vsblt_cfg.yaml
@@ -1,0 +1,20 @@
+# Test of the DNS managed zone template.
+#
+
+imports:
+  - path: templates/dns_managed_zone/dns_managed_zone.py
+    name: dns_managed_zone.py
+
+resources:
+  - name: ${CLOUDDNS_ZONE_NAME}-resource
+    type: dns_managed_zone.py
+    properties:
+      name: ${CLOUDDNS_ZONE_NAME}
+      dnsName: ${CLOUDDNS_DNS_NAME}
+      description: ${CLOUDDNS_DESCRIPTION}
+      visibility: ${CLOUDDNS_VISIBILITY}
+      privateVisibilityConfig:
+        kind: "dns#managedZonePrivateVisibilityConfig"
+        networks:
+          - kind: "dns#managedZonePrivateVisibilityConfigNetwork"
+            networkUrl: ${CLOUDDNS_NETWORK_URL}

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_public.bats
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_public.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+source tests/helpers.bash
+
+TEST_NAME=$(basename "${BATS_TEST_FILENAME}" | cut -d '.' -f 1)
+
+# Create a random 10-char string and save it in a file.
+RANDOM_FILE="/tmp/${CLOUD_FOUNDATION_ORGANIZATION_ID}-${TEST_NAME}.txt"
+if [[ ! -e "${RANDOM_FILE}" ]]; then
+    RAND=$(head /dev/urandom | LC_ALL=C tr -dc a-z0-9 | head -c 10)
+    echo ${RAND} > "${RANDOM_FILE}"
+fi
+
+# Set variables based on the random string saved in the file.
+# envsubst requires all variables used in the example/config to be exported.
+if [[ -e "${RANDOM_FILE}" ]]; then
+    export RAND=$(cat "${RANDOM_FILE}")
+    DEPLOYMENT_NAME="${CLOUD_FOUNDATION_PROJECT_ID}-${TEST_NAME}-${RAND}"
+    # Replace underscores in the deployment name with dashes.
+    DEPLOYMENT_NAME=${DEPLOYMENT_NAME//_/-}
+    CONFIG=".${DEPLOYMENT_NAME}.yaml"
+    export CLOUDDNS_ZONE_NAME="test-managed-zone-${RAND}"
+    export CLOUDDNS_DNS_NAME="${RAND}.com."
+    export CLOUDDNS_DESCRIPTION="Managed DNS Zone for Testing"
+    export CLOUDDNS_VISIBILITY="public"
+    export CLOUDDNS_NETWORKS="default"
+fi
+
+########## HELPER FUNCTIONS ##########
+
+function create_config() {
+    echo "Creating ${CONFIG}"
+    envsubst < templates/dns_managed_zone/tests/integration/${TEST_NAME}.yaml > "${CONFIG}"
+}
+
+function delete_config() {
+    echo "Deleting ${CONFIG}"
+    rm -f "${CONFIG}"
+}
+
+function setup() {
+    # Global setup; this is executed once per test file.
+    if [ ${BATS_TEST_NUMBER} -eq 1 ]; then
+        create_config
+    fi
+
+    # Per-test setup steps.
+}
+
+function teardown() {
+    # Global teardown; this is executed once per test file.
+    if [[ "$BATS_TEST_NUMBER" -eq "${#BATS_TEST_NAMES[@]}" ]]; then
+        delete_config
+        rm -f "${RANDOM_FILE}"
+    fi
+
+    # Per-test teardown steps.
+}
+
+
+########## TESTS ##########
+
+@test "Creating deployment ${DEPLOYMENT_NAME} from ${CONFIG}" {
+   gcloud deployment-manager deployments create "${DEPLOYMENT_NAME}" \
+       --config "${CONFIG}" --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+   [[ "$status" -eq 0 ]]
+}
+
+@test "Verify if a managed zone with name $CLOUDDNS_ZONE_NAME was created" {
+   run gcloud dns managed-zones list --format=flattened
+   [[ "$status" -eq 0 ]]
+   [[ "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
+}
+
+@test "Verify if a DNS named ${CLOUDDNS_DNS_NAME} was created" {
+    run gcloud dns managed-zones list
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ "${CLOUDDNS_DNS_NAME}" ]]
+}
+
+@test "Verify if visibility is ${CLOUDDNS_VISIBILITY}" {
+    run gcloud dns managed-zones describe ${CLOUDDNS_ZONE_NAME}
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ "visibility: ${CLOUDDNS_VISIBILITY}" ]]
+}
+
+@test "Deleting deployment ${DEPLOYMENT_NAME}" {
+    gcloud deployment-manager deployments delete "${DEPLOYMENT_NAME}" \
+        -q --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+
+    run gcloud dns managed-zones list
+    [[ "$status" -eq 0 ]]
+    [[ ! "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
+}

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_public.yaml
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_public.yaml
@@ -1,0 +1,15 @@
+# Test of the DNS managed zone template.
+#
+
+imports:
+  - path: templates/dns_managed_zone/dns_managed_zone.py
+    name: dns_managed_zone.py
+
+resources:
+  - name: ${CLOUDDNS_ZONE_NAME}-resource
+    type: dns_managed_zone.py
+    properties:
+      name: ${CLOUDDNS_ZONE_NAME}
+      dnsName: ${CLOUDDNS_DNS_NAME}
+      description: ${CLOUDDNS_DESCRIPTION}
+      visibility: ${CLOUDDNS_VISIBILITY}

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_simple.bats
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_simple.bats
@@ -59,15 +59,15 @@ function teardown() {
 ########## TESTS ##########
 
 @test "Creating deployment ${DEPLOYMENT_NAME} from ${CONFIG}" {
-   gcloud deployment-manager deployments create "${DEPLOYMENT_NAME}" \
-       --config "${CONFIG}" --project "${CLOUD_FOUNDATION_PROJECT_ID}"
-   [[ "$status" -eq 0 ]]
+    gcloud deployment-manager deployments create "${DEPLOYMENT_NAME}" \
+        --config "${CONFIG}" --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+    [[ "$status" -eq 0 ]]
 }
 
 @test "Verify if a managed zone with name $CLOUDDNS_ZONE_NAME was created" {
-   run gcloud dns managed-zones list --format=flattened
-   [[ "$status" -eq 0 ]]
-   [[ "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
+    run gcloud dns managed-zones list --format=flattened
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
 }
 
 @test "Verify if a DNS named ${CLOUDDNS_DNS_NAME} was created" {
@@ -84,4 +84,3 @@ function teardown() {
     [[ "$status" -eq 0 ]]
     [[ ! "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
 }
-

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_simple.yaml
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_simple.yaml
@@ -9,6 +9,6 @@ resources:
   - name: ${CLOUDDNS_ZONE_NAME}-resource
     type: dns_managed_zone.py
     properties:
-      zoneName: ${CLOUDDNS_ZONE_NAME}
+      name: ${CLOUDDNS_ZONE_NAME}
       dnsName: ${CLOUDDNS_DNS_NAME}
       description: ${CLOUDDNS_DESCRIPTION}


### PR DESCRIPTION
#138 
- Switched to using gcp type provider
- Added support for cross-project resource creation
- Aligned resource names with the API documentation
- Added full schema validation against the API documentation (including all supported properties with their regular expressions for acceptable values)
- Added following integration test cases: 
- [Managed Zone with `public visibility`](tests/integration/dns_mz_public.bats)
  - [Managed Zone with `private visibility`](tests/integration/dns_mz_private.bats)
  - [Managed Zone with `private visibility config`](tests/integration/dns_mz_prvt_vsblt_cfg.bats)
  - [Managed Zone with `cross-project reference`](tests/integration/dns_mz_cross_project.bats)
- Added version, updated inks to docs, examples and tests

