### PR TITLE
#138 - refactoring scope updated with backward compatibility and tests

### DIFF
--- a/dm/templates/dns_managed_zone/README.md
+++ b/dm/templates/dns_managed_zone/README.md
@@ -60,12 +60,14 @@ See the `properties` section in the schema file(s):
 
 ## Examples
 - [Cloud DNS Managed Zone](examples/dns_managed_zone.yaml)
+- [Cloud DNS Managed Zone with legacy property](examples/dns_managed_zone_legacy.yaml)
 - [Managed Zone with `public visibility`](examples/dns_managed_zone_public.yaml)
 - [Managed Zone with `private visibility`](examples/dns_managed_zone_private.yaml)
 - [Managed Zone with `private visibility config`](examples/dns_managed_zone_private_visibility_config.yaml)
 
 ## Tests Cases
 - [Simple Managed Zone Test](tests/integration/dns_mz_simple.bats)
+- [Backward Compatibility Test](tests/integration/dns_mz_bkwrd_cmptb.bats)
 - [Managed Zone with `public visibility`](tests/integration/dns_mz_public.bats)
 - [Managed Zone with `private visibility`](tests/integration/dns_mz_private.bats)
 - [Managed Zone with `private visibility config`](tests/integration/dns_mz_prvt_vsblt_cfg.bats)

--- a/dm/templates/dns_managed_zone/dns_managed_zone.py.schema
+++ b/dm/templates/dns_managed_zone/dns_managed_zone.py.schema
@@ -29,20 +29,33 @@ info:
 imports:
   - path: dns_managed_zone.py
 
-required:
-  - dnsName
-  - name
+# Note: Supported Backward Compatibility with the old property `zoneName`
+oneOf:
+  - required:
+    - dnsName
+    - zoneName
+  - required:
+    - dnsName
+    - name
 
 additionalProperties: false
 
 properties:
+  zoneName:
+    type: string
+    pattern: ^[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$
+    description: |
+      Old resource name to support backward compatablility.
+      Value is rescricted by API pattern for `resource.name`
+      The name must be 1-63 characters long, must begin with a letter, end
+      with a letter or digit, and only contain lowercase letters, digits or dashes.
   project:
     type: string
     description: |
       The project ID of for Managed Zone to be associated with.
   description:
     type: string
-    pattern: ^.{0,1023}
+    pattern: ^.{0,1023}$
     description: |
       A description of the managed zone. A mutable string, max 1024 characters
       long. Associated with the resource for users' convenience; does not affect
@@ -80,9 +93,9 @@ properties:
             algorithm:
               oneOf:
                 - type: string
-                  pattern: ^ecdsap(256|384)sha(256|384)
+                  pattern: ^ecdsap(256|384)sha(256|384)$
                 - type: string
-                  pattern: ^rsasha(1|256|512)
+                  pattern: ^rsasha(1|256|512)$
               description: |
                 String mnemonic specifying the DNSSEC algorithm of this key.
                 Acceptable values are:
@@ -96,7 +109,7 @@ properties:
               description: Length of the keys in bits.
             keyType:
               type: string
-              pattern: ^(key|zone)Signing
+              pattern: ^(key|zone)Signing$
               description: |
                 Specifies whether this is a key signing key (KSK) or a zone
                 signing key (ZSK). Key signing keys have the Secure Entry Point
@@ -109,7 +122,7 @@ properties:
                   - "zoneSigning"
             kind:
               type: string
-              pattern: ^dns#managedZoneDnsSecConfig
+              pattern: ^dns#managedZoneDnsSecConfig$
               default: "dns#managedZoneDnsSecConfig"
               description: |
                 Identifies what kind of resource this is.
@@ -122,10 +135,10 @@ properties:
       Acceptable values are:
         - "nsec"
         - "nsec3"
-    pattern: ^nsec3?
+    pattern: ^nsec3?$
   state:
     type: string
-    pattern: ^(on|off|transfer)
+    pattern: ^(on|off|transfer)$
     description: |
       Specifies whether DNSSEC is enabled, and what mode it is in.
       Acceptable values are:
@@ -134,7 +147,7 @@ properties:
       - "transfer"
   kind:
     type: string
-    pattern: ^dns#managedZone
+    pattern: ^dns#managedZone$
     default: "dns#managedZone"
     description: |
       Identifies what kind of resource this is.
@@ -146,7 +159,7 @@ properties:
       type: string
   name:
     type: string
-    pattern: ^[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?
+    pattern: ^[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$
     description: |
       User assigned name for this resource. Must be unique within the project.
       The name must be 1-63 characters long, must begin with a letter, end
@@ -171,7 +184,7 @@ properties:
     properties:
       kind:
         type: string
-        pattern: ^dns#managedZonePrivateVisibilityConfig
+        pattern: ^dns#managedZonePrivateVisibilityConfig$
         description: |
           Identifies what kind of resource this is.
           Value: the fixed string "dns#managedZonePrivateVisibilityConfig"
@@ -186,19 +199,19 @@ properties:
           properties:
             kind:
               type: string
-              pattern: ^dns#managedZonePrivateVisibilityConfigNetwork
+              pattern: ^dns#managedZonePrivateVisibilityConfigNetwork$
               description: |
                 Identifies what kind of resource this is.
                 Value: the fixed string "dns#managedZonePrivateVisibilityConfigNetwork".
             networkUrl:
               type: string
-              pattern: ^https:\/\/www.googleapis.com\/compute\/v1\/projects\/[a-zA-Z0-9_-]+\/global\/networks\/[a-zA-Z0-9_-]+
+              pattern: ^https:\/\/www.googleapis.com\/compute\/v1\/projects\/[a-zA-Z0-9_-]+\/global\/networks\/[a-zA-Z0-9_-]+$
               description: |
                 The fully qualified URL of the VPC network to bind to. This should be formatted
                 like https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{network}
   visibility:
     type: string
-    pattern: ^(public|private)
+    pattern: ^(public|private)$
     description: |
       The zone's visibility. Public zones are exposed to the Internet, while
       private zones are visible only to Virtual Private Cloud resources.

--- a/dm/templates/dns_managed_zone/examples/dns_managed_zone_legacy.yaml
+++ b/dm/templates/dns_managed_zone/examples/dns_managed_zone_legacy.yaml
@@ -1,0 +1,16 @@
+# Example of the DNS managed zone template usage.
+#
+# In this example, a DNS managed zone is created with the use of
+# the old `zoneName` and `dnsName` properties.
+
+imports:
+  - path: templates/dns_managed_zone/dns_managed_zone.py
+    name: dns_managed_zone.py
+
+resources:
+  - name: test-managed-zone
+    type: dns_managed_zone.py
+    properties:
+      zoneName: test-managed-zone
+      dnsName: foobar.local.
+      description: 'My foobar DNS Managed Zone'

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_bkwrd_cmptb.bats
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_bkwrd_cmptb.bats
@@ -22,8 +22,6 @@ if [[ -e "${RANDOM_FILE}" ]]; then
     export CLOUDDNS_ZONE_NAME="test-managed-zone-${RAND}"
     export CLOUDDNS_DNS_NAME="${RAND}.com."
     export CLOUDDNS_DESCRIPTION="Managed DNS Zone for Testing"
-    export CLOUDDNS_VISIBILITY="private"
-    export CLOUDDNS_NETWORK_URL="https://www.googleapis.com/compute/v1/projects/${CLOUD_FOUNDATION_PROJECT_ID}/global/networks/default"
 fi
 
 ########## HELPER FUNCTIONS ##########
@@ -77,20 +75,6 @@ function teardown() {
     run gcloud dns managed-zones list --project "${CLOUD_FOUNDATION_PROJECT_ID}"
     [[ "$status" -eq 0 ]]
     [[ "$output" =~ "${CLOUDDNS_DNS_NAME}" ]]
-}
-
-@test "Verify if visibility is ${CLOUDDNS_VISIBILITY}" {
-    run gcloud dns managed-zones describe ${CLOUDDNS_ZONE_NAME} \
-        --project "${CLOUD_FOUNDATION_PROJECT_ID}"
-    [[ "$status" -eq 0 ]]
-    [[ "$output" =~ "visibility: ${CLOUDDNS_VISIBILITY}" ]]
-}
-
-@test "Verify if networkUrl is ${CLOUDDNS_NETWORK_URL}" {
-    run gcloud dns managed-zones describe ${CLOUDDNS_ZONE_NAME} \
-        --project "${CLOUD_FOUNDATION_PROJECT_ID}"
-    [[ "$status" -eq 0 ]]
-    [[ "$output" =~ "networkUrl: ${CLOUDDNS_NETWORK_URL}" ]]
 }
 
 @test "Deleting deployment ${DEPLOYMENT_NAME}" {

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_bkwrd_cmptb.yaml
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_bkwrd_cmptb.yaml
@@ -1,0 +1,19 @@
+# Test Case: Backward Compatibility
+# Use Case:
+#   You have updated CFT code base up to the latest version and now it works
+#   with your old-style written templates in a slightly different way.
+#
+#   F.e.: `zoneName` property is now replaced by `name` to align syntax with
+#   the naming convention of the API.
+
+imports:
+  - path: templates/dns_managed_zone/dns_managed_zone.py
+    name: dns_managed_zone.py
+
+resources:
+  - name: ${CLOUDDNS_ZONE_NAME}-resource
+    type: dns_managed_zone.py
+    properties:
+      zoneName: ${CLOUDDNS_ZONE_NAME}
+      dnsName: ${CLOUDDNS_DNS_NAME}
+      description: ${CLOUDDNS_DESCRIPTION}

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_cross_project.bats
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_cross_project.bats
@@ -80,7 +80,6 @@ function teardown() {
 @test "Deleting deployment ${DEPLOYMENT_NAME}" {
     gcloud deployment-manager deployments delete "${DEPLOYMENT_NAME}" \
         -q --project "${CLOUD_FOUNDATION_PROJECT_ID}"
-
     run gcloud dns managed-zones list
     [[ "$status" -eq 0 ]]
     [[ ! "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_cross_project.yaml
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_cross_project.yaml
@@ -1,6 +1,12 @@
-# Test of the DNS managed zone template.
+# Test Case: Cross-Project Reference
+# Use Case:
+#   You have multiple projects with dependancies on each other.
+#   Like one project assumes a presence of DNS Zone in another in order
+#   to use it as an endpoint. So within your agregated pipe-line you may want
+#   to provision resources in both of the projets.
 #
-
+#   Please note: you should grant Editor permission on the cross-referenced
+#   Project to your current Google APIs account <PROJECT_ID>@cloudservices.gserviceaccount.com
 imports:
   - path: templates/dns_managed_zone/dns_managed_zone.py
     name: dns_managed_zone.py

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_private.bats
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_private.bats
@@ -60,25 +60,27 @@ function teardown() {
 ########## TESTS ##########
 
 @test "Creating deployment ${DEPLOYMENT_NAME} from ${CONFIG}" {
-   gcloud deployment-manager deployments create "${DEPLOYMENT_NAME}" \
-       --config "${CONFIG}" --project "${CLOUD_FOUNDATION_PROJECT_ID}"
-   [[ "$status" -eq 0 ]]
+    gcloud deployment-manager deployments create "${DEPLOYMENT_NAME}" \
+        --config "${CONFIG}" --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+    [[ "$status" -eq 0 ]]
 }
 
 @test "Verify if a managed zone with name $CLOUDDNS_ZONE_NAME was created" {
-   run gcloud dns managed-zones list --format=flattened
-   [[ "$status" -eq 0 ]]
-   [[ "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
+    run gcloud dns managed-zones list --format=flattened \
+        --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
 }
 
 @test "Verify if a DNS named ${CLOUDDNS_DNS_NAME} was created" {
-    run gcloud dns managed-zones list
+    run gcloud dns managed-zones list --project "${CLOUD_FOUNDATION_PROJECT_ID}"
     [[ "$status" -eq 0 ]]
     [[ "$output" =~ "${CLOUDDNS_DNS_NAME}" ]]
 }
 
 @test "Verify if visibility is ${CLOUDDNS_VISIBILITY}" {
-    run gcloud dns managed-zones describe ${CLOUDDNS_ZONE_NAME}
+    run gcloud dns managed-zones describe ${CLOUDDNS_ZONE_NAME} \
+        --project "${CLOUD_FOUNDATION_PROJECT_ID}"
     [[ "$status" -eq 0 ]]
     [[ "$output" =~ "visibility: ${CLOUDDNS_VISIBILITY}" ]]
 }
@@ -86,7 +88,6 @@ function teardown() {
 @test "Deleting deployment ${DEPLOYMENT_NAME}" {
     gcloud deployment-manager deployments delete "${DEPLOYMENT_NAME}" \
         -q --project "${CLOUD_FOUNDATION_PROJECT_ID}"
-
     run gcloud dns managed-zones list
     [[ "$status" -eq 0 ]]
     [[ ! "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_private.yaml
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_private.yaml
@@ -1,5 +1,7 @@
-# Test of the DNS managed zone template.
-#
+# Test Case: Private Visibility
+# Use Case:
+#   You want to create a Private Managed Zone, which is not exposed to Internet
+#   and visible only to Virtual Private Cloud resources.
 
 imports:
   - path: templates/dns_managed_zone/dns_managed_zone.py
@@ -13,7 +15,3 @@ resources:
       dnsName: ${CLOUDDNS_DNS_NAME}
       description: ${CLOUDDNS_DESCRIPTION}
       visibility: ${CLOUDDNS_VISIBILITY}
-      # nameServers: ${CLOUDDNS_NAME_SERVERS}
-      # nameServerSet: ${CLOUDDNS_NAME_SEVER_SET}
-      # privateVisibilityConfig: ${CLOUDDNS_PRIVATE_VISIBILITY_CONFIG}
-      # dnssecConfig: ${CLOUDDNS_DNS_SEC_CONFIG}

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_prvt_vsblt_cfg.yaml
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_prvt_vsblt_cfg.yaml
@@ -1,5 +1,7 @@
-# Test of the DNS managed zone template.
-#
+# Test Case: Private Visibility
+# Use Case:
+#   You want to create a Private Managed Zone visible only for specific
+#   networks of your Virtual Private Cloud.
 
 imports:
   - path: templates/dns_managed_zone/dns_managed_zone.py

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_public.bats
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_public.bats
@@ -61,25 +61,27 @@ function teardown() {
 ########## TESTS ##########
 
 @test "Creating deployment ${DEPLOYMENT_NAME} from ${CONFIG}" {
-   gcloud deployment-manager deployments create "${DEPLOYMENT_NAME}" \
-       --config "${CONFIG}" --project "${CLOUD_FOUNDATION_PROJECT_ID}"
-   [[ "$status" -eq 0 ]]
+    gcloud deployment-manager deployments create "${DEPLOYMENT_NAME}" \
+        --config "${CONFIG}" --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+    [[ "$status" -eq 0 ]]
 }
 
 @test "Verify if a managed zone with name $CLOUDDNS_ZONE_NAME was created" {
-   run gcloud dns managed-zones list --format=flattened
-   [[ "$status" -eq 0 ]]
-   [[ "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
+    run gcloud dns managed-zones list --format=flattened \
+        --project "${CLOUD_FOUNDATION_PROJECT_ID}"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
 }
 
 @test "Verify if a DNS named ${CLOUDDNS_DNS_NAME} was created" {
-    run gcloud dns managed-zones list
+    run gcloud dns managed-zones list --project "${CLOUD_FOUNDATION_PROJECT_ID}"
     [[ "$status" -eq 0 ]]
     [[ "$output" =~ "${CLOUDDNS_DNS_NAME}" ]]
 }
 
 @test "Verify if visibility is ${CLOUDDNS_VISIBILITY}" {
-    run gcloud dns managed-zones describe ${CLOUDDNS_ZONE_NAME}
+    run gcloud dns managed-zones describe ${CLOUDDNS_ZONE_NAME} \
+        --project "${CLOUD_FOUNDATION_PROJECT_ID}"
     [[ "$status" -eq 0 ]]
     [[ "$output" =~ "visibility: ${CLOUDDNS_VISIBILITY}" ]]
 }
@@ -87,7 +89,6 @@ function teardown() {
 @test "Deleting deployment ${DEPLOYMENT_NAME}" {
     gcloud deployment-manager deployments delete "${DEPLOYMENT_NAME}" \
         -q --project "${CLOUD_FOUNDATION_PROJECT_ID}"
-
     run gcloud dns managed-zones list
     [[ "$status" -eq 0 ]]
     [[ ! "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_public.yaml
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_public.yaml
@@ -1,5 +1,7 @@
-# Test of the DNS managed zone template.
-#
+# Test Case: Public Visibility
+# Use Case:
+#   You want to create a Managed Zone with Public Visibility,
+#   which makes it exposed to Internet
 
 imports:
   - path: templates/dns_managed_zone/dns_managed_zone.py

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_simple.bats
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_simple.bats
@@ -65,13 +65,14 @@ function teardown() {
 }
 
 @test "Verify if a managed zone with name $CLOUDDNS_ZONE_NAME was created" {
-    run gcloud dns managed-zones list --format=flattened
+    run gcloud dns managed-zones list --format=flattened \
+        --project "${CLOUD_FOUNDATION_PROJECT_ID}"
     [[ "$status" -eq 0 ]]
     [[ "$output" =~ "${CLOUDDNS_ZONE_NAME}" ]]
 }
 
 @test "Verify if a DNS named ${CLOUDDNS_DNS_NAME} was created" {
-    run gcloud dns managed-zones list
+    run gcloud dns managed-zones list --project "${CLOUD_FOUNDATION_PROJECT_ID}"
     [[ "$status" -eq 0 ]]
     [[ "$output" =~ "${CLOUDDNS_DNS_NAME}" ]]
 }

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_simple.yaml
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_simple.yaml
@@ -1,5 +1,4 @@
-# Test of the DNS managed zone template.
-#
+# Test of the simplest DNS managed zone template.
 
 imports:
   - path: templates/dns_managed_zone/dns_managed_zone.py


### PR DESCRIPTION
#138 (updated scope)
- Added Backward Compatibility with the old property `zoneName`.
- Added legacy example template with the use of `zoneName` property.
- Added Integration Test for Backward Compatibility.
- Fixed not proper integration tests indentation inherited from previous tests.
- Added project parameter for `gcloud` calls. 
- Adjusted schema patterns with full match patterns where applicable.
- Added description for all the integration tests.
