### PR TITLE
Fixed Backward Compatibility Support. Fixed pydocstyle D210, D202. #138

### DIFF
--- a/dm/templates/dns_managed_zone/dns_managed_zone.py
+++ b/dm/templates/dns_managed_zone/dns_managed_zone.py
@@ -11,13 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" This template creates a managed zone resource in the Cloud DNS. """
+"""This template creates a managed zone resource in the Cloud DNS."""
 
 
 def generate_config(context):
-    """ Entry point for the deployment resources. """
-
-    managed_zone_name = context.properties.get('name', context.env['name'])
+    """Entry point for the deployment resources."""
+    # Backward Compatibility with the old property `zoneName`
+    try:
+        managed_zone_name = context.properties['zoneName']
+    except KeyError:
+        managed_zone_name = context.properties.get('name', context.env['name'])
     dnsname = context.properties['dnsName']
     managed_zone_description = context.properties['description']
     name_servers = '$(ref.' + context.env['name'] + '.nameServers)'

--- a/dm/templates/dns_managed_zone/dns_managed_zone.py.schema
+++ b/dm/templates/dns_managed_zone/dns_managed_zone.py.schema
@@ -41,6 +41,10 @@ oneOf:
 additionalProperties: false
 
 properties:
+  project:
+    type: string
+    description: |
+      The Project ID for Cross-Project Reference.
   zoneName:
     type: string
     pattern: ^[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$
@@ -49,10 +53,6 @@ properties:
       Value is rescricted by API pattern for `resource.name`
       The name must be 1-63 characters long, must begin with a letter, end
       with a letter or digit, and only contain lowercase letters, digits or dashes.
-  project:
-    type: string
-    description: |
-      The project ID of for Managed Zone to be associated with.
   description:
     type: string
     pattern: ^.{0,1023}$
@@ -62,7 +62,7 @@ properties:
       managed zone's function.
   dnsName:
     type: string
-    pattern: \.
+    pattern: ^([(a-z)\d\-]{1,62}\.){1,3}([(a-z)\d\-]{1,61}){0,1}\.$
     description: |
       The DNS name of the managed zone; for example, "example.com."
       Make sure that the value ends with a period "."

--- a/dm/templates/dns_managed_zone/tests/integration/dns_mz_cross_project.bats
+++ b/dm/templates/dns_managed_zone/tests/integration/dns_mz_cross_project.bats
@@ -24,6 +24,11 @@ if [[ -e "${RANDOM_FILE}" ]]; then
     export CLOUDDNS_DESCRIPTION="Managed DNS Zone for Testing"
 fi
 
+if [ -z "${CLOUDDNS_CROSS_PROJECT_ID}" ]; then
+    echo "CLOUDDNS_CROSS_PROJECT_ID is not set, nothing to test." >&2
+    exit 1
+fi
+
 ########## HELPER FUNCTIONS ##########
 
 function create_config() {


### PR DESCRIPTION
#138 
- Fixed Backward Compatibility Support.
- Fixed pydocstyle D210, D202.
- Updated project property description
- Restricted dnsName pattern to comply with RFC. 1035
- Made Cros-Project test to exit if Cros-Project variable is not set