### PR TITLE
Fixes #183: DM/interconnect_attachment: refactoring

### DIFF
--- a/dm/templates/interconnect_attachment/interconnect_attachment.py
+++ b/dm/templates/interconnect_attachment/interconnect_attachment.py
@@ -17,14 +17,20 @@
 
 def generate_config(context):
     """ Entry point for the deployment resources. """
+
+    properties = context.properties
+    name = properties.get('name', context.env['name'])
+    project_id = properties.get('project', context.env['project'])
+
     resources = []
     attach = {
         'name': context.env['name'],
-        'type': 'compute.v1.interconnectAttachments',
+        # https://cloud.google.com/compute/docs/reference/rest/v1/interconnectAttachments
+        'type': 'gcp-types/compute-v1:interconnectAttachments',
         'properties':
             {
-                'name':
-                    context.properties.get('name', context.env['name']),
+                'project': project_id,
+                'name': name,
                 'router':
                     context.properties['router'],
                 'region':
@@ -59,7 +65,7 @@ def generate_config(context):
             [
                 {
                     'name': 'name',
-                    'value': context.env['name']
+                    'value': name
                 },
                 {
                     'name': 'selfLink',

--- a/dm/templates/interconnect_attachment/interconnect_attachment.py.schema
+++ b/dm/templates/interconnect_attachment/interconnect_attachment.py.schema
@@ -15,12 +15,17 @@
 info:
   title: Interconnect Attachment
   author: Sourced Group Inc.
+  version: 1.0.0
   description: |
     Creates an Interconnect Attachment.
 
     For more information on this resource:
     https://cloud.google.com/interconnect/docs/how-to/dedicated/creating-vlan-attachments (Dedicated)
     https://cloud.google.com/interconnect/docs/how-to/partner/creating-vlan-attachments (Partner)
+
+    APIs endpoints used by this template:
+    - gcp-types/compute-v1:interconnectAttachments =>
+        https://cloud.google.com/compute/docs/reference/rest/v1/interconnectAttachments
 
 imports:
   - path: interconnect_attachment.py
@@ -32,34 +37,164 @@ required:
   - region
   - type
 
+oneOf:
+  - allOf:
+      - properties:
+          type:
+            enum: ["PARTNER"]
+      - not:
+          required:
+            - pairingKey
+      - not:
+          required:
+            - bandwidth
+      - not:
+          required:
+            - partnerMetadata
+      - not:
+          required:
+            - partnerAsn
+  - allOf:
+      - properties:
+          type:
+            enum: ["PARTNER_PROVIDER"]
+      - not:
+          required:
+            - adminEnabled
+      - not:
+          required:
+            - edgeAvailabilityDomain
+  - allOf:
+      - properties:
+          type:
+            enum: ["DEDICATED"]
+      - not:
+          required:
+            - pairingKey
+      - not:
+          required:
+            - edgeAvailabilityDomain
+      - not:
+          required:
+            - partnerAsn
+
 properties:
   name:
     type: string
-    description: The name of the Interconnect Attachment.
+    description: |
+    The name of the Interconnect Attachment resource. Resource name would be used if omitted.
+  project:
+    type: string
+    description: |
+      The project ID of the project containing the instance.
   router:
     type: string
-    description: The URL of the cloud router that the attachment is being 
-                 attached to.
+    description: |
+      URL of the Cloud Router to be used for dynamic routing. This router must be in the same region as this
+      InterconnectAttachment. The InterconnectAttachment will automatically connect the Interconnect to the
+      network & region within which the Cloud Router is configured.
+
+      Authorization requires the following Google IAM permission on the specified resource router:
+      - compute.routers.use
   region:
     type: string
-    description: The URL of the region where the router resides.
+    description: |
+     The URL of the region where the router resides.
+  pairingKey:
+    type: string
+    description: |
+      The opaque identifier of an PARTNER attachment used to initiate provisioning with a selected partner.
+      Of the form "XXXXX/region/domain"
   type:
     type: string
-    description: The type of Interconnect
+    description: |
+      The type of interconnect attachment this is.
     enum:
       - DEDICATED
       - PARTNER
       - PARTNER_PROVIDER
+  bandwidth:
+    type: string
+    description: |
+      Provisioned bandwidth capacity for the interconnect attachment. For attachments of type DEDICATED,
+      the user can set the bandwidth. For attachments of type PARTNER, the Google Partner that is operating
+      the interconnect must set the bandwidth.
+      Output only for PARTNER type, mutable for PARTNER_PROVIDER and DEDICATED.
+    enum:
+      - BPS_50M
+      - BPS_100M
+      - BPS_200M
+      - BPS_300M
+      - BPS_400M
+      - BPS_500M
+      - BPS_1G
+      - BPS_2G
+      - BPS_5G
+      - BPS_10G
+  adminEnabled:
+    type: boolean
+    description: |
+      Determines whether this Attachment will carry packets. Not present for PARTNER_PROVIDER.
+  partnerMetadata:
+    type: object
+    additionalProperties: false
+    description: |
+      Informational metadata about Partner attachments from Partners to display to customers.
+      Output only for for PARTNER type, mutable for PARTNER_PROVIDER, not available for DEDICATED.
+    properties:
+      partnerName:
+        type: string
+        description: |
+          Plain text name of the Partner providing this attachment.
+          This value may be validated to match approved Partner values.
+      interconnectName:
+        type: string
+        description: |
+          Plain text name of the Interconnect this attachment is connected to, as displayed in the Partner’s portal.
+          For instance "Chicago 1". This value may be validated to match approved Partner values.
+      portalUrl:
+        type: string
+        description: |
+          URL of the Partner’s portal for this Attachment. Partners may customise this to be a deep link to the
+          specific resource on the Partner portal. This value may be validated to match approved Partner values.
+  vlanTag8021q:
+    type: number
+    description: |
+      The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094. Only specified at creation time.
   interconnect:
     type: string
     description: |
       URL of the underlying Interconnect object that this attachment's traffic 
       will traverse through.
+
+      Authorization requires the following Google IAM permission on the specified resource interconnect:
+      - compute.interconnects.use
+  partnerAsn:
+    type: string
+    description: |
+      Optional BGP ASN for the router supplied by a Layer 3 Partner if they configured BGP on behalf of the customer.
+      Output only for PARTNER type, input only for PARTNER_PROVIDER, not available for DEDICATED.
+  candidateSubnets:
+    type: array
+    uniqItems: True
+    description: |
+      Up to 16 candidate prefixes that can be used to restrict the allocation of cloudRouterIpAddress and
+      customerRouterIpAddress for this attachment. All prefixes must be within link-local address space (169.254.0.0/16)
+      and must be /29 or shorter (/28, /27, etc). Google will attempt to select an unused /29 from the supplied
+      candidate prefix(es). The request will fail if all possible /29s are in use on Google’s edge.
+      If not supplied, Google will randomly select an unused /29 from all of link-local space.
+    maxItems: 16
+    items:
+      type: string
   edgeAvailabilityDomain:
     type: string
     description: |
       Desired availability domain for the attachment. Only available for type 
-      PARTNER, at creation time
+      PARTNER, at creation time.
+
+      For improved reliability, customers should configure a pair of attachments, one per availability domain.
+      The selected availability domain will be provided to the Partner via the pairing key, so that the provisioned
+      circuit will lie in the specified domain. If not specified, the value will default to AVAILABILITY_DOMAIN_ANY.
     enum:
       - AVAILABILITY_DOMAIN_1
       - AVAILABILITY_DOMAIN_2


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/183

- Added version, links to docs
- Switched to using type provider
- Added support for cross-project resource creation
- Fixed resource names
- Added missing fileds: "pairingKey", "vlanTag8021q", "adminEnabled",
"candidateSubnets", "bandwidth", "partnerMetadata", "partnerAsn"