### PR TITLE
Fix prerequisites Makefile target to align with docs and help

### DIFF
--- a/dm/Makefile
+++ b/dm/Makefile
@@ -18,7 +18,7 @@ help:
 .ONESHELL:
 .PHONY: cft-prerequisites cft-venv cft-clean-venv cft-test cft-test-venv template-prerequisites
 
-prerequisites:
+cft-prerequisites:
 	${PYTHON} -m pip install -r requirements/prerequisites.txt
 
 cft-venv:

--- a/dm/docs/userguide.md
+++ b/dm/docs/userguide.md
@@ -370,7 +370,7 @@ Proceed as follows:
 
 ```shell
 cd dm
-sudo make prerequisites        # Installs prerequisites in system python
+sudo make cft-prerequisites    # Installs prerequisites in system python
 make build                     # builds the package
 sudo make install              # installs the package in /usr/local
 ```
@@ -390,7 +390,7 @@ To update CFT to a newer version, proceed as follows:
 ```shell
 cd dm
 make clean
-sudo make prerequisites
+sudo make cft-prerequisites
 make build
 sudo make uninstall
 sudo make install


### PR DESCRIPTION
Change Makefile target from `cft-prerequisites` to `prerequisites`.