### PR TITLE
Fixes #185: DM/stackdriver_metric_descriptor: refactoring

### DIFF
--- a/dm/templates/stackdriver_metric_descriptor/examples/stackdriver_metric_descriptor.yaml
+++ b/dm/templates/stackdriver_metric_descriptor/examples/stackdriver_metric_descriptor.yaml
@@ -17,7 +17,7 @@ resources:
       metricKind: CUMULATIVE
       valueType: INT64
       unit: "1"
+      launchStage: ALPHA
       metadata:
-        launchStage: ALPHA
         samplePeriod: "10s"
         ingestDelay: "1s"

--- a/dm/templates/stackdriver_metric_descriptor/stackdriver_metric_descriptor.py
+++ b/dm/templates/stackdriver_metric_descriptor/stackdriver_metric_descriptor.py
@@ -20,11 +20,15 @@ def generate_config(context):
     resources = []
     outputs = []
     properties = context.properties
-    name = properties.get('name', context.env['name'])
+    project_id = properties.get('project', context.env['project'])
     metric_descriptor = {
-        'name': name,
+        'name': context.env['name'],
+        # https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors
         'type': 'gcp-types/monitoring-v3:projects.metricDescriptors',
-        'properties': {}
+        'properties': {
+            'name': properties.get('name', context.env['name']),
+            # 'project': project_id,
+        }
     }
 
     required_properties = [
@@ -39,7 +43,7 @@ def generate_config(context):
             metric_descriptor['properties'][prop] = properties[prop]
 
     # Optional properties:
-    optional_properties = ['displayName', 'labels', 'description', 'metadata']
+    optional_properties = ['displayName', 'labels', 'description', 'metadata', 'launchStage']
 
     for prop in optional_properties:
         if prop in properties:
@@ -64,7 +68,7 @@ def generate_config(context):
         output = {}
         if outprop in properties:
             output['name'] = outprop
-            output['value'] = '$(ref.{}.{})'.format(name, outprop)
+            output['value'] = '$(ref.{}.{})'.format(context.env['name'], outprop)
             outputs.append(output)
 
     return {'resources': resources, 'outputs': outputs}

--- a/dm/templates/stackdriver_metric_descriptor/stackdriver_metric_descriptor.py.schema
+++ b/dm/templates/stackdriver_metric_descriptor/stackdriver_metric_descriptor.py.schema
@@ -15,26 +15,86 @@
 info:
   title: Stackdriver Metric Descriptor
   author: Sourced Group Inc.
+  version: 1.0.0
   description: |
     Supports creation of a Stackdriver Metric Descriptor.
+
     For more information on this resource, see
-    https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors.
+    https://cloud.google.com/monitoring/
+
+    APIs endpoints used by this template:
+    - gcp-types/monitoring-v3:projects.metricDescriptors =>
+        https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors
 
 imports:
   - path: stackdriver_metric_descriptor.py
 
 additionalProperties: false
 
-required:
-  - type
-  - metricKind
-  - valueType
-  - unit
+allOf:
+  - required:
+      - type
+      - metricKind
+      - valueType
+  - oneOf:
+      - required:
+          - launchStage
+      - allOf:
+          - required:
+              - metadata
+          - properties:
+              metadata:
+                required:
+                  - launchStage
+      - allOf:
+          - not:
+              required:
+                - launchStage
+          - oneOf:
+              - not:
+                  required:
+                    - metadata
+              - properties:
+                  metadata:
+                    not:
+                      required:
+                        - launchStage
+
+  - oneOf:
+      - valueType:
+          enum:
+            - INT64
+            - DOUBLE
+            - DISTRIBUTION
+      - not:
+          required:
+            - unit
+
+definitions:
+  launchStage:
+    type: string
+    description: |
+      The launch stage as defined by Google Cloud Platform Launch Stages:
+      http://cloud.google.com/terms/launch-stages.
+    enum:
+      - LAUNCH_STAGE_UNSPECIFIED
+      - EARLY_ACCESS
+      - ALPHA
+      - BETA
+      - GA
+      - DEPRECATED
 
 properties:
   name:
     type: string
-    description: The resource name of the Metric Descriptor.
+    description: |
+      The name of the Metric Descriptor.
+      Resource name would be used if omitted.
+  project:
+    type: string
+    description: |
+      The project ID of the project containing resources. The
+      Google apps domain is prefixed if applicable.
   type:
     type: string
     description: |
@@ -120,23 +180,15 @@ properties:
       case without the ending period; for example, "Request count".
       Optional but recommended to be set for any metrics associated with
       user-visible concepts, such as Quota.
+  launchStage:
+    $ref: '#/definitions/launchStage'
   metadata:
     type: object
     description: |
       Additional annotations that can be used to guide the usage of a metric.
     properties:
       launchStage:
-        type: string
-        description: |
-          The launch stage as defined by Google Cloud Platform Launch Stages:
-          http://cloud.google.com/terms/launch-stages.
-        enum:
-          - LAUNCH_STAGE_UNSPECIFIED
-          - EARLY_ACCESS
-          - ALPHA
-          - BETA
-          - GA
-          - DEPRECATED
+        $ref: '#/definitions/launchStage'
       samplePeriod:
         type: string
         description: |

--- a/dm/templates/stackdriver_metric_descriptor/tests/integration/stackdriver_metric_descriptor.yaml
+++ b/dm/templates/stackdriver_metric_descriptor/tests/integration/stackdriver_metric_descriptor.yaml
@@ -16,7 +16,7 @@ imports:
     name: metric_descriptor.py
 
 resources:
-  - name: ${METRIC_NAME}
+  - name: metric
     type: metric_descriptor.py
     properties:
       name: ${METRIC_NAME}
@@ -26,7 +26,7 @@ resources:
       metricKind: ${METRIC_KIND}
       valueType: ${VALUE_TYPE}
       unit: "${UNIT}"
+      launchStage: ${LAUNCH_STAGE}
       metadata:
-        launchStage: ${LAUNCH_STAGE}
         samplePeriod: "${SAMPLE_PERIOD}"
         ingestDelay: "${INGEST_DELAY}"


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/185

- Added version, links to docs
- Added support for cross-project resource creation
- Fixed resource names
- Added support for "launchStage", deprecated "metadata.launchStage"
- Added checks for "unit"