### PR TITLE
Fixes #180: DM/cloudbuild: refactoring

### DIFF
--- a/dm/templates/cloudbuild/cloudbuild.py
+++ b/dm/templates/cloudbuild/cloudbuild.py
@@ -20,12 +20,15 @@ def generate_config(context):
     resources = []
     outputs = []
     properties = context.properties
+    project_id = properties.get('project', context.env['project'])
     name = context.env['name']
     build_steps = properties['steps']
     cloud_build = {
         'name': name,
+        # https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds/create
         'action': 'gcp-types/cloudbuild-v1:cloudbuild.projects.builds.create',
         'properties': {
+            'projectId': project_id,
             'steps': build_steps
         },
         'metadata': {

--- a/dm/templates/cloudbuild/cloudbuild.py.schema
+++ b/dm/templates/cloudbuild/cloudbuild.py.schema
@@ -17,8 +17,13 @@ info:
   author: Sourced Group Inc.
   description: |
     Creates a Cloud Build resource.
+
     For more information on this resource, see
-    https://cloud.google.com/cloud-build/docs/.
+    https://cloud.google.com/cloud-build/docs/
+
+    APIs endpoints used by this template:
+    - gcp-types/cloudbuild-v1:cloudbuild.projects.builds.create =>
+        https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds/create
 
 imports:
   - path: cloudbuild.py
@@ -29,6 +34,11 @@ required:
   - steps
 
 properties:
+  project:
+    type: string
+    description: |
+      The project ID of the project containing resources. The
+      Google apps domain is prefixed if applicable.
   source:
     description: The location of the source files to build.
     oneOf:
@@ -36,9 +46,11 @@ properties:
       - "$ref": "#/definitions/repoSource"
   steps:
     type: array
+    uniqItems: true
     description: The list of steps in the build pipeline.
     items:
       type: object
+      additionalProperties: false
       description: A step in the build pipeline.
       required:
         - name
@@ -46,10 +58,21 @@ properties:
         name:
           type: string
           description: |
-            The name of the container image that runs this particular build
-            step.
+            The name of the container image that will run this particular build step.
+
+            If the image is available in the host's Docker daemon's cache, it will be run directly. If not, the host
+            will attempt to pull the image first, using the builder service account's credentials if necessary.
+
+            The Docker daemon's cache will already have the latest versions of all of the officially supported
+            build steps (https://github.com/GoogleCloudPlatform/cloud-builders). The Docker daemon will also have
+            cached many of the layers for some popular images, like "ubuntu", "debian", but they will be refreshed
+            at the time you attempt to use them.
+
+            If you built an image in a previous build step, it will be stored in the host's Docker daemon's cache
+            and is available to use as the name for a later build step.
         env:
           type: array
+          uniqItems: true
           description: |
             The list of environment variable definitions to be used when 
             running a step. The elements are in the "KEY=VALUE" form, 
@@ -86,6 +109,7 @@ properties:
             reference this build step as a dependency.
         waitFor:
           type: array
+          uniqItems: true
           description: |
             The ID(s) of the step(s) that the build step depends on.
             This build step will not start until all the build steps in waitFor
@@ -98,10 +122,11 @@ properties:
           type: string
           description: |
             The entry point to be used instead of the build step image's
-            default entry point. If not set, the image's default entry 
+            default entry point. If not set, the image's default entry
             point is used.
         secretEnv:
           type: array
+          uniqItems: true
           description: |
             The list of environment variables which are encrypted using the 
             Cloud Key Management Service crypto key. These values must be 
@@ -110,9 +135,11 @@ properties:
             type: string
         volumes:
           type: array
+          uniqItems: true
           description: The list of volumes to mount into the build step.
           items:
             type: object
+            additionalProperties: false
             properties:
               name:
                 type: string
@@ -144,6 +171,7 @@ properties:
       terminated by 's'; for example 3.5s.
   images:
     type: array
+    uniqItems: true
     description: |
       The list of images to be pushed upon successful completion of all build
       steps. The images are pushed using the Builder service account's
@@ -154,12 +182,14 @@ properties:
       type: string
   artifacts:
     type: object
+    additionalProperties: false
     description: |
       Artifacts produced by the build, to be uploaded upon successful
       completion of all build steps.
     properties:
       images:
         type: array
+        uniqItems: true
         description: |
           The list of images to be pushed upon successful completion of all
           build steps. The images are pushed using the Builder serviceaccount's
@@ -170,31 +200,27 @@ properties:
           type: string
       objects:
         type: object
+        additionalProperties: false
         description: |
           The list of objects to be uploaded to Cloud Storage upon successful
           completion of all build steps. Files in the workspace matching
           the specified paths globs are uploaded using the Builder
           serviceaccount's credentials.
         properties:
-          artifactObjects:
-            type: object
+          location:
+            type: string
             description: |
-              Files in the workspace to upload to Cloud Storage upon successful
-              completion of all build steps.
-            properties:
-              location:
-                type: string
-                description: |
-                  The Cloud Storage bucket, with an optional object path, in
-                  the "gs://bucket/path/to/somewhere/" form. Files in the
-                  workspace matching any pattern specified uder that path are
-                  uploaded to Cloud Storage with this location as a prefix.
-              paths:
-                type: array
-                description: |
-                  Path globs used to match files in the build's workspace.
-                items:
-                  type: string
+              The Cloud Storage bucket, with an optional object path, in
+              the "gs://bucket/path/to/somewhere/" form. Files in the
+              workspace matching any pattern specified uder that path are
+              uploaded to Cloud Storage with this location as a prefix.
+          paths:
+            type: array
+            uniqItems: true
+            description: |
+              Path globs used to match files in the build's workspace.
+            items:
+              type: string
   logsBucket:
     type: string
     description: |
@@ -202,6 +228,7 @@ properties:
       Log file names are in the ${logsBucket}/log-${build_id}.txt format.
   options:
     type: object
+    additionalProperties: false
     description: Special options for the build.
     properties:
       sourceProvenanceHash:
@@ -249,6 +276,11 @@ properties:
           - STREAM_DEFAULT
           - STREAM_ON
           - STREAM_OFF
+      workerPool:
+        type: string
+        description: |
+          Option to specify a WorkerPool for the build. User specifies the pool with the format
+          "[WORKERPOOL_PROJECT_ID]/[WORKERPOOL_NAME]". This is an experimental field.
       logging:
         type: string
         description: |
@@ -258,6 +290,54 @@ properties:
           - LOGGING_UNSPECIFIED
           - LEGACY
           - GCS_ONLY
+            point is used.
+      env:
+        type: array
+        uniqItems: true
+        description: |
+          A list of global environment variable definitions that will exist for all build steps in this build.
+          If a variable is defined in both globally and in a build step, the variable will use the build step value.
+
+          The elements are of the form "KEY=VALUE" for the environment variable "KEY" being given the value "VALUE".
+        items:
+          type: string
+      secretEnv:
+        type: array
+        uniqItems: true
+        description: |
+          A list of global environment variables, which are encrypted using a Cloud Key Management Service crypto key.
+          These values must be specified in the build's Secret. These variables will be available to
+          all build steps in this build.
+        items:
+          type: string
+      volumes:
+        type: array
+        uniqItems: true
+        description: |
+          Global list of volumes to mount for ALL build steps
+
+          Each volume is created as an empty volume prior to starting the build process. Upon completion of the build,
+          volumes and their contents are discarded. Global volume names and paths cannot conflict with the volumes
+          defined a build step.
+
+          Using a global volume in a build with only one step is not valid as it is indicative of a build request
+          with an incorrect configuration.
+        items:
+          type: object
+          additionalProperties: false
+          properties:
+            name:
+              type: string
+              description: |
+                The name of the volume to mount. Volume names must be unique
+                per build step, and must be valid names for Docker volumes.
+                Each named volume must be used by at least two build steps.
+            path:
+              type: string
+              description: |
+                The path to mount the volume at. Paths must be absolute.
+                They cannot conflict with other volume paths on the same
+                build step or with certain reserved volume paths.
   substitutions:
     type: object
     description: |
@@ -265,15 +345,19 @@ properties:
       Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
   tags:
     type: array
-    description: Build annotation tags. These are NOT Docker tags.
+    uniqItems: true
+    description: |
+      Tags for annotation of a Build. These are not docker tags.
     items:
       type: string
   secrets:
     type: object
+    additionalProperties: false
     description: Secrets to decrypt using Cloud Key Management Service.
     properties:
       secret:
         type: object
+        additionalProperties: false
         properties:
           kmsKeyName:
             type: string

--- a/dm/templates/cloudbuild/trigger.py
+++ b/dm/templates/cloudbuild/trigger.py
@@ -20,7 +20,7 @@ def generate_config(context):
     resources = []
     properties = context.properties
     name = context.env['name']
-    project_id = context.env['project']
+    project_id = properties.get('project', context.env['project'])
     # set projectId in triggerTemplate
     properties['triggerTemplate']['projectId'] = project_id
     build_def = properties.get('build')
@@ -29,28 +29,28 @@ def generate_config(context):
 
     # build trigger create action
     build_trigger_create = {
-        'name':
-            name,
-        'action':
-            'gcp-types/cloudbuild-v1:cloudbuild.projects.triggers.create',
+        'name': name,
+        # https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.triggers/create
+        'action': 'gcp-types/cloudbuild-v1:cloudbuild.projects.triggers.create',
         'metadata': {
             'runtimePolicy': ['CREATE'],
         },
         'properties': {
+            'projectId': project_id,
             'triggerTemplate': properties['triggerTemplate']
         }
     }
 
     # build trigger update action
     build_trigger_update = {
-        'name':
-            name + '-update',
-        'action':
-            'gcp-types/cloudbuild-v1:cloudbuild.projects.triggers.patch',
+        'name': name + '-update',
+        # https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.triggers/patch
+        'action': 'gcp-types/cloudbuild-v1:cloudbuild.projects.triggers.patch',
         'metadata': {
             'runtimePolicy': ['UPDATE_ON_CHANGE'],
         },
         'properties': {
+            'projectId': project_id,
             'id': build_trigger_id,
             'triggerId': build_trigger_id,
             'triggerTemplate': properties['triggerTemplate']
@@ -62,7 +62,8 @@ def generate_config(context):
         'disabled',
         'substitutions',
         'ignoredFiles',
-        'includedFiles'
+        'includedFiles',
+        'tags'
     ]
 
     for prop in optional_properties:
@@ -82,10 +83,9 @@ def generate_config(context):
 
     # build trigger delete action
     build_trigger_delete = {
-        'name':
-            name + '-delete',
-        'action':
-            'gcp-types/cloudbuild-v1:cloudbuild.projects.triggers.delete',
+        'name': name + '-delete',
+        # https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.triggers/delete
+        'action': 'gcp-types/cloudbuild-v1:cloudbuild.projects.triggers.delete',
         'metadata': {
             'runtimePolicy': ['DELETE'],
         },

--- a/dm/templates/cloudbuild/trigger.py.schema
+++ b/dm/templates/cloudbuild/trigger.py.schema
@@ -17,21 +17,38 @@ info:
   author: Sourced Group Inc.
   description: |
     Supports creation of an automated Cloud Build trigger.
+
     For more information on this resource, see
-    https://cloud.google.com/cloud-build/docs/running-builds/automate-builds.
+    https://cloud.google.com/cloud-build/docs/running-builds/automate-builds
+
+    APIs endpoints used by this template:
+    - gcp-types/cloudbuild-v1:cloudbuild.projects.triggers.create =>
+        https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.triggers/create
+    - gcp-types/cloudbuild-v1:cloudbuild.projects.triggers.patch =>
+        https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.triggers/patch
+    - gcp-types/cloudbuild-v1:cloudbuild.projects.triggers.delete =>
+        https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.triggers/delete
 
 imports:
   - path: trigger.py
+
+additionalProperties: false
 
 required:
   - triggerTemplate
 
 properties:
+  project:
+    type: string
+    description: |
+      The project ID of the project containing resources. The
+      Google apps domain is prefixed if applicable.
   description:
     type: string
     description: The human-readable trigger description.
   triggerTemplate:
     type: object
+    additionalProperties: false
     description: |
       The template describing the types of source changes that trigger a build.
       Branch and tag names in the trigger templates are interpreted as regular
@@ -59,6 +76,7 @@ properties:
         oneOf:
           - "$ref": "#/definitions/branchName"
           - "$ref": "#/definitions/tagName"
+          - "$ref": "#/definitions/commitSha"
   disabled:
     type: boolean
     default: False
@@ -70,6 +88,7 @@ properties:
       Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
   ignoredFiles:
     type: array
+    uniqItems: true
     description: |
       A file glob match using http://godoc/pkg/path/filepath#Match extended 
       with support for "**". If both ignoredFiles and changed files are empty, 
@@ -81,6 +100,7 @@ properties:
       type: string
   includedFiles:
     type: array
+    uniqItems: true
     description: |
       A file glob match using http://godoc/pkg/path/filepath#Match extended
       with support for "**". If any of the files altered in the commit pass
@@ -95,10 +115,18 @@ properties:
     oneOf:
       - "$ref": "#/definitions/build"
       - "$ref": "#/definitions/filename"
+  tags:
+    type: array
+    uniqItems: true
+    description: |
+      Tags for annotation of a BuildTrigger
+    items:
+      type: string
 
 definitions:
   storageSource:
     type: object
+    additionalProperties: false
     description: |
       The location of the source in an archive file on Google Cloud Storage.
     properties:
@@ -117,6 +145,7 @@ definitions:
           the latest generation is used.
   repoSource:
     type: object
+    additionalProperties: false
     description: The source location in the Google Cloud Source repository.
     properties:
       projectId:
@@ -140,6 +169,9 @@ definitions:
           - "$ref": "#/definitions/branchName"
           - "$ref": "#/definitions/tagName"
           - "$ref": "#/definitions/commitSha"
+  commitSha:
+    type: string
+    description: Explicit commit SHA to build.
   branchName:
     type: string
     description: The name of the branch to build.
@@ -153,19 +185,23 @@ definitions:
       the template.
   build:
     type: object
+    additionalProperties: false
     description: The contents of the build template.
     properties:
       source:
         type: object
+        additionalProperties: false
         description: The location of the source files to build.
         oneOf:
           - "$ref": "#/definitions/storageSource"
           - "$ref": "#/definitions/repoSource"
       steps:
         type: array
+        uniqItems: true
         description: The list of the steps in the build pipeline.
         items:
           type: object
+          additionalProperties: false
           description: A step in the build pipeline.
           required:
             - name
@@ -176,6 +212,7 @@ definitions:
                 The name of the container image that runs the build step.
             env:
               type: array
+              uniqItems: true
               description: |
                 The list of environment variable definitions to be used when
                 running a step. The elements are in the "KEY=VALUE" form,
@@ -213,6 +250,7 @@ definitions:
                 reference this build step as a dependency.
             waitFor:
               type: array
+              uniqItems: true
               description: |
                 The ID(s) of the step(s) this build step depends on.
                 The build step will not start until all the build steps in 
@@ -229,6 +267,7 @@ definitions:
                 point is used.
             secretEnv:
               type: array
+              uniqItems: true
               description: |
                 The list of environment variables are encrypted using the
                 Cloud Key Management Service crypto key. These values must be
@@ -237,9 +276,11 @@ definitions:
                 type: string
             volumes:
               type: array
+              uniqItems: true
               description: The list of volumes to mount into the build step.
               items:
                 type: object
+                additionalProperties: false
                 properties:
                   name:
                     type: string
@@ -273,6 +314,7 @@ definitions:
           by 's'. Example: "3.5s".
       images:
         type: array
+        uniqItems: true
         description: |
           The list of images to be pushed upon successful completion of all
           build steps. The images are pushed using the Builder service
@@ -283,12 +325,14 @@ definitions:
           type: string
       artifacts:
         type: object
+        additionalProperties: false
         description: |
           Artifacts produced by the build that must be uploaded upon successful
           completion of all build steps.
         properties:
           images:
             type: array
+            uniqItems: true
             description: |
               The list of images to be pushed upon successful completion of all
               build steps. The images are pushed using the Builder service
@@ -299,31 +343,27 @@ definitions:
               type: string
           objects:
             type: object
+            additionalProperties: false
             description: |
               The list of objects to be uploaded to Cloud Storage upon
               successful completion of all build steps. Files in the
               workspace matching specified paths globs are uploaded using
               the Builder service account's credentials.
             properties:
-              artifactObjects:
-                type: object
+              location:
+                type: string
                 description: |
-                  Files in the workspace to upload to Cloud Storage upon
-                  successful completion of all build steps.
-                properties:
-                  location:
-                    type: string
-                    description: |
-                      The Cloud Storage bucket, with an optional object path,
-                      in the "gs://bucket/path/to/somewhere/" form. Files in
-                      the workspace matching any pattern under that path are
-                      uploaded to Cloud Storage with this location as a prefix.
-                  paths:
-                    type: array
-                    description: |
-                      Path globs used to match files in the build's workspace.
-                    items:
-                      type: string
+                  The Cloud Storage bucket, with an optional object path,
+                  in the "gs://bucket/path/to/somewhere/" form. Files in
+                  the workspace matching any pattern under that path are
+                  uploaded to Cloud Storage with this location as a prefix.
+              paths:
+                type: array
+                uniqItems: true
+                description: |
+                  Path globs used to match files in the build's workspace.
+                items:
+                  type: string
       logsBucket:
         type: string
         description: |
@@ -332,10 +372,12 @@ definitions:
           format.
       options:
         type: object
+        additionalProperties: false
         description: Special options for this build.
         properties:
           sourceProvenanceHash:
             type: array
+            uniqItems: true
             items:
               type: string
               enum:
@@ -388,22 +430,73 @@ definitions:
               - LOGGING_UNSPECIFIED
               - LEGACY
               - GCS_ONLY
+          env:
+            type: array
+            uniqItems: true
+            description: |
+              A list of global environment variable definitions that will exist for all build steps in this build.
+              If a variable is defined in both globally and in a build step, the variable will use the build step value.
+
+              The elements are of the form "KEY=VALUE" for the environment variable "KEY" being given the value "VALUE".
+            items:
+              type: string
+          secretEnv:
+            type: array
+            uniqItems: true
+            description: |
+              A list of global environment variables, which are encrypted using a Cloud Key Management Service crypto key.
+              These values must be specified in the build's Secret. These variables will be available to
+              all build steps in this build.
+            items:
+              type: string
+          volumes:
+            type: array
+            uniqItems: true
+            description: |
+              Global list of volumes to mount for ALL build steps
+
+              Each volume is created as an empty volume prior to starting the build process. Upon completion of the build,
+              volumes and their contents are discarded. Global volume names and paths cannot conflict with the volumes
+              defined a build step.
+
+              Using a global volume in a build with only one step is not valid as it is indicative of a build request
+              with an incorrect configuration.
+            items:
+              type: object
+              additionalProperties: false
+              properties:
+                name:
+                  type: string
+                  description: |
+                    The name of the volume to mount. Volume names must be unique
+                    per build step, and must be valid names for Docker volumes.
+                    Each named volume must be used by at least two build steps.
+                path:
+                  type: string
+                  description: |
+                    The path to mount the volume at. Paths must be absolute.
+                    They cannot conflict with other volume paths on the same
+                    build step or with certain reserved volume paths.
       substitutions:
         type: object
+        additionalProperties: false
         description: |
           Substitution data for the build resource. A list of key-value items.
           Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
       tags:
         type: array
+        uniqItems: true
         description: Build annotation tags. These are NOT Docker tags.
         items:
           type: string
       secrets:
         type: object
+        additionalProperties: false
         description: Secrets to decrypt using Cloud Key Management Service.
         properties:
           secret:
             type: object
+            additionalProperties: false
             properties:
               kmsKeyName:
                 type: string
@@ -412,6 +505,7 @@ definitions:
                   variables.
               secretEnv:
                 type: object
+                additionalProperties: false
                 description: |
                   Maps of the environment variable names to their encrypted
                   values. 


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/180

- Added version, links to docs
- Added support for cross-project resource creation
- Fixed resource names
- Added checks to objects and arrays
- Fixed "artifacts.objects" property, add "options.workerPool, env,
secretEnv, volumes" for cloudbuild
- Added "tags", "github", "triggerTemplate.revision->commitSha" for
trigger