### PR TITLE
Update Project Factory integration test image

### DIFF
--- a/infra/concourse/pipelines/terraform-google-project-factory.yml
+++ b/infra/concourse/pipelines/terraform-google-project-factory.yml
@@ -33,7 +33,7 @@ resources:
   type: docker-image
   source:
     repository: gcr.io/cloud-foundation-cicd/cft/kitchen-terraform
-    tag: 1.0.1
+    tag: 2.0.0
     username: _json_key
     password: ((sa.google))
 


### PR DESCRIPTION
This commit updates the version of the integration test docker image to
version 2.0.0 which includes Terraform 0.12. This is needed to enable CI
testing for the impending Terraform 0.12 upgrade. NOTE: This change will
be a blocker for any open PRs that implement Terraform 0.11 syntax.