### PR TITLE
Update docker images for TF 0.12.3

### DIFF
--- a/infra/concourse/Makefile.BUILD
+++ b/infra/concourse/Makefile.BUILD
@@ -1,9 +1,9 @@
 SHELL := /usr/bin/env bash # Make will use bash instead of sh
 
-BUILD_TERRAFORM_VERSION := 0.12.0
+BUILD_TERRAFORM_VERSION := 0.12.3
 BUILD_CLOUD_SDK_VERSION := 239.0.0
 BUILD_PROVIDER_GOOGLE_VERSION := 2.7.0
-BUILD_PROVIDER_GSUITE_VERSION := 0.1.19
+BUILD_PROVIDER_GSUITE_VERSION := 0.1.22
 BUILD_RUBY_VERSION := 2.6.3
 # Make sure you update DOCKER_TAG_VERSION_TERRAFORM or DOCKER_TAG_VERSION_KITCHEN_TERRAFORM independently:
 # If you make changes to the Docker.terraform file, update DOCKER_TAG_VERSION_TERRAFORM
@@ -13,13 +13,13 @@ BUILD_RUBY_VERSION := 2.6.3
 # Adding a component or upgrading a component to a backwards compatible release should constitute a minor release.
 # Fixing bugs or making trivial changes should be considered a patch release.
 
-DOCKER_TAG_VERSION_TERRAFORM := 2.0.0
-DOCKER_TAG_VERSION_KITCHEN_TERRAFORM := 2.1.0
+DOCKER_TAG_VERSION_TERRAFORM := 2.1.0
+DOCKER_TAG_VERSION_KITCHEN_TERRAFORM := 2.2.0
 
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
 DOCKER_IMAGE_LINT := cft/lint
-DOCKER_TAG_LINT := 2.3.0
+DOCKER_TAG_LINT := 2.4.0
 
 DOCKER_IMAGE_UNIT := cft/unit
 DOCKER_TAG_UNIT := latest
@@ -30,6 +30,8 @@ DOCKER_IMAGE_KITCHEN_TERRAFORM := cft/kitchen-terraform
 .PHONY: build-image-lint
 build-image-lint:
 	docker build -f build/Dockerfile.lint \
+		--build-arg BUILD_TERRAFORM_VERSION=${BUILD_TERRAFORM_VERSION} \
+		--build-arg BUILD_PROVIDER_GSUITE_VERSION=${BUILD_PROVIDER_GSUITE_VERSION} \
 		-t ${DOCKER_IMAGE_LINT}:${DOCKER_TAG_LINT} .
 
 .PHONY: build-image-unit

--- a/infra/concourse/build/Dockerfile.lint
+++ b/infra/concourse/build/Dockerfile.lint
@@ -19,10 +19,10 @@ RUN wget https://shellcheck.storage.googleapis.com/shellcheck-v0.6.0.linux.x86_6
     tar -xf shellcheck-v0.6.0.linux.x86_64.tar.xz && \
     mv shellcheck-v0.6.0/shellcheck /usr/local/bin/ && \
     rm -r shellcheck-v0.6.0 shellcheck-v0.6.0.linux.x86_64.tar.xz
+ARG BUILD_TERRAFORM_VERSION
+ENV TERRAFORM_VERSION="${BUILD_TERRAFORM_VERSION}"
 
-ENV TERRAFORM_VERSION=0.12.0
-
-RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+RUN wget "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     mv terraform /usr/local/bin/
@@ -38,3 +38,12 @@ RUN wget https://github.com/segmentio/terraform-docs/releases/download/v0.6.0/te
 RUN wget https://raw.githubusercontent.com/antonbabenko/pre-commit-terraform/master/terraform_docs.sh && \
     mv terraform_docs.sh /usr/local/bin/terraform_docs.sh && \
     chmod 0755 /usr/local/bin/terraform_docs.sh
+
+ARG BUILD_PROVIDER_GSUITE_VERSION
+ENV PROVIDER_GSUITE_VERSION="${BUILD_PROVIDER_GSUITE_VERSION}"
+
+RUN wget "https://github.com/DeviaVir/terraform-provider-gsuite/releases/download/v${PROVIDER_GSUITE_VERSION}/terraform-provider-gsuite_${PROVIDER_GSUITE_VERSION}_linux_amd64.tgz" && \
+    tar xzf terraform-provider-gsuite_${PROVIDER_GSUITE_VERSION}_linux_amd64.tgz && \
+    rm terraform-provider-gsuite_${PROVIDER_GSUITE_VERSION}_linux_amd64.tgz && \
+    install -m 0755 -d ~/.terraform.d/plugins/ && \
+    mv terraform-provider-gsuite_v${PROVIDER_GSUITE_VERSION} ~/.terraform.d/plugins/

--- a/infra/concourse/pipelines/terraform-google-project-factory.yml
+++ b/infra/concourse/pipelines/terraform-google-project-factory.yml
@@ -33,7 +33,7 @@ resources:
   type: docker-image
   source:
     repository: gcr.io/cloud-foundation-cicd/cft/kitchen-terraform
-    tag: 2.0.0
+    tag: 2.2.0
     username: _json_key
     password: ((sa.google))
 

--- a/infra/concourse/pipelines/terraform-google-project-factory.yml
+++ b/infra/concourse/pipelines/terraform-google-project-factory.yml
@@ -18,7 +18,7 @@ resources:
   type: docker-image
   source:
     repository: gcr.io/cloud-foundation-cicd/cft/lint
-    tag: 1.0.0
+    tag: 2.4.0
     username: _json_key
     password: ((sa.google))
 


### PR DESCRIPTION
This patch builds a new lint image with Terraform 0.12.3 which includes
the gsuite provider to fix the following error with the 2.3.0 image.
This patch also builds version 2.1.0 for both the terraform and
kitchen-terraform images, based on TF 0.12.3.

    helpers/terraform_validate ./examples/project-hierarchy
    Initializing modules...
    - project-factory in ../../modules/gsuite_enabled
    - project-factory.gsuite_group in ../../modules/gsuite_group
    - project-factory.project-factory in ../../modules/core_project_factory
    - project-prod-gke in ../../modules/gsuite_enabled
    - project-prod-gke.gsuite_group in ../../modules/gsuite_group
    - project-prod-gke.project-factory in ../../modules/core_project_factory

    Initializing provider plugins...
    - Checking for available provider plugins...

    Provider "gsuite" not available for installation.

    A provider named "gsuite" could not be found in the Terraform Registry.

    This may result from mistyping the provider name, or the given provider may
    be a third-party provider that cannot be installed automatically.

    In the latter case, the plugin must be installed manually by locating and
    downloading a suitable distribution package and placing the plugin's executable
    file in the following directory:
        terraform.d/plugins/linux_amd64

    Terraform detects necessary plugins by inspecting the configuration and state.
    To view the provider versions requested by each module, run
    "terraform providers".

    - Downloading plugin for provider "google" (terraform-providers/google) 2.10.0...
    - Downloading plugin for provider "null" (terraform-providers/null) 2.1.2...
    - Downloading plugin for provider "random" (terraform-providers/random) 2.1.2...
    - Downloading plugin for provider "google-beta" (terraform-providers/google-beta) 2.10.0...

    Error: no provider exists with the given name
    Error: Could not satisfy plugin requirements

