### PR TITLE
Add kubectl to kitchen-terraform image

### DIFF
--- a/infra/concourse/Makefile.BUILD
+++ b/infra/concourse/Makefile.BUILD
@@ -14,7 +14,7 @@ BUILD_RUBY_VERSION := 2.6.3
 # Fixing bugs or making trivial changes should be considered a patch release.
 
 DOCKER_TAG_VERSION_TERRAFORM := 2.0.0
-DOCKER_TAG_VERSION_KITCHEN_TERRAFORM := 2.0.0
+DOCKER_TAG_VERSION_KITCHEN_TERRAFORM := 2.0.1
 
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/infra/concourse/Makefile.BUILD
+++ b/infra/concourse/Makefile.BUILD
@@ -14,7 +14,7 @@ BUILD_RUBY_VERSION := 2.6.3
 # Fixing bugs or making trivial changes should be considered a patch release.
 
 DOCKER_TAG_VERSION_TERRAFORM := 2.0.0
-DOCKER_TAG_VERSION_KITCHEN_TERRAFORM := 2.0.1
+DOCKER_TAG_VERSION_KITCHEN_TERRAFORM := 2.1.0
 
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/infra/concourse/build/Dockerfile.kitchen-terraform
+++ b/infra/concourse/build/Dockerfile.kitchen-terraform
@@ -29,7 +29,8 @@ RUN apk add --no-cache \
     musl-dev \
     openssh \
     python \
-    python3
+    python3 \
+    ca-certificates
 
 SHELL ["/bin/bash", "-c"]
 
@@ -40,6 +41,9 @@ RUN cd /tmp && \
     unzip packer_1.4.1_linux_amd64.zip && \
     rm -rf packer_1.4.1_linux_amd64.zip && \
     mv packer /bin/
+
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.12.2/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+RUN chmod +x /usr/local/bin/kubectl
 
 COPY --from=cft-terraform $APP_BASE_DIR $APP_BASE_DIR
 
@@ -56,7 +60,8 @@ RUN terraform --version && \
     gcloud --version && \
     ruby --version && \
     bundle --version && \
-    packer --version
+    packer --version && \
+    kubectl version --client=true
 
 WORKDIR /opt/kitchen
 ADD ./build/data/Gemfile .


### PR DESCRIPTION
Per conversation with @aaron-lane, this will go towards simplifying the `terraform-google-kubernetes-engine` Concourse pipeline by eliminating a presently-problematic intermediary build stage.

When this is approved, I plan to release it via `make build-image-kitchen-terraform && make release-image-kitchen-terraform`. `DOCKER_TAG_VERSION_KITCHEN_TERRAFORM` has been set to `2.0.1` in this PR.