### PR TITLE
Update docker images for network module

### DIFF
--- a/infra/concourse/pipelines/terraform-google-network.yml
+++ b/infra/concourse/pipelines/terraform-google-network.yml
@@ -18,7 +18,7 @@ resources:
   type: docker-image
   source:
     repository: gcr.io/cloud-foundation-cicd/cft/lint
-    tag: 2.3.0
+    tag: 2.4.0
     username: _json_key
     password: ((sa.google))
 
@@ -26,7 +26,7 @@ resources:
   type: docker-image
   source:
     repository: gcr.io/cloud-foundation-cicd/cft/kitchen-terraform
-    tag: 2.0.0
+    tag: 2.2.0
     username: _json_key
     password: ((sa.google))
 


### PR DESCRIPTION
This commit updates both the lint and integration test docker images for
the network module to versions that will support the Terraform 0.12
upgrade.