### PR TITLE
Enable VPN DM template to support static routing.

### DIFF
--- a/dm/templates/vpn/vpn.py
+++ b/dm/templates/vpn/vpn.py
@@ -23,7 +23,7 @@ def generate_config(context):
 
     network = context.properties.get('networkURL', generate_network_uri(
         project_id,
-        context.properties.get('networkName','')
+        context.properties.get('network','')
     ))
     target_vpn_gateway = context.env['name'] + '-tvpng'
     esp_rule = context.env['name'] + '-esp-rule'

--- a/dm/templates/vpn/vpn.py
+++ b/dm/templates/vpn/vpn.py
@@ -32,15 +32,15 @@ def generate_config(context):
     vpn_tunnel = context.env['name'] + '-vpn'
     router_vpn_binding = context.env['name'] + '-router-vpn-binding'
     resources = []
-    static_ip = ''
-    ip_address = ''
     if 'ipAddress' in context.properties:
         ip_address = context.properties['ipAddress']
+        static_ip = ''
     else:
         static_ip = context.env['name'] + '-ip'
         resources.append({
             # The reserved address resource.
             'name': static_ip,
+            # https://cloud.google.com/compute/docs/reference/rest/v1/addresses
             'type': 'gcp-types/compute-v1:addresses',
             'properties': {
                 'region': context.properties['region']

--- a/dm/templates/vpn/vpn.py
+++ b/dm/templates/vpn/vpn.py
@@ -111,7 +111,7 @@ def generate_config(context):
                     'target': '$(ref.' + target_vpn_gateway + '.selfLink)',
                 }
         },
-        
+
     ])
     router_url_tag = 'routerURL'
     router_name_tag = 'router'
@@ -243,6 +243,10 @@ def generate_config(context):
                 {
                     'name': 'vpnTunnel',
                     'value': vpn_tunnel
+                },
+                {
+                    'name': 'vpnTunnelUri',
+                    'value': '$(ref.'+vpn_tunnel+'.selfLink)'
                 }
             ]
     }

--- a/dm/templates/vpn/vpn.py
+++ b/dm/templates/vpn/vpn.py
@@ -43,6 +43,8 @@ def generate_config(context):
             # https://cloud.google.com/compute/docs/reference/rest/v1/addresses
             'type': 'gcp-types/compute-v1:addresses',
             'properties': {
+                'name': properties.get('name', static_ip),
+                'project': project_id,
                 'region': context.properties['region']
             }
         })

--- a/dm/templates/vpn/vpn.py
+++ b/dm/templates/vpn/vpn.py
@@ -114,7 +114,7 @@ def generate_config(context):
         
     ])
     router_url_tag = 'routerURL'
-    router_name_tag = 'routerName'
+    router_name_tag = 'router'
 
     if router_name_tag in context.properties:
         router_url = context.properties.get(router_url_tag, generate_router_uri(

--- a/dm/templates/vpn/vpn.py
+++ b/dm/templates/vpn/vpn.py
@@ -21,19 +21,34 @@ def generate_config(context):
     properties = context.properties
     project_id = properties.get('project', context.env['project'])
 
-    network = generate_network_url(
+    network = context.properties.get('networkURL', generate_network_uri(
         project_id,
-        context.properties['network']
-    )
+        context.properties.get('networkName','')
+    ))
     target_vpn_gateway = context.env['name'] + '-tvpng'
-    static_ip = context.env['name'] + '-ip'
     esp_rule = context.env['name'] + '-esp-rule'
     udp_500_rule = context.env['name'] + '-udp-500-rule'
     udp_4500_rule = context.env['name'] + '-udp-4500-rule'
     vpn_tunnel = context.env['name'] + '-vpn'
     router_vpn_binding = context.env['name'] + '-router-vpn-binding'
+    resources = []
+    static_ip = ''
+    ip_address = ''
+    if 'ipAddress' in context.properties:
+        ip_address = context.properties['ipAddress']
+    else:
+        static_ip = context.env['name'] + '-ip'
+        resources.append({
+            # The reserved address resource.
+            'name': static_ip,
+            'type': 'gcp-types/compute-v1:addresses',
+            'properties': {
+                'region': context.properties['region']
+            }
+        })
+        ip_address = '$(ref.' + static_ip + '.address)'
 
-    resources = [
+    resources.extend([
         {
             # The target VPN gateway resource.
             'name': target_vpn_gateway,
@@ -48,17 +63,6 @@ def generate_config(context):
                 }
         },
         {
-            # The reserved address resource.
-            'name': static_ip,
-            # https://cloud.google.com/compute/docs/reference/rest/v1/addresses
-            'type': 'gcp-types/compute-v1:addresses',
-            'properties': {
-                'name': properties.get('name', static_ip),
-                'project': project_id,
-                'region': context.properties['region'],
-            }
-        },
-        {
             # The forwarding rule resource for the ESP traffic.
             'name': esp_rule,
             # https://cloud.google.com/compute/docs/reference/rest/v1/forwardingRules
@@ -67,7 +71,7 @@ def generate_config(context):
                 {
                     'name': '{}-esp'.format(properties.get('name')) if 'name' in properties else esp_rule,
                     'project': project_id,
-                    'IPAddress': '$(ref.' + static_ip + '.address)',
+                    'IPAddress': ip_address,
                     'IPProtocol': 'ESP',
                     'region': context.properties['region'],
                     'target': '$(ref.' + target_vpn_gateway + '.selfLink)',
@@ -82,7 +86,7 @@ def generate_config(context):
                 {
                     'name': '{}-udp-4500'.format(properties.get('name')) if 'name' in properties else udp_4500_rule,
                     'project': project_id,
-                    'IPAddress': '$(ref.' + static_ip + '.address)',
+                    'IPAddress': ip_address,
                     'IPProtocol': 'UDP',
                     'portRange': 4500,
                     'region': context.properties['region'],
@@ -98,22 +102,93 @@ def generate_config(context):
                 {
                     'name': '{}-udp-500'.format(properties.get('name')) if 'name' in properties else udp_500_rule,
                     'project': project_id,
-                    'IPAddress': '$(ref.' + static_ip + '.address)',
+                    'IPAddress': ip_address,
                     'IPProtocol': 'UDP',
                     'portRange': 500,
                     'region': context.properties['region'],
                     'target': '$(ref.' + target_vpn_gateway + '.selfLink)',
                 }
         },
-        {
-            # The VPN tunnel resource.
-            'name': vpn_tunnel,
-            # https://cloud.google.com/compute/docs/reference/rest/v1/vpnTunnels
-            'type': 'gcp-types/compute-v1:vpnTunnels',
-            'properties':
-                {
-                    'name': properties.get('name', vpn_tunnel),
-                    'project': project_id,
+        
+    ])
+    router_url_tag = 'routerURL'
+    router_name_tag = 'routerName'
+
+    if router_name_tag in context.properties:
+        router_url = context.properties.get(router_url_tag, generate_router_uri(
+            context.env['project'],
+            context.properties['region'],
+            context.properties[router_name_tag]))
+        # Create dynamic routing VPN
+        resources.extend([
+            {
+                # The VPN tunnel resource.
+                'name': vpn_tunnel,
+                # https://cloud.google.com/compute/docs/reference/rest/v1/vpnTunnels
+                'type': 'gcp-types/compute-v1:vpnTunnels',
+                'properties':
+                    {
+                        'name': properties.get('name', vpn_tunnel),
+                        'project': project_id,
+                        'description':
+                            'A vpn tunnel',
+                        'ikeVersion':
+                            2,
+                        'peerIp':
+                            context.properties['peerAddress'],
+                        'region':
+                            context.properties['region'],
+                        'router': router_url,
+                        'sharedSecret':
+                            context.properties['sharedSecret'],
+                        'targetVpnGateway':
+                            '$(ref.' + target_vpn_gateway + '.selfLink)'
+                    },
+                'metadata': {
+                    'dependsOn': [esp_rule,
+                                udp_500_rule,
+                                udp_4500_rule]
+                }
+            },
+            {
+                # An action that is executed after the vpn_tunnel function.
+                # It calls the method patch by ID on the descriptor document
+                # https://cloud.google.com/compute/docs/reference/rest/v1/routers/patch
+                'name': router_vpn_binding,
+                'action': 'gcp-types/compute-v1:compute.routers.patch',
+                'properties':
+                    {
+                        'project': project_id,
+                        'router':
+                            context.properties[router_name_tag],
+                        'region':
+                            context.properties['region'],
+                        'name':
+                            context.properties[router_name_tag],
+                        'asn':
+                            context.properties['asn'],
+                        'interfaces':
+                            [
+                                {
+                                    'ipRange':
+                                        '169.254.1.1/31',
+                                    'linkedVpnTunnel':
+                                        '$(ref.' + vpn_tunnel + '.selfLink)',
+                                    'name':
+                                        'if-1'
+                                }
+                            ]
+                    }
+            }])
+    else:
+        # Create static routing VPN
+        resources.append(
+            {
+                # The VPN tunnel resource.
+                'name': vpn_tunnel,
+                'type': 'gcp-types/compute-v1:vpnTunnels',
+                'properties': {
+                    'name': vpn_tunnel,
                     'description':
                         'A vpn tunnel',
                     'ikeVersion':
@@ -122,54 +197,21 @@ def generate_config(context):
                         context.properties['peerAddress'],
                     'region':
                         context.properties['region'],
-                    'router':
-                        generate_router_url(
-                            context.env['project'],
-                            context.properties['region'],
-                            context.properties['router']
-                        ),
                     'sharedSecret':
                         context.properties['sharedSecret'],
                     'targetVpnGateway':
-                        '$(ref.' + target_vpn_gateway + '.selfLink)'
+                        '$(ref.' + target_vpn_gateway + '.selfLink)',
+                    'localTrafficSelector':
+                        context.properties['localTrafficSelector'],
+                    'remoteTrafficSelector':
+                        context.properties['remoteTrafficSelector'],
+
                 },
-            'metadata': {
-                'dependsOn': [esp_rule,
-                              udp_500_rule,
-                              udp_4500_rule]
-            }
-        },
-        {
-            # An action that is executed after the vpn_tunnel function.
-            # It calls the method patch by ID on the descriptor document
-            # https://cloud.google.com/compute/docs/reference/rest/v1/routers/patch
-            'name': router_vpn_binding,
-            'action': 'gcp-types/compute-v1:compute.routers.patch',
-            'properties':
-                {
-                    'project': project_id,
-                    'router':
-                        context.properties['router'],
-                    'region':
-                        context.properties['region'],
-                    'name':
-                        context.properties['router'],
-                    'asn':
-                        context.properties['asn'],
-                    'interfaces':
-                        [
-                            {
-                                'ipRange':
-                                    '169.254.1.1/31',
-                                'linkedVpnTunnel':
-                                    '$(ref.' + vpn_tunnel + '.selfLink)',
-                                'name':
-                                    'if-1'
-                            }
-                        ]
+                'metadata': {
+                    'dependsOn': [esp_rule, udp_500_rule, udp_4500_rule]
                 }
-        }
-    ]
+            },
+        )
 
     return {
         'resources':
@@ -203,16 +245,14 @@ def generate_config(context):
             ]
     }
 
-
-def generate_network_url(project_id, network):
+def generate_network_uri(project_id, network):
     """Format the resource name as a resource URI."""
     return 'projects/{}/global/networks/{}'.format(project_id, network)
 
-
-def generate_router_url(project_id, region, router):
-    """Format the resource name as a resource URI."""
+def generate_router_uri(project_id, region, router_name):
+    """Format the router name as a router URI."""
     return 'projects/{}/regions/{}/routers/{}'.format(
         project_id,
         region,
-        router
+        router_name
     )

--- a/dm/templates/vpn/vpn.py.schema
+++ b/dm/templates/vpn/vpn.py.schema
@@ -39,11 +39,12 @@ info:
 additionalProperties: false
 
 required:
-  - network
+  # One of "networkURL" and "networkName" must be specified.
   - region
   - peerAddress
-  - asn
   - sharedSecret
+  # asn and routerName are required when using dynamic routing
+  # Do not specify "router" when using static routing.
 
 properties:
   name:
@@ -56,13 +57,22 @@ properties:
     description: |
       The project ID of the project containing resources. The
       Google apps domain is prefixed if applicable.
-  router:
+  routerURL:
+    type: string
+    description: URL (or URI) of the Router resource. Used by vpnTunnels.
+  routerName:
     type: string
     description: |
       Name of the Router resource.
-  network:
+  networkURL:
     type: string
-    description: The URI of the network to which the VPN belongs.
+    description: |
+      The URL (or URI) of the network to which the VPN belongs.
+  networkName:
+    type: string
+    description: |
+      The name of the network to which the VPN belongs. Only use "networkName"
+      when it is impossible to get "networkURL".
   region:
     type: string
     description: The URI of the region where the VPN resides.
@@ -81,6 +91,27 @@ properties:
     description: |
       The value is used to set the secure session between the Cloud VPN
       gateway and the peer VPN gateway.
+  localTrafficSelector:
+    type: array
+    description: |
+      Used when establishing the VPN tunnel with the peer VPN gateway.
+    default: ["0.0.0.0/0"]
+    items:
+      type: string
+      description: "CIDR formatted string, for example: 192.168.0.0/16."
+  remoteTrafficSelector:
+    type: array
+    description: |
+      Used when establishing the VPN tunnel with the peer VPN gateway.
+    default: ["0.0.0.0/0"]
+    items:
+      type: string
+      description: "CIDR formatted string, for example: 192.168.0.0/16."
+  ipAddress:
+    type: string
+    description: |
+      Static IP address used by forwarding rules. When not specified, a new static
+      IP address will be created.
 
 outputs:
   properties:

--- a/dm/templates/vpn/vpn.py.schema
+++ b/dm/templates/vpn/vpn.py.schema
@@ -38,13 +38,29 @@ info:
 
 additionalProperties: false
 
-required:
-  # One of "networkURL" and "networkName" must be specified.
-  - region
-  - peerAddress
-  - sharedSecret
-  # asn and routerName are required when using dynamic routing
-  # Do not specify "router" when using static routing.
+allOf:
+  - required:
+    - region
+    - peerAddress
+    - sharedSecret
+  - oneOf:
+    - required:
+      - networkURL
+    - required:
+      - network
+  - oneOf:
+    # Use dynamic routing.
+    - required:
+      - asn
+      - router
+    # Use static routing.
+    - allOf:
+      - not:
+          required:
+          - router
+      - required:
+        - localTrafficSelector
+        - remoteTrafficSelector
 
 properties:
   name:
@@ -60,7 +76,7 @@ properties:
   routerURL:
     type: string
     description: URL (or URI) of the Router resource. Used by vpnTunnels.
-  routerName:
+  router:
     type: string
     description: |
       Name of the Router resource.
@@ -68,7 +84,7 @@ properties:
     type: string
     description: |
       The URL (or URI) of the network to which the VPN belongs.
-  networkName:
+  network:
     type: string
     description: |
       The name of the network to which the VPN belongs. Only use "networkName"

--- a/dm/templates/vpn/vpn.py.schema
+++ b/dm/templates/vpn/vpn.py.schema
@@ -112,6 +112,7 @@ properties:
     description: |
       Used when establishing the VPN tunnel with the peer VPN gateway.
     default: ["0.0.0.0/0"]
+    uniqItems: true
     items:
       type: string
       description: "CIDR formatted string, for example: 192.168.0.0/16."
@@ -120,6 +121,7 @@ properties:
     description: |
       Used when establishing the VPN tunnel with the peer VPN gateway.
     default: ["0.0.0.0/0"]
+    uniqItems: true
     items:
       type: string
       description: "CIDR formatted string, for example: 192.168.0.0/16."

--- a/dm/templates/vpn/vpn.py.schema
+++ b/dm/templates/vpn/vpn.py.schema
@@ -148,7 +148,10 @@ outputs:
         description: The name of the ForwardingRule resource for the UDP 500 traffic.
     - vpnTunnel:
         type: string
-        description: The mame of the VPN tunnel resource.
+        description: The name of the VPN tunnel resource.
+    - vpnTunnelUri:
+        type: string
+        description: The URI of the VPN tunnel resource.
 
 documentation:
   - templates/vpn/README.md


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/226
In this PR, we add static routing to VPN template
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/233
We also add routeURL and netURL to the schema so that users can specify the references of other resources in the config file.
