### PR TITLE
Enable cloud_router DM template to support networkURL.

### DIFF
--- a/dm/templates/cloud_router/cloud_router.py
+++ b/dm/templates/cloud_router/cloud_router.py
@@ -47,7 +47,7 @@ def generate_config(context):
                 'network':
                     properties.get('networkURL', generate_network_uri(
                         project_id,
-                        properties.get('networkName', ''))),
+                        properties.get('network', ''))),
             }
     }
 

--- a/dm/templates/cloud_router/cloud_router.py
+++ b/dm/templates/cloud_router/cloud_router.py
@@ -45,10 +45,9 @@ def generate_config(context):
                     properties['region'],
                 'bgp': bgp,
                 'network':
-                    generate_network_url(
+                    properties.get('networkURL', generate_network_uri(
                         project_id,
-                        properties['network']
-                    ),
+                        properties.get('networkName', ''))),
             }
     }
 
@@ -84,8 +83,8 @@ def generate_config(context):
     }
 
 
-def generate_network_url(project_id, network):
-    """Format the resource name as a resource URI."""
+def generate_network_uri(project_id, network):
+    """Format the network name as a network URI."""
 
     return 'projects/{}/global/networks/{}'.format(
         project_id,

--- a/dm/templates/cloud_router/cloud_router.py.schema
+++ b/dm/templates/cloud_router/cloud_router.py.schema
@@ -32,7 +32,7 @@ imports:
 additionalProperties: false
 
 required:
-  - network
+  # one of networkURL or networkName is required.
   - region
 
 oneOf:
@@ -62,7 +62,10 @@ properties:
   region:
     type: string
     description: The URI of the region where the Cloud Router resides.
-  network:
+  networkURL:
+    type: string
+    description: The URL (or URI) of the network to which the Cloud Router belongs.
+  networkName:
     type: string
     description: The name of the network to which the Cloud Router belongs (without project prefix).
   bgp:

--- a/dm/templates/cloud_router/cloud_router.py.schema
+++ b/dm/templates/cloud_router/cloud_router.py.schema
@@ -15,7 +15,7 @@
 info:
   title: Cloud Router
   author: Sourced Group Inc.
-  version: 1.0.0
+  version: 1.0.1
   description: |
     Deploys a Cloud Router.
 

--- a/dm/templates/cloud_router/cloud_router.py.schema
+++ b/dm/templates/cloud_router/cloud_router.py.schema
@@ -31,19 +31,18 @@ imports:
 
 additionalProperties: false
 
-required:
-  - region
-
-oneOf:
+allOf:
   - required:
+      - region
+  - oneOf:
+    - required:
       - networkURL
-  - required:
+    - required:
       - network
-
-oneOf:
-  - required:
+  - oneOf:
+    - required:
       - asn
-  - required:
+    - required:
       - bgp
 
 properties:

--- a/dm/templates/cloud_router/cloud_router.py.schema
+++ b/dm/templates/cloud_router/cloud_router.py.schema
@@ -38,7 +38,7 @@ oneOf:
   - required:
       - networkURL
   - required:
-      - networkName
+      - network
 
 oneOf:
   - required:
@@ -70,7 +70,7 @@ properties:
   networkURL:
     type: string
     description: The URL (or URI) of the network to which the Cloud Router belongs.
-  networkName:
+  network:
     type: string
     description: The name of the network to which the Cloud Router belongs (without project prefix).
   bgp:

--- a/dm/templates/cloud_router/cloud_router.py.schema
+++ b/dm/templates/cloud_router/cloud_router.py.schema
@@ -32,8 +32,13 @@ imports:
 additionalProperties: false
 
 required:
-  # one of networkURL or networkName is required.
   - region
+
+oneOf:
+  - required:
+      - networkURL
+  - required:
+      - networkName
 
 oneOf:
   - required:


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/233
Enable cloud_router to accept network URL.
- add a new tag "networkURL" that accepts the URL of a network.
