### PR TITLE
Add networkURL tag to firewall DM template.

### DIFF
--- a/dm/templates/firewall/firewall.py
+++ b/dm/templates/firewall/firewall.py
@@ -23,7 +23,7 @@ def generate_config(context):
     project_id = properties.get('project', context.env['project'])
     network = properties.get('network')
     if network:
-        if not '/' in network or '.' in network:
+        if not ('/' in network or '.' in network):
             network = 'global/networks/{}'.format(network)
     else:
         network = 'projects/{}/global/networks/{}'.format(

--- a/dm/templates/firewall/firewall.py.schema
+++ b/dm/templates/firewall/firewall.py.schema
@@ -67,7 +67,6 @@ properties:
     description: |
       URL of the network resource for this firewall rule. If not specified when creating a firewall rule,
       the default network is used.
-      This is deprecated and not compatible with setting "project", please use networkName
   networkName:
     type: string
     description: |


### PR DESCRIPTION
Remove the deprecated "network" tag.
Add a "networkURL" to enable users to specify network URL. See issue "https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/233"