### PR TITLE
Enable GKE DM template to support 'latest' initial cluster version.

### DIFF
--- a/dm/templates/gke/gke.py
+++ b/dm/templates/gke/gke.py
@@ -14,7 +14,6 @@
 """ This template creates a Google Kubernetes Engine cluster. """
 
 from packaging import version
-import re
 
 def generate_config(context):
     """ Entry point for the deployment resources. """
@@ -118,16 +117,19 @@ def generate_config(context):
     ]
 
     initial_cluster_version = propc.get('initialClusterVersion')
-    if initial_cluster_version.lower() != 'latest':
-        if (
-            # https://github.com/GoogleCloudPlatform/deploymentmanager-samples/issues/463
-            propc.get('enableDefaultAuthOutput', False) and (
-                version.parse(initial_cluster_version.split('-')[0]) < version.parse("1.12") or
-                propc.get('masterAuth', {}).get('clientCertificateConfig', False)
-            )
-        ):
-            output_props.append('clientCertificate')
-            output_props.append('clientKey')
+    less_than_112 = (
+        initial_cluster_version.lower() != 'latest' and 
+        version.parse(initial_cluster_version.split('-')[0]) < version.parse("1.12")
+    )
+
+    if (
+        # https://github.com/GoogleCloudPlatform/deploymentmanager-samples/issues/463
+        propc.get('enableDefaultAuthOutput', False) and (
+            less_than_112 or propc.get('masterAuth', {}).get('clientCertificateConfig', False)
+        )
+    ):
+        output_props.append('clientCertificate')
+        output_props.append('clientKey')
 
     for outprop in output_props:
         output_obj = {}

--- a/dm/templates/gke/gke.py
+++ b/dm/templates/gke/gke.py
@@ -14,6 +14,7 @@
 """ This template creates a Google Kubernetes Engine cluster. """
 
 from packaging import version
+import re
 
 def generate_config(context):
     """ Entry point for the deployment resources. """
@@ -116,15 +117,17 @@ def generate_config(context):
         'servicesIpv4Cidr'
     ]
 
-    if (
-        # https://github.com/GoogleCloudPlatform/deploymentmanager-samples/issues/463
-        propc.get('enableDefaultAuthOutput', False) and (
-            version.parse(propc.get('initialClusterVersion').split('-')[0]) < version.parse("1.12") or
-            propc.get('masterAuth', {}).get('clientCertificateConfig', False)
-        )
-    ):
-        output_props.append('clientCertificate')
-        output_props.append('clientKey')
+    initial_cluster_version = propc.get('initialClusterVersion')
+    if initial_cluster_version.lower() != 'latest':
+        if (
+            # https://github.com/GoogleCloudPlatform/deploymentmanager-samples/issues/463
+            propc.get('enableDefaultAuthOutput', False) and (
+                version.parse(initial_cluster_version.split('-')[0]) < version.parse("1.12") or
+                propc.get('masterAuth', {}).get('clientCertificateConfig', False)
+            )
+        ):
+            output_props.append('clientCertificate')
+            output_props.append('clientKey')
 
     for outprop in output_props:
         output_obj = {}


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/177
Do not get "clientCertificate" and "clientKey" when "latest" is used in the initialClusterVersion.