### PR TITLE
Linking to root directory instead of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Cloud Foundation toolkit (henceforth, CFT) includes the following parts:
 - A comprehensive set of production-ready resource templates that follow
   Google's best practices, which can be used with the CFT or the gcloud
   utility (part of the Google Cloud SDK) - see
-  [the template directory](dm/templates/README.md)
+  [the template directory](dm/templates/)
 - A command-line interface (henceforth, CLI) that deploys resources defined in
   single or multiple CFT-compliant config files - see:
   - The CFT source Python files (the `src/` directory)


### PR DESCRIPTION
So that users can see the contents of the directory without having to navigate one step up.