### PR TITLE
Bumped docker images for module terraform-google-container-vm

### DIFF
--- a/infra/concourse/pipelines/terraform-google-container-vm.yml
+++ b/infra/concourse/pipelines/terraform-google-container-vm.yml
@@ -17,7 +17,7 @@ resources:
   type: docker-image
   source:
     repository: gcr.io/cloud-foundation-cicd/cft/lint
-    tag: 2.2.0
+    tag: 2.4.0
     username: _json_key
     password: ((sa.google))
 
@@ -25,7 +25,7 @@ resources:
   type: docker-image
   source:
     repository: gcr.io/cloud-foundation-cicd/cft/kitchen-terraform
-    tag: 2.0.0
+    tag: 2.3.0
     username: _json_key
     password: ((sa.google))
 


### PR DESCRIPTION
This is related to the [linter issue in the module](https://github.com/terraform-google-modules/terraform-google-container-vm/pull/31#issuecomment-522716548), though might not fix it.