### PR TITLE
Helper function to facilitate switch to a 0.12 doc generator

### DIFF
--- a/infra/concourse/build/developer-tools/build/scripts/task_helper_functions.sh
+++ b/infra/concourse/build/developer-tools/build/scripts/task_helper_functions.sh
@@ -177,6 +177,48 @@ check_whitespace() {
   return $((rc+$?))
 }
 
+# Helper function to facilitate switch to a 0.12 compatible doc generator:
+#  - replaces `terraform_docs`s markers with `pre-commit-terraform`s
+#    markers for `terraform_docs.sh` - a wrapper around `terraform_docs`
+#  - removes `combine_docfiles.py` script
+#  - adds a copy of `terraform_docs.sh` script
+#  - adds `terraform_validate` script
+function replace_doc_generator {
+  local rval rc rmf old_script_path
+  rval=0
+  # Replace markers
+  for rmf in $(find_files . -name 'README.md'); do
+    if [ -f "${rmf}" ]; then
+      sed -i '/autogen_docs_start/,/autogen_docs_end/{//!d}' "${rmf}"
+      sed -i 's/\[\^]:\ (autogen_docs_start)/<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->/g' "${rmf}"
+      sed -i 's/\[\^]:\ (autogen_docs_end)/<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->/g' "${rmf}"
+    fi
+  done
+  # Replace script
+  old_script_path=$(find . -name 'combine_docfiles.py')
+  if [ -n "${old_script_path}" ]; then
+    rm -rf "${old_script_path}"
+    cd "$(dirname "${old_script_path}")"
+    wget https://raw.githubusercontent.com/terraform-google-modules/terraform-google-project-factory/master/helpers/terraform_{docs,validate} &>/dev/null
+    rc=$?
+    if [ $rc -ne 0 ]; then
+      echo "Error: Doc Generator scripts have not been downloaded properly, please check/re-download them manually."
+      ((rval++))
+    else
+      chmod +x ./terraform_{docs,validate}
+    fi
+    cd - >/dev/null
+  fi
+  # Re-generate docs
+  generate_docs
+  rc=$?
+  if [ $rc -ne 0 ]; then
+    echo -e "Error: Doc Generator failed. please check/re-generate them manually."
+    ((rval++))
+  fi
+  return $((rval))
+}
+
 function generate_docs() {
   echo "Generating markdown docs with terraform-docs"
   local path


### PR DESCRIPTION
Fixes #277 

- Added `replace_doc_generator`

Helper function to facilitate switch to a 0.12 compatible doc generator:
  - replaces `terraform_docs`s markers with `pre-commit-terraform`s
    markers for `terraform_docs.sh` - a wrapper around `terraform_docs`
  - removes `combine_docfiles.py` script
  - adds a copy of `terraform_docs.sh` script
  - adds `terraform_validate` script