### PR TITLE
farisjarrah/cloud-sql-docs: Fixed a path error in an Cloud SQL exampl…

### DIFF
--- a/dm/templates/cloud_sql/README.md
+++ b/dm/templates/cloud_sql/README.md
@@ -43,7 +43,7 @@ See the `properties` section in the schema file(s):
    case, [examples/cloud\_sql.yaml](examples/cloud_sql.yaml):
 
     ```shell
-    cp templates/dns_managed_zone/examples/cloud_sql.yaml my_cloud_sql.yaml
+    cp templates/cloud_sql/examples/cloud_sql.yaml my_cloud_sql.yaml
     ```
 
 4. Change the values in the config file to match your specific GCP setup (for
@@ -61,10 +61,22 @@ See the `properties` section in the schema file(s):
         --config my_cloud_sql.yaml
     ```
 
+   To deploy with CFT:
+
+    ```shell
+    cft apply my_cloud_sql.yaml
+    ```
+
 6. In case you need to delete your deployment:
 
     ```shell
     gcloud deployment-manager deployments delete <YOUR_DEPLOYMENT_NAME>
+    ```
+
+   To delete deployment with CFT:
+
+    ```shell
+    cft delete my_cloud_sql.yaml
     ```
 
 `Notes:` After a Cloud SQL instance is deleted, its name cannot be reused for
@@ -72,5 +84,7 @@ up to 7 days.
 
 ## Examples
 
-- [Cloud SQL](examples/cloud_sql_.yaml)
+- [Cloud SQL](examples/cloud_sql.yaml)
 - [Cloud SQL with Read Replica](examples/cloud_sql_read_replica.yaml)
+- [Cloud SQL Postgres](examples/cloud_sql_postgres.yaml)
+- [Cloud SQL Private Networking](examples/cloud_sql_private_network.yaml)

--- a/dm/templates/cloud_sql/examples/cloud_sql_postgres.yaml
+++ b/dm/templates/cloud_sql/examples/cloud_sql_postgres.yaml
@@ -1,0 +1,30 @@
+# Example of the Cloud SQL template usage.
+# Note that Postgres instances use different instance types then MySQL instances
+
+imports:
+  - path: templates/cloud_sql/cloud_sql.py
+    name: cloud_sql.py
+
+resources:
+  - name: cloud-sql-postgres-instance
+    type: cloud_sql.py
+    properties:
+      region: us-central1
+      databaseVersion: POSTGRES_0_6
+      instanceType: CLOUD_SQL_INSTANCE
+      settings:
+        tier: db-f1-micro
+        backupConfiguration:
+          startTime: '02:00'
+          enabled: true
+          binaryLogEnabled: true
+        locationPreference:
+          zone: us-central1-c
+      users:
+        - name: user-1
+          host: 10.1.1.1
+        - name: user-2
+          host: 10.1.1.2
+      databases:
+        - name: db-1
+        - name: db-2

--- a/dm/templates/cloud_sql/examples/cloud_sql_postgres.yaml
+++ b/dm/templates/cloud_sql/examples/cloud_sql_postgres.yaml
@@ -10,14 +10,13 @@ resources:
     type: cloud_sql.py
     properties:
       region: us-central1
-      databaseVersion: POSTGRES_0_6
+      databaseVersion: POSTGRES_9_6
       instanceType: CLOUD_SQL_INSTANCE
       settings:
         tier: db-f1-micro
         backupConfiguration:
           startTime: '02:00'
           enabled: true
-          binaryLogEnabled: true
         locationPreference:
           zone: us-central1-c
       users:

--- a/dm/templates/cloud_sql/examples/cloud_sql_private_network.yaml
+++ b/dm/templates/cloud_sql/examples/cloud_sql_private_network.yaml
@@ -1,0 +1,33 @@
+# Example of the Cloud SQL template usage.
+# Replace 'your-vpc-network-name' with the name of the vpc
+# in which the Cloud SQL instance will be deployed.
+
+
+imports:
+  - path: templates/cloud_sql/cloud_sql.py
+    name: cloud_sql.py
+
+resources:
+  - name: cloud-sql-instance
+    type: cloud_sql.py
+    properties:
+      region: us-central1
+      settings:
+        tier: db-n1-standard-1
+        backupConfiguration:
+          startTime: '02:00'
+          enabled: true
+          binaryLogEnabled: true
+        locationPreference:
+          zone: us-central1-c
+        ipConfiguration:
+          ipv4Enabled: false
+          privateNetwork: 'your-vpc-network-name'
+      users:
+        - name: user-1
+          host: 10.1.1.1
+        - name: user-2
+          host: 10.1.1.2
+      databases:
+        - name: db-1
+        - name: db-2


### PR DESCRIPTION
…e and added CFT commands for deployment and deleting Cloud SQL instances. Added an example template for Postgres.

Greetings,

I have been working on a CFT Cloud SQL deployment and saw a few things that could possibly use some fixing, and also a potential quality of life improvement for your users.

 1. There was an error in the README.md that had an incorrect file path. Was: `dns_managed_zone`, Changed to: `cloud_sql`
2. Incorrect file path in the README with regards to linking to the `example/cloud_sql.yaml`
3. Quality of life improvement: Added CFT commands for the deployment and deleting of the Cloud SQL instances
4. Quality of life improvement: Added an example template for Postgres.

If there are any changes you would like to see or any other fixes, please don't hesitate to let me know and I will try my best to get them patched up.

Thanks!
Faris