### PR TITLE
Add ci folder for `folders` module

### DIFF
--- a/infra/terraform/test-org/org/folders.tf
+++ b/infra/terraform/test-org/org/folders.tf
@@ -37,7 +37,8 @@ module "folders-ci" {
 
   names = [
     "ci-kms",
-    "ci-network"
+    "ci-network",
+    "ci-folders"
   ]
 
   set_roles = false

--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -22,5 +22,6 @@ locals {
     ci_folders = {
         kms = module.folders-ci.names_and_ids["ci-kms"]
         ci-network = module.folders-ci.names_and_ids["ci-network"]
+        ci-folders = module.folders-ci.names_and_ids["ci-folders"]
     }
 }


### PR DESCRIPTION
Add `ci-folders` folder which is going to be a part of new testing approach with CloudBuild for [terraform-google-folders](https://github.com/terraform-google-modules/terraform-google-folders) module. 