### PR TITLE
DM/CLI Not fail on cross-deployment references to existing deployments

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 # need to change this to VERSION=`git describe --tags`
-VERSION=v0.2.0
+VERSION=v0.2.1
 BINARY=bin/cft
 GITHUB_REPO=github.com/GoogleCloudPlatform/cloud-foundation-toolkit
 PLATFORMS := linux windows darwin

--- a/cli/deployment/api_client.go
+++ b/cli/deployment/api_client.go
@@ -23,7 +23,7 @@ const (
 	// NotFound Status means Deployment is not exists in any state.
 	NotFound Status = 3
 	// Error Status means Deployment is failed or deployment describe operation itself completed with error.
-	Error Status = -1
+	Error Status = 4
 )
 
 const (
@@ -48,6 +48,11 @@ type Resources struct {
 }
 
 var actions = []string{ActionApply, ActionDelete, ActionCreate, ActionUpdate}
+
+// String returns human readable string representation of Deployment Status.
+func (s Status) String() string {
+	return [...]string{"DONE", "PENDING", "RUNNING", "NOT_FOUND", "ERROR"}[s]
+}
 
 // The runGCloud function runs the gcloud tool with the specified arguments. It is implemented
 // as a variable so that it can be mocked in tests of its exported consumers.

--- a/cli/deployment/api_client_test.go
+++ b/cli/deployment/api_client_test.go
@@ -1,6 +1,7 @@
 package deployment
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -22,5 +23,27 @@ func TestGetOutputs(t *testing.T) {
 	expected := "my-network-prod"
 	if expected != outputs["my-network-prod.name"] {
 		t.Errorf("expected: %s, got: %s", expected, outputs["my-network-prod.name"])
+	}
+}
+
+func TestStatus_String(t *testing.T) {
+	var inputTests = []struct {
+		status   Status
+		expected string
+	}{
+		{Done, "DONE"},
+		{Pending, "PENDING"},
+		{Running, "RUNNING"},
+		{NotFound, "NOT_FOUND"},
+		{Error, "ERROR"},
+	}
+
+	for _, tt := range inputTests {
+		t.Run(tt.expected, func(t *testing.T) {
+			var actual string = fmt.Sprintf("%v", tt.status)
+			if actual != tt.expected {
+				t.Errorf("got: %s, want: %s", actual, tt.expected)
+			}
+		})
 	}
 }

--- a/cli/deployment/config.go
+++ b/cli/deployment/config.go
@@ -165,7 +165,7 @@ func (c Config) findAllDependencies(configs map[string]Config) ([]Config, error)
 				log.Print(message)
 				return nil, errors.New(message)
 			case Pending, Error, Running:
-				message := fmt.Sprintf("Dependency deployment = %s is in PENDING, RUNNING or ERROR state", fullName)
+				message := fmt.Sprintf("Dependency deployment = %sis in %v state", fullName, status)
 				log.Print(message)
 				return nil, errors.New(message)
 			}


### PR DESCRIPTION
DM/CLI Cross deployment reference was not even trying to look up the output of the other deployments.

Fixes #334