### PR TITLE
[DM local testing] Docker image and tutorial for local testing 

### DIFF
--- a/dm/CI/cft_base_container/Dockerfile
+++ b/dm/CI/cft_base_container/Dockerfile
@@ -1,7 +1,5 @@
 FROM gcr.io/cloud-builders/gcloud
 
-
-
 RUN set -ex && apt-get update && apt-get -y install make \
     && apt-get -y install gettext-base \
     && pip install --upgrade pip \
@@ -22,6 +20,5 @@ RUN set -ex && apt-get update && apt-get -y install make \
     && cft --version \
     && bats -v \
     && which bats
-
 
 WORKDIR /cloud-foundation-toolkit/dm

--- a/dm/CI/cft_base_container/cloudbuild.yaml
+++ b/dm/CI/cft_base_container/cloudbuild.yaml
@@ -1,0 +1,13 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/cft:${_CFT_VERSION}',
+        '-t', 'gcr.io/$PROJECT_ID/cft',
+        '--build-arg', 'CFT_VERSION=${_CFT_VERSION}',
+        '.']
+substitutions:
+  _CFT_VERSION: 0.0.4
+
+images:
+- 'gcr.io/$PROJECT_ID/cft:latest'
+- 'gcr.io/$PROJECT_ID/cft:$_CFT_VERSION'
+tags: ['cft-test-dm']

--- a/dm/CI/cft_base_contianer/cft_base_container
+++ b/dm/CI/cft_base_contianer/cft_base_container
@@ -1,0 +1,1 @@
+cft_base_container

--- a/dm/Makefile
+++ b/dm/Makefile
@@ -2,6 +2,10 @@ PYTHON  ?= python
 SHELL   := /bin/bash
 PACKAGE =  cloud_foundation_toolkit
 
+ifndef CLOUD_FOUNDATION_CONF
+override CLOUD_FOUNDATION_CONF = ~/.cloud-foundation-tests.conf
+endif
+
 help:
 	@echo "cft-prerequisites         Installs prerequisites for CFT python utility development"
 	@echo "cft-venv                  Creates the virtual environment called 'venv' for development"
@@ -16,7 +20,7 @@ help:
 
 
 .ONESHELL:
-.PHONY: cft-prerequisites cft-venv cft-clean-venv cft-test cft-test-venv template-prerequisites
+.PHONY: cft-prerequisites cft-venv cft-clean-venv cft-test cft-test-venv template-prerequisites cft-build-base-image
 
 cft-prerequisites:
 	${PYTHON} -m pip install -r requirements/prerequisites.txt
@@ -35,6 +39,18 @@ cft-test-templates:
 
 cft-test-venv:
 	${PYTHON} -m pytest -v
+
+cft-build-base-image:
+	docker build -f CI/cft_base_container/Dockerfile -t cft_base_image CI/cft_base_container/
+
+cft-test-bats:
+	docker run  -it --rm \
+	 -v `pwd`:/workspace \
+	 --entrypoint "/bin/bash" \
+	 -v ~/.config/:/root/.config \
+	 -v $(CLOUD_FOUNDATION_CONF):/root/.cloud-foundation-tests.conf \
+	 cft_base_image \
+	 -c "cd /workspace && /cloud-foundation-toolkit/dm/venv/bin/bats /workspace/$(TEST)"
 
 template-prerequisites:
 	rm -rf bats && git clone https://github.com/sstephenson/bats.git && ./bats/install.sh venv && rm -rf bats

--- a/dm/docs/template_dev_guide.md
+++ b/dm/docs/template_dev_guide.md
@@ -105,38 +105,28 @@ to the *example configs* available in each template's `examples/` directory.
 
 ### Running Bats tests with docker image
 
-You can use Developer Tools docker image with Bats and other needed tools installed. 
-Check cloud-foundation-toolkit/infra/concourse/build/developer-tools/Makefile for DOCKER_TAG_VERSION_DEVELOPER_TOOLS version.
+#### Prepare environment
 
-    export DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.2.0
- 
-Create GCloud project and Service Account with permissions needed to run tests (they listed in README.md)
-Export Service Account as json file and export corresponding ENV variable, for example:
+Authenticate your local gcloud tool with your personal user account https://cloud.google.com/sdk/gcloud/reference/auth/login or
+using service account json https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account
 
-    export SERVICE_ACCOUNT_JSON=$(< my-service-account.json)
+Create test config file by following [Using the Cloud Foundation Config File](#using-the-cloud-foundation-config-file)
 
-Go to cloud-foundation-toolkit/md folder
+Build test dcocker image:
+
+    cd cloud-foundation-toolkit/dm
+    make cft-build-base-image
+
+#### Run test
+
+To run templates/instance/tests/integration/instance.bats file, run:
+
+    make cft-test-bats TEST=templates/instance/tests/integration/instance.bats
     
-    cd cloud-foundation-toolkit/md
+Or, if you have config file not in ~/.cloud-foundation-tests.conf:
 
-#### Run Docker container
+    make cft-test-bats TEST=templates/instance/tests/integration/instance.bats  CLOUD_FOUNDATION_CONF=/conf/file/location.json
 
-If you followed [Using the Cloud Foundation Config File](#using-the-cloud-foundation-config-file), you can mount config file on docker run:
-
-    docker run -it -e SERVICE_ACCOUNT_JSON=${SERVICE_ACCOUNT_JSON} -v `pwd`:/workspace -v ~/.cloud-foundation-tests.conf:/root/.cloud-foundation-tests.conf cft/developer-tools:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} bash
-    
-Alternatively if you can set config variables following way (assuming you did export all needed variables before running command):
-
-    docker run -it -e SERVICE_ACCOUNT_JSON \
-                   -e CLOUD_FOUNDATION_ORGANIZATION_ID \
-                   -e CLOUD_FOUNDATION_PROJECT_ID \
-                   -e CLOUD_FOUNDATION_BILLING_ACCOUNT_ID \
-                   -e CLOUD_FOUNDATION_USER_ACCOUNT="andriy.kopachevskyy@dev.infra.cft.tips"  -v `pwd`:/workspace cft/developer-tools:0.1.0 bash
-
-Run tests:
-    
-     bats ./templates/network/tests/integration/network.bats
-      
 
 #### Unit Tests
 


### PR DESCRIPTION
Additional scope implemented.

Fixed dm/CI/cft_base_container - wasn't able to build it initially.
Added make command to build cft-base-image to build it.
Added cft-test-bats command to run test locally, example command:
   cd ./dm
   make cft-test-bats TEST=templates/instance/tests/integration/instance.bats

Fixes #291