### PR TITLE
Exclude *.svg files from lint checks

### DIFF
--- a/infra/concourse/build/developer-tools/build/scripts/task_helper_functions.sh
+++ b/infra/concourse/build/developer-tools/build/scripts/task_helper_functions.sh
@@ -68,6 +68,7 @@ find_files() {
     -path '*/*.png' -o \
     -path '*/*.jpg' -o \
     -path '*/*.jpeg' -o \
+    -path '*/*.svg' -o \
     -path './autogen' -o \
     -path './test/fixtures/all_examples' -o \
     -path './test/fixtures/shared' ')' \


### PR DESCRIPTION
 * Fix #387