### PR TITLE
added the dependsOn to the example

### DIFF
--- a/dm/templates/bigquery/examples/bigquery.yaml
+++ b/dm/templates/bigquery/examples/bigquery.yaml
@@ -22,6 +22,8 @@ resources:
     type: bigquery_table.py
     properties:
       name: test_bq_table
+      dependsOn:
+        - test-bq-dataset
       datasetId: $(ref.test-bq-dataset.datasetId)
       schema:
         - name: firstname


### PR DESCRIPTION
The dependsOn property prevents the case that the table is created before the dataset exists.