### PR TITLE
Set cleanup timeout to maximum 540 seconds

### DIFF
--- a/infra/terraform/test-org/test-cleanup/cleanup.tf
+++ b/infra/terraform/test-org/test-cleanup/cleanup.tf
@@ -23,8 +23,9 @@ module "app-engine" {
 
 module "projects_cleanup" {
   source  = "terraform-google-modules/scheduled-function/google//modules/project_cleanup"
-  version = "~> 1.1"
+  version = "~> 1.2"
 
+  function_timeout_s       = 540
   job_schedule             = "17 * * * *"
   max_project_age_in_hours = "6"
   organization_id          = local.org_id


### PR DESCRIPTION
This depends on https://github.com/terraform-google-modules/terraform-google-scheduled-function/pull/23.