### PR TITLE
Ignore the cache directory when finding files for syntax checking

### DIFF
--- a/infra/build/developer-tools/build/scripts/task_helper_functions.sh
+++ b/infra/build/developer-tools/build/scripts/task_helper_functions.sh
@@ -72,6 +72,7 @@ find_files() {
     -path './autogen' -o \
     -path './test/fixtures/all_examples' -o \
     -path './test/fixtures/shared' -o \
+    -path './cache' -o \
     -path './test/source.sh' ')' \
     -prune -o -type f "$@"
 }


### PR DESCRIPTION
See https://github.com/terraform-google-modules/terraform-google-gcloud/pull/5