### PR TITLE
[test-org] Create long-living SA which has G-Suite access.

### DIFF
--- a/infra/terraform/test-org/org/gsuite.tf
+++ b/infra/terraform/test-org/org/gsuite.tf
@@ -73,18 +73,18 @@ resource "google_service_account" "ci_gsuite_sa" {
 }
 
 resource "google_project_iam_member" "ci_gsuite_sa_project" {
-  count = length(local.ci_gsuite_sa_project_roles)
+  for_each = toset(local.ci_gsuite_sa_project_roles)
 
   project = module.ci_gsuite_sa_project.project_id
-  role    = local.ci_gsuite_sa_project_roles[count.index]
+  role    = each.value
   member  = "serviceAccount:${google_service_account.ci_gsuite_sa.email}"
 }
 
 resource "google_folder_iam_member" "ci_gsuite_sa_folder" {
-  count = length(local.ci_gsuite_sa_folder_roles)
+  for_each = toset(local.ci_gsuite_sa_folder_roles)
 
   folder = google_folder.ci_gsuite_sa_folder.name
-  role   = local.ci_gsuite_sa_folder_roles[count.index]
+  role   = each.value
   member = "serviceAccount:${google_service_account.ci_gsuite_sa.email}"
 }
 

--- a/infra/terraform/test-org/org/gsuite.tf
+++ b/infra/terraform/test-org/org/gsuite.tf
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  ci_gsuite_sa_project_roles = [
+    "roles/owner",
+    "roles/compute.admin",
+    "roles/iam.serviceAccountAdmin",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/storage.admin",
+    "roles/iam.serviceAccountUser",
+    "roles/billing.projectManager",
+  ]
+
+  ci_gsuite_sa_folder_roles = [
+    "roles/owner",
+    "roles/resourcemanager.projectCreator",
+    "roles/resourcemanager.folderAdmin",
+    "roles/resourcemanager.folderIamAdmin",
+    "roles/billing.projectManager",
+  ]
+}
+
+resource "google_folder" "ci_gsuite_sa_folder" {
+  display_name = "ci-gsuite-sa-folder"
+  parent      = "folders/${replace(local.folders["ci-projects"], "folders/", "")}"
+}
+
+module "ci_gsuite_sa_project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 4.0"
+
+  name              = "ci-gsuite-sa-project"
+  random_project_id = true
+  org_id            = local.org_id
+  folder_id         = google_folder.ci_gsuite_sa_folder.id
+  billing_account   = local.billing_account
+
+  labels = {
+    cft-ci = "permanent"
+  }
+
+  activate_apis = [
+    "admin.googleapis.com",
+    "appengine.googleapis.com",
+    "cloudbilling.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "compute.googleapis.com",
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "oslogin.googleapis.com",
+    "serviceusage.googleapis.com",
+  ]
+}
+
+resource "google_service_account" "ci_gsuite_sa" {
+  project      = module.ci_gsuite_sa_project.project_id
+  account_id   = "ci-gsuite-sa"
+  display_name = "ci-gsuite-sa"
+}
+
+resource "google_project_iam_member" "ci_gsuite_sa_project" {
+  count = length(local.ci_gsuite_sa_project_roles)
+
+  project = module.ci_gsuite_sa_project.project_id
+  role    = local.ci_gsuite_sa_project_roles[count.index]
+  member  = "serviceAccount:${google_service_account.ci_gsuite_sa.email}"
+}
+
+resource "google_folder_iam_member" "ci_gsuite_sa_folder" {
+  count = length(local.ci_gsuite_sa_folder_roles)
+
+  folder = google_folder.ci_gsuite_sa_folder.name
+  role   = local.ci_gsuite_sa_folder_roles[count.index]
+  member = "serviceAccount:${google_service_account.ci_gsuite_sa.email}"
+}
+
+resource "google_billing_account_iam_member" "ci_gsuite_sa_billing" {
+  billing_account_id = local.billing_account
+  role               = "roles/billing.user"
+  member             = "serviceAccount:${google_service_account.ci_gsuite_sa.email}"
+}
+
+resource "google_service_account_key" "ci_gsuite_sa" {
+  service_account_id = google_service_account.ci_gsuite_sa.id
+}

--- a/infra/terraform/test-org/org/gsuite.tf
+++ b/infra/terraform/test-org/org/gsuite.tf
@@ -44,7 +44,7 @@ module "ci_gsuite_sa_project" {
   version = "~> 4.0"
 
   name              = "ci-gsuite-sa-project"
-  random_project_id = true
+  project_id        = "ci-gsuite-sa-project"
   org_id            = local.org_id
   folder_id         = google_folder.ci_gsuite_sa_folder.id
   billing_account   = local.billing_account
@@ -92,8 +92,4 @@ resource "google_billing_account_iam_member" "ci_gsuite_sa_billing" {
   billing_account_id = local.billing_account
   role               = "roles/billing.user"
   member             = "serviceAccount:${google_service_account.ci_gsuite_sa.email}"
-}
-
-resource "google_service_account_key" "ci_gsuite_sa" {
-  service_account_id = google_service_account.ci_gsuite_sa.id
 }

--- a/infra/terraform/test-org/org/outputs.tf
+++ b/infra/terraform/test-org/org/outputs.tf
@@ -29,3 +29,19 @@ output "billing_account" {
 output "cft_ci_group" {
   value = local.cft_ci_group
 }
+
+output "ci_gsuite_sa_id" {
+  value = google_service_account.ci_gsuite_sa.id
+}
+
+output "ci_gsuite_sa_email" {
+  value = google_service_account.ci_gsuite_sa.email
+}
+
+output "ci_gsuite_sa_folder_id" {
+  value = google_folder.ci_gsuite_sa_folder.id
+}
+
+output "ci_gsuite_sa_project_id" {
+  value = module.ci_gsuite_sa_project.project_id
+}

--- a/infra/terraform/test-org/org/outputs.tf
+++ b/infra/terraform/test-org/org/outputs.tf
@@ -45,8 +45,3 @@ output "ci_gsuite_sa_folder_id" {
 output "ci_gsuite_sa_project_id" {
   value = module.ci_gsuite_sa_project.project_id
 }
-
-output "ci_gsuite_sa_key" {
-  value     = google_service_account_key.ci_gsuite_sa.private_key
-  sensitive = true
-}

--- a/infra/terraform/test-org/org/outputs.tf
+++ b/infra/terraform/test-org/org/outputs.tf
@@ -45,3 +45,8 @@ output "ci_gsuite_sa_folder_id" {
 output "ci_gsuite_sa_project_id" {
   value = module.ci_gsuite_sa_project.project_id
 }
+
+output "ci_gsuite_sa_key" {
+  value     = google_service_account_key.ci_gsuite_sa.private_key
+  sensitive = true
+}


### PR DESCRIPTION
Used for project-factory tests of gsuite functionality.
Can later be used in other gsuite-related tests in other modules.

Note for @aaron-lane:

Added an output `ci_gsuite_sa_email` with the SA email which will need to be used when going through the delegation guide here:
https://developers.google.com/admin-sdk/directory/v1/guides/delegation

The guide has to be followed all the way up to granting SA the domain-wide access to Admin SDK Directory API.

Also we'll use the `project-factory-test-admin@test.infra.cft.tips` user account to impersonate this newly created SA account (https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/build/int.cloudbuild.yaml#L24).

Don't really know if any additional linkage has to be setup between `project-factory-test-admin@test.infra.cft.tips` and the created SA, but the guide says nothing about it, so probably any real user account can be impersonated by the SA.

Related to https://github.com/terraform-google-modules/terraform-google-project-factory/issues/111.