### PR TITLE
Fixes #506: Network template incorrectly handles empty networks

### DIFF
--- a/dm/templates/network/network.py.schema
+++ b/dm/templates/network/network.py.schema
@@ -41,6 +41,15 @@ oneOf:
         type: array
         default: []
         minItems: 1
+  - properties:
+      autoCreateSubnetworks:
+        enum:
+          - false
+      subnetworks:
+        type: array
+        default: []
+        minItems: 0
+        maxItems: 0
 
 properties:
   name:

--- a/dm/templates/network/network.py.schema
+++ b/dm/templates/network/network.py.schema
@@ -15,7 +15,7 @@
 info:
   title: Network
   author: Sourced Group Inc.
-  version: 1.0.0
+  version: 1.0.1
   description: |
     Creates a network.
 


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/506

Removed oneOf from network.py.schema.