### PR TITLE
[test-org] Create a secrets bucket to store gsuite sa key in.

### DIFF
--- a/infra/terraform/test-org/org/gsuite.tf
+++ b/infra/terraform/test-org/org/gsuite.tf
@@ -109,14 +109,7 @@ resource "google_service_account_key" "ci_gsuite_sa" {
   service_account_id = google_service_account.ci_gsuite_sa.id
 }
 
-provider "google" {
-  alias       = "sa"
-  credentials = base64decode(google_service_account_key.ci_gsuite_sa.private_key)
-}
-
 resource "google_storage_bucket" "ci_gsuite_sa" {
-  provider = google.sa
-
   name          = local.ci_gsuite_sa_bucket
   storage_class = "MULTI_REGIONAL"
   project       = module.ci_gsuite_sa_project.project_id
@@ -129,31 +122,10 @@ resource "google_storage_bucket" "ci_gsuite_sa" {
 }
 
 resource "google_storage_bucket_object" "ci_gsuite_sa_json" {
-  provider = google.sa
-
   name    = local.ci_gsuite_sa_bucket_path
   content = base64decode(google_service_account_key.ci_gsuite_sa.private_key)
   bucket  = google_storage_bucket.ci_gsuite_sa.name
 }
-
-/* EXAMPLE: Retrieve json key in CI in the end-user's module
-
-data "google_storage_object_signed_url" "ci_gsuite_sa_json" {
-  bucket   = "ci-gsuite-sa-secrets"
-  path     = "gsuite-sa.json"
-  duration = "1m"
-}
-
-data "http" "ci_gsuite_sa_json" {
-  url = data.google_storage_object_signed_url.ci_gsuite_sa_json.signed_url
-}
-
-output "gsuite_sa_json" {
-  value     = data.http.ci_gsuite_sa_json.body
-  sensitive = true
-}
-
-*/
 
 # Grant G-Suite project rights to cft_ci_group.
 # Required to be able to create new gsuite sa keys and to fetch

--- a/infra/terraform/test-org/org/gsuite.tf
+++ b/infra/terraform/test-org/org/gsuite.tf
@@ -36,7 +36,11 @@ locals {
   ci_group_gsuite_sa_project_roles = [
     "roles/owner",
     "roles/iam.serviceAccountAdmin",
+    "roles/storage.admin",
   ]
+
+  ci_gsuite_sa_bucket      = "ci-gsuite-sa-secrets"
+  ci_gsuite_sa_bucket_path = "gsuite-sa.json"
 }
 
 resource "google_folder" "ci_gsuite_sa_folder" {
@@ -99,8 +103,61 @@ resource "google_billing_account_iam_member" "ci_gsuite_sa_billing" {
   member             = "serviceAccount:${google_service_account.ci_gsuite_sa.email}"
 }
 
-# Grant G-Suite project rights to cft_ci_group
-# Required to be able to create keys for the gsuite sa.
+// Generate a json key and put it into the secrets bucket.
+
+resource "google_service_account_key" "ci_gsuite_sa" {
+  service_account_id = google_service_account.ci_gsuite_sa.id
+}
+
+provider "google" {
+  alias       = "sa"
+  credentials = base64decode(google_service_account_key.ci_gsuite_sa.private_key)
+}
+
+resource "google_storage_bucket" "ci_gsuite_sa" {
+  provider = google.sa
+
+  name          = local.ci_gsuite_sa_bucket
+  storage_class = "MULTI_REGIONAL"
+  project       = module.ci_gsuite_sa_project.project_id
+
+  versioning {
+    enabled = true
+  }
+
+  force_destroy = true
+}
+
+resource "google_storage_bucket_object" "ci_gsuite_sa_json" {
+  provider = google.sa
+
+  name    = local.ci_gsuite_sa_bucket_path
+  content = base64decode(google_service_account_key.ci_gsuite_sa.private_key)
+  bucket  = google_storage_bucket.ci_gsuite_sa.name
+}
+
+/* EXAMPLE: Retrieve json key in CI in the end-user's module
+
+data "google_storage_object_signed_url" "ci_gsuite_sa_json" {
+  bucket   = "ci-gsuite-sa-secrets"
+  path     = "gsuite-sa.json"
+  duration = "1m"
+}
+
+data "http" "ci_gsuite_sa_json" {
+  url = data.google_storage_object_signed_url.ci_gsuite_sa_json.signed_url
+}
+
+output "gsuite_sa_json" {
+  value     = data.http.ci_gsuite_sa_json.body
+  sensitive = true
+}
+
+*/
+
+# Grant G-Suite project rights to cft_ci_group.
+# Required to be able to create new gsuite sa keys and to fetch
+# the precreated one from the secrets bucket.
 
 resource "google_project_iam_member" "ci_group_gsuite_sa_project" {
   for_each = toset(local.ci_group_gsuite_sa_project_roles)

--- a/infra/terraform/test-org/org/outputs.tf
+++ b/infra/terraform/test-org/org/outputs.tf
@@ -45,3 +45,16 @@ output "ci_gsuite_sa_folder_id" {
 output "ci_gsuite_sa_project_id" {
   value = module.ci_gsuite_sa_project.project_id
 }
+
+output "ci_gsuite_sa_key" {
+  value     = google_service_account_key.ci_gsuite_sa.private_key
+  sensitive = true
+}
+
+output "ci_gsuite_sa_bucket" {
+  value = google_storage_bucket.ci_gsuite_sa.name
+}
+
+output "ci_gsuite_sa_bucket_path" {
+  value = google_storage_bucket_object.ci_gsuite_sa_json.name
+}


### PR DESCRIPTION
Create a new bucket to store and later retrieve the gsuite key.

Also has an example on how to retrieve the key as the comment.

```hcl
data "google_storage_object_signed_url" "ci_gsuite_sa_json" {
  bucket   = "ci-gsuite-sa-secrets"
  path     = "gsuite-sa.json"
  duration = "1m"
}
data "http" "ci_gsuite_sa_json" {
  url = data.google_storage_object_signed_url.ci_gsuite_sa_json.signed_url
}
output "gsuite_sa_json" {
  value     = data.http.ci_gsuite_sa_json.body
  sensitive = true
}
```
