### PR TITLE
Allow CFT Scorecard to read JSON metadata from Stdin

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/golang/protobuf v1.3.1
 	github.com/hashicorp/terraform v0.12.2 // indirect
 	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec
-	github.com/kr/pty v1.1.3 // indirect
 	github.com/open-policy-agent/opa v0.11.0
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.5

--- a/cli/scorecard/cmd.go
+++ b/cli/scorecard/cmd.go
@@ -13,6 +13,7 @@ var flags struct {
 	targetProjectID  string
 	controlProjectID string
 	bucketName       string
+	stdin            bool
 	dirPath          string
 	outputPath       string
 	outputFormat     string
@@ -31,8 +32,9 @@ func init() {
 	viper.BindPFlag("output-format", Cmd.Flags().Lookup("output-format"))
 
 	//Cmd.Flags().StringVar(&flags.targetProjectID, "project", "", "Project to analyze (conflicts with --organization)")
-	Cmd.Flags().StringVar(&flags.bucketName, "bucket", "", "GCS bucket name for storing inventory (conflicts with --dir-path)")
-	Cmd.Flags().StringVar(&flags.dirPath, "dir-path", "", "Local directory path for storing inventory (conflicts with --bucket)")
+	Cmd.Flags().StringVar(&flags.bucketName, "bucket", "", "GCS bucket name for storing inventory (conflicts with --dir-path and --stdin)")
+	Cmd.Flags().StringVar(&flags.dirPath, "dir-path", "", "Local directory path for storing inventory (conflicts with --bucket and --stdin)")
+	Cmd.Flags().BoolVar(&flags.stdin, "stdin", false, "Whether inventory will be passed as stdin or not (conflicts with --dir-path and --bucket)")
 	Cmd.Flags().StringVar(&flags.controlProjectID, "control-project", "", "Control project to use for API calls")
 	viper.BindPFlag("google_project", Cmd.Flags().Lookup("control-project"))
 
@@ -52,14 +54,20 @@ var Cmd = &cobra.Command{
 		  cft scorecard --policy-path <path-to>/policy-library \
 			  --dir-path <path-to-directory-containing-cai-export>
 
+	Read from stdin:
+		  cft scorecard --policy-path <path-to>/policy-library \
+			  --stdin
+
 	As of now, CAI export file names need to be resource_inventory.json and/or iam_inventory.json
 
-	To read from stdin, do not set neither --bucket or --dir-path.
 	`,
 	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if flags.bucketName != "" && flags.dirPath != "" {
-			return fmt.Errorf("Only one of bucket and dir-path should be set")
+		if flags.bucketName != "" && flags.dirPath != "" && !flags.stdin ||
+			flags.bucketName != "" && flags.stdin ||
+			flags.bucketName != "" && flags.dirPath != "" ||
+			flags.dirPath != "" && flags.stdin {
+			return fmt.Errorf("One of bucket, dir-path, or stdin should be set")
 		}
 		return nil
 	},
@@ -75,7 +83,7 @@ var Cmd = &cobra.Command{
 		}
 
 		inventory, err := NewInventory(controlProjectID,
-			flags.bucketName, flags.dirPath,
+			flags.bucketName, flags.dirPath, flags.stdin,
 			TargetProject(flags.targetProjectID))
 		if err != nil {
 			return err

--- a/cli/scorecard/cmd.go
+++ b/cli/scorecard/cmd.go
@@ -13,8 +13,8 @@ var flags struct {
 	targetProjectID  string
 	controlProjectID string
 	bucketName       string
-	stdin            bool
 	dirPath          string
+	stdin            bool
 	outputPath       string
 	outputFormat     string
 }
@@ -34,7 +34,7 @@ func init() {
 	//Cmd.Flags().StringVar(&flags.targetProjectID, "project", "", "Project to analyze (conflicts with --organization)")
 	Cmd.Flags().StringVar(&flags.bucketName, "bucket", "", "GCS bucket name for storing inventory (conflicts with --dir-path and --stdin)")
 	Cmd.Flags().StringVar(&flags.dirPath, "dir-path", "", "Local directory path for storing inventory (conflicts with --bucket and --stdin)")
-	Cmd.Flags().BoolVar(&flags.stdin, "stdin", false, "Whether inventory will be passed as stdin or not (conflicts with --dir-path and --bucket)")
+	Cmd.Flags().BoolVar(&flags.stdin, "stdin", false, "Whether inventory will be passed as standard input or not (conflicts with --dir-path and --bucket)")
 	Cmd.Flags().StringVar(&flags.controlProjectID, "control-project", "", "Control project to use for API calls")
 	viper.BindPFlag("google_project", Cmd.Flags().Lookup("control-project"))
 
@@ -54,7 +54,7 @@ var Cmd = &cobra.Command{
 		  cft scorecard --policy-path <path-to>/policy-library \
 			  --dir-path <path-to-directory-containing-cai-export>
 
-	Read from stdin:
+	Read from standard input:
 		  cft scorecard --policy-path <path-to>/policy-library \
 			  --stdin
 

--- a/cli/scorecard/cmd.go
+++ b/cli/scorecard/cmd.go
@@ -56,9 +56,8 @@ var Cmd = &cobra.Command{
 	`,
 	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if (flags.bucketName == "" && flags.dirPath == "") ||
-			(flags.bucketName != "" && flags.dirPath != "") {
-			return fmt.Errorf("Either bucket or dir-path should be set")
+		if flags.bucketName != "" && flags.dirPath != "" {
+			return fmt.Errorf("Only one of bucket and dir-path should be set")
 		}
 		return nil
 	},

--- a/cli/scorecard/cmd.go
+++ b/cli/scorecard/cmd.go
@@ -44,15 +44,17 @@ var Cmd = &cobra.Command{
 	Short: "Print a scorecard of your GCP environment",
 	Long: `Print a scorecard of your GCP environment, for resources and IAM policies in Cloud Asset Inventory (CAI) exports, and constraints and constraint templates from Config Validator policy library.
 
-	Example:
+	Read from a bucket:
 		  cft scorecard --policy-path <path-to>/policy-library \
 			  --bucket <name-of-bucket-containing-cai-export>
-	Or:
+
+	Read from a local directory:
 		  cft scorecard --policy-path <path-to>/policy-library \
 			  --dir-path <path-to-directory-containing-cai-export>
 
 	As of now, CAI export file names need to be resource_inventory.json and/or iam_inventory.json
 
+	To read from stdin, do not set neither --bucket or --dir-path.
 	`,
 	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/scorecard/inventory.go
+++ b/cli/scorecard/inventory.go
@@ -33,6 +33,7 @@ type InventoryConfig struct {
 	organizationID   string
 	bucketName       string
 	dirPath          string
+	readFromStdin    bool
 }
 
 // Option for NewInventory
@@ -53,11 +54,12 @@ func TargetProject(projectID string) Option {
 }
 
 // NewInventory creates a new CAI inventory manager
-func NewInventory(projectID string, bucketName string, dirPath string, options ...Option) (*InventoryConfig, error) {
+func NewInventory(projectID, bucketName, dirPath string, readFromStdin bool, options ...Option) (*InventoryConfig, error) {
 	inventory := new(InventoryConfig)
 	inventory.controlProjectID = projectID
 	inventory.bucketName = bucketName
 	inventory.dirPath = dirPath
+	inventory.readFromStdin = readFromStdin
 
 	for _, option := range options {
 		option(inventory)

--- a/cli/scorecard/violations.go
+++ b/cli/scorecard/violations.go
@@ -118,7 +118,7 @@ func getViolations(inventory *InventoryConfig, config *ScoringConfig) (*validato
 		if err != nil {
 			return nil, errors.Wrap(err, "Fetching inventory from local directory")
 		}
-	} else {
+	} else if inventory.readFromStdin {
 		err := addDataFromStdin(config)
 		if err != nil {
 			return nil, errors.Wrap(err, "Reading from stdin")

--- a/cli/scorecard/violations.go
+++ b/cli/scorecard/violations.go
@@ -96,6 +96,14 @@ func addDataFromFile(config *ScoringConfig, caiDirName string) error {
 	return nil
 }
 
+func addDataFromStdin(config *ScoringConfig) error {
+	err := addDataFromReader(config, os.Stdin)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // getViolations finds all Config Validator violations for a given Inventory
 func getViolations(inventory *InventoryConfig, config *ScoringConfig) (*validator.AuditResponse, error) {
 	v := config.validator
@@ -105,10 +113,15 @@ func getViolations(inventory *InventoryConfig, config *ScoringConfig) (*validato
 		if err != nil {
 			return nil, errors.Wrap(err, "Fetching inventory from Bucket")
 		}
-	} else {
+	} else if inventory.dirPath != "" {
 		err := addDataFromFile(config, inventory.dirPath)
 		if err != nil {
 			return nil, errors.Wrap(err, "Fetching inventory from local directory")
+		}
+	} else {
+		err := addDataFromStdin(config)
+		if err != nil {
+			return nil, errors.Wrap(err, "Reading from stdin")
 		}
 	}
 	auditResponse, err := v.Audit(context.Background())


### PR DESCRIPTION
Update to allow CFT Scorecard to read IAM and Resources inventories from Stdin when bucket and dir-path where not passed.