### PR TITLE
Adding support for releaseChannel setting

### DIFF
--- a/dm/CHANGELOG.md
+++ b/dm/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## CFT Templates
 
+### 16.01.2020
+
+- Updated gke template to support setting for releaseChannel [#539](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/pull/539)
+
 ### 08.01.2020
 
 - Updated gke template to support Python 3 [#531](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/pull/531)

--- a/dm/templates/gke/gke.py
+++ b/dm/templates/gke/gke.py
@@ -83,7 +83,8 @@ def generate_config(context):
         'maintenancePolicy',
         'podSecurityPolicyConfig',
         'privateCluster',
-        'masterIpv4CidrBlock'
+        'masterIpv4CidrBlock',
+        'releaseChannel'
     ]
 
     cluster_props = gke_cluster['properties']['cluster']

--- a/dm/templates/gke/gke.py.schema
+++ b/dm/templates/gke/gke.py.schema
@@ -703,6 +703,21 @@ properties:
                 cidrBlock:
                   type: string
                   description: The cidrBlock in the CIDR notation.
+      releaseChannel:
+        type: object
+        additionalProperties: false
+        description: |
+          Instead of defining explicit version of Kubernetes, uses the new Release channel feature.
+        properties:
+          channel:
+            type: string
+            default: REGULAR
+            description: |
+              Use RAPID, REGULAR or STABLE. Defaults to REGULAR
+            enum:
+              - REGULAR
+              - RAPID
+              - STABLE
       addonsConfig:
         type: object
         additionalProperties: false

--- a/dm/templates/gke/gke.py.schema
+++ b/dm/templates/gke/gke.py.schema
@@ -15,7 +15,7 @@
 info:
   title: Google Kubernetes Engine (GKE)
   author: Sourced Group Inc.
-  version: 1.0.2
+  version: 1.0.3
   description: |
     Schema for deploying a GKE cluster.
 
@@ -707,7 +707,10 @@ properties:
         type: object
         additionalProperties: false
         description: |
-          Instead of defining explicit version of Kubernetes, uses the new Release channel feature.
+          ReleaseChannel indicates which release channel a cluster is subscribed to. Release channels are arranged in order of risk and frequency of updates.
+
+          When a cluster is subscribed to a release channel, Google maintains both the master version and the node version. 
+          Node auto-upgrade defaults to true and cannot be disabled. Updates to version related fields (e.g. currentMasterVersion) return an error.
         properties:
           channel:
             type: string


### PR DESCRIPTION
This PR adds support for the `releaseChannel` setting when creating a GKE cluster.

Documentation: https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.ReleaseChannel
