### PR TITLE
Varies scorecard bugfixes

### DIFF
--- a/cli/scorecard/cmd.go
+++ b/cli/scorecard/cmd.go
@@ -63,10 +63,10 @@ var Cmd = &cobra.Command{
 	`,
 	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if flags.bucketName != "" && flags.dirPath != "" && !flags.stdin ||
-			flags.bucketName != "" && flags.stdin ||
-			flags.bucketName != "" && flags.dirPath != "" ||
-			flags.dirPath != "" && flags.stdin {
+		if (flags.bucketName == "" && flags.dirPath == "" && !flags.stdin) ||
+			(flags.bucketName != "" && flags.stdin) ||
+			(flags.bucketName != "" && flags.dirPath != "") ||
+			(flags.dirPath != "" && flags.stdin) {
 			return fmt.Errorf("One of bucket, dir-path, or stdin should be set")
 		}
 		return nil

--- a/cli/scorecard/score.go
+++ b/cli/scorecard/score.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -45,6 +46,7 @@ func NewScoringConfigFromValidator(v *gcv.Validator) *ScoringConfig {
 
 // NewScoringConfig creates a scoring engine for the given policy library
 func NewScoringConfig(ctx context.Context, policyPath string) (*ScoringConfig, error) {
+	flag.Parse()
 	v, err := gcv.NewValidator(ctx.Done(),
 		[]string{filepath.Join(policyPath, "policies")},
 		filepath.Join(policyPath, "lib"),

--- a/cli/scorecard/violations.go
+++ b/cli/scorecard/violations.go
@@ -31,7 +31,10 @@ import (
 )
 
 func addDataFromReader(config *ScoringConfig, reader io.Reader) error {
+	const maxCapacity = 1024 * 1024
 	scanner := bufio.NewScanner(reader)
+	buf := make([]byte, maxCapacity)
+	scanner.Buffer(buf, maxCapacity)
 	for scanner.Scan() {
 		pbAsset, err := getAssetFromJSON(scanner.Bytes())
 		if err != nil {


### PR DESCRIPTION
- bugfix for input flag validation to check for either one of the 3 CAI input methods
- add flag.parse() to get rid of "ERROR: logging before flag.parse" output to stderr as result of new config-validator version introduced in recently updated go.mod
- increase NewScanner buffer size to handle lines in CAI export that is larger than 64k, usually from BigQuery Tables