### PR TITLE
scorecard - new feature to include additional metadata fields in output

### DIFF
--- a/cli/docs/scorecard.md
+++ b/cli/docs/scorecard.md
@@ -118,6 +118,7 @@ Flags:
       --dir-path string              Local directory path for storing inventory (conflicts with --bucket or --stdin)
   -h, --help                         help for scorecard
       --output-format string         Format of scorecard outputs, can be txt, json or csv, default is txt
+      --output-metadata strings      List of comma delimited violation metadata fields of string type to include in output. Works when --output-format is txt or csv. By default no metadata fields in output when --output-format is txt or csv. All metadata will be in output when output-format is json.
       --output-path string           Path to directory to contain scorecard outputs. Output to console if not specified
       --policy-path string           Path to directory containing validation policies
       --refresh                      Refresh Cloud Asset Inventory export files in GCS bucket. If set, Application Default Credentials must be a service account (Works with --bucket)

--- a/cli/docs/scorecard.md
+++ b/cli/docs/scorecard.md
@@ -118,7 +118,7 @@ Flags:
       --dir-path string              Local directory path for storing inventory (conflicts with --bucket or --stdin)
   -h, --help                         help for scorecard
       --output-format string         Format of scorecard outputs, can be txt, json or csv, default is txt
-      --output-metadata strings      List of comma delimited violation metadata fields of string type to include in output. Works when --output-format is txt or csv. By default no metadata fields in output when --output-format is txt or csv. All metadata will be in output when output-format is json.
+      --output-metadata-fields strings      List of comma delimited violation metadata fields of string type to include in output. Works when --output-format is txt or csv. By default no metadata fields in output when --output-format is txt or csv. All metadata will be in output when output-format is json.
       --output-path string           Path to directory to contain scorecard outputs. Output to console if not specified
       --policy-path string           Path to directory containing validation policies
       --refresh                      Refresh Cloud Asset Inventory export files in GCS bucket. If set, Application Default Credentials must be a service account (Works with --bucket)

--- a/cli/scorecard/cmd.go
+++ b/cli/scorecard/cmd.go
@@ -19,7 +19,7 @@ var flags struct {
 	refresh          bool
 	outputPath       string
 	outputFormat     string
-	metadata		 []string
+	metadataFields		 []string
 }
 
 func init() {
@@ -34,7 +34,7 @@ func init() {
 	viper.SetDefault("output-format", "txt")
 	viper.BindPFlag("output-format", Cmd.Flags().Lookup("output-format"))
 
-	Cmd.Flags().StringSliceVar(&flags.metadata, "output-metadata", []string{}, "List of comma delimited violation metadata fields of string type to include in output. Works when --output-format is txt or csv. By default no metadata fields in output when --output-format is txt or csv. All metadata will be in output when --output-format is json.")
+	Cmd.Flags().StringSliceVar(&flags.metadataFields, "output-metadata-fields", []string{}, "List of comma delimited violation metadata fields of string type to include in output. Works when --output-format is txt or csv. By default no metadata fields in output when --output-format is txt or csv. All metadata will be in output when --output-format is json.")
 
 	Cmd.Flags().StringVar(&flags.bucketName, "bucket", "", "GCS bucket name for storing inventory (conflicts with --dir-path or --stdin)")
 	Cmd.Flags().StringVar(&flags.dirPath, "dir-path", "", "Local directory path for storing inventory (conflicts with --bucket or --stdin)")
@@ -105,7 +105,7 @@ var Cmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = inventory.Score(config, flags.outputPath, viper.GetString("output-format"), flags.metadata)
+		err = inventory.Score(config, flags.outputPath, viper.GetString("output-format"), flags.metadataFields)
 		if err != nil {
 			return err
 		}

--- a/cli/scorecard/cmd.go
+++ b/cli/scorecard/cmd.go
@@ -34,7 +34,7 @@ func init() {
 	viper.SetDefault("output-format", "txt")
 	viper.BindPFlag("output-format", Cmd.Flags().Lookup("output-format"))
 
-	Cmd.Flags().StringSliceVar(&flags.metadataFields, "output-metadata-fields", []string{}, "List of comma delimited violation metadata fields of string type to include in output. Works when --output-format is txt or csv. By default no metadata fields in output when --output-format is txt or csv. All metadata will be in output when --output-format is json.")
+	Cmd.Flags().StringSliceVar(&flags.metadataFields, "output-metadata-fields", []string{}, "List of comma delimited violation metadata fields of string/bool/number types to include in output. By default no metadata fields in output when --output-format is txt or csv. All metadata will be in output when --output-format is json.")
 
 	Cmd.Flags().StringVar(&flags.bucketName, "bucket", "", "GCS bucket name for storing inventory (conflicts with --dir-path or --stdin)")
 	Cmd.Flags().StringVar(&flags.dirPath, "dir-path", "", "Local directory path for storing inventory (conflicts with --bucket or --stdin)")

--- a/cli/scorecard/cmd.go
+++ b/cli/scorecard/cmd.go
@@ -19,6 +19,7 @@ var flags struct {
 	refresh          bool
 	outputPath       string
 	outputFormat     string
+	metadata		 []string
 }
 
 func init() {
@@ -29,7 +30,7 @@ func init() {
 
 	Cmd.Flags().StringVar(&flags.outputPath, "output-path", "", "Path to directory to contain scorecard outputs. Output to console if not specified")
 
-	Cmd.Flags().StringVar(&flags.outputFormat, "output-format", "", "Format of scorecard outputs, can be txt, json or csv, default is txt")
+	Cmd.Flags().StringVar(&flags.outputFormat, "output-format", "txt", "Format of scorecard outputs, can be txt, json or csv")
 	viper.SetDefault("output-format", "txt")
 	viper.BindPFlag("output-format", Cmd.Flags().Lookup("output-format"))
 
@@ -40,6 +41,14 @@ func init() {
 	Cmd.Flags().StringVar(&flags.targetProjectID, "target-project", "", "Project ID to analyze (Works with --bucket and --refresh; conflicts with --target-folder or --target--organization)")
 	Cmd.Flags().StringVar(&flags.targetFolderID, "target-folder", "", "Folder ID to analyze (Works with --bucket and --refresh; conflicts with --target-project or --target--organization)")
 	Cmd.Flags().StringVar(&flags.targetOrgID, "target-organization", "", "Organization ID to analyze (Works with --bucket and --refresh; conflicts with --target-project or --target--folder)")
+	//Cmd.Flags().StringVar(&flags.targetProjectID, "project", "", "Project to analyze (conflicts with --organization)")
+	Cmd.Flags().StringVar(&flags.bucketName, "bucket", "", "GCS bucket name for storing inventory (conflicts with --dir-path and --stdin)")
+	Cmd.Flags().StringVar(&flags.dirPath, "dir-path", "", "Local directory path for storing inventory (conflicts with --bucket and --stdin)")
+	Cmd.Flags().BoolVar(&flags.stdin, "stdin", false, "Whether inventory will be passed as standard input or not (conflicts with --dir-path and --bucket)")
+	Cmd.Flags().StringVar(&flags.controlProjectID, "control-project", "", "Control project to use for API calls")
+	viper.BindPFlag("google_project", Cmd.Flags().Lookup("control-project"))
+	Cmd.Flags().StringSliceVar(&flags.metadata, "output-metadata", []string{}, "List of comma delimited violation metadata fields of string type to include in output. Works when --output-format is txt or csv. By default no metadata fields in output when --output-format is txt or csv. All metadata will be in output when output-format is json.")
+	
 }
 
 // Cmd represents the base scorecard command
@@ -101,7 +110,7 @@ var Cmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = inventory.Score(config, flags.outputPath, viper.GetString("output-format"))
+		err = inventory.Score(config, flags.outputPath, viper.GetString("output-format"), flags.metadata)
 		if err != nil {
 			return err
 		}

--- a/cli/scorecard/cmd.go
+++ b/cli/scorecard/cmd.go
@@ -34,6 +34,8 @@ func init() {
 	viper.SetDefault("output-format", "txt")
 	viper.BindPFlag("output-format", Cmd.Flags().Lookup("output-format"))
 
+	Cmd.Flags().StringSliceVar(&flags.metadata, "output-metadata", []string{}, "List of comma delimited violation metadata fields of string type to include in output. Works when --output-format is txt or csv. By default no metadata fields in output when --output-format is txt or csv. All metadata will be in output when output-format is json.")
+
 	Cmd.Flags().StringVar(&flags.bucketName, "bucket", "", "GCS bucket name for storing inventory (conflicts with --dir-path or --stdin)")
 	Cmd.Flags().StringVar(&flags.dirPath, "dir-path", "", "Local directory path for storing inventory (conflicts with --bucket or --stdin)")
 	Cmd.Flags().BoolVar(&flags.stdin, "stdin", false, "Passed Cloud Asset Inventory json string as standard input (conflicts with --dir-path or --bucket)")
@@ -41,13 +43,6 @@ func init() {
 	Cmd.Flags().StringVar(&flags.targetProjectID, "target-project", "", "Project ID to analyze (Works with --bucket and --refresh; conflicts with --target-folder or --target--organization)")
 	Cmd.Flags().StringVar(&flags.targetFolderID, "target-folder", "", "Folder ID to analyze (Works with --bucket and --refresh; conflicts with --target-project or --target--organization)")
 	Cmd.Flags().StringVar(&flags.targetOrgID, "target-organization", "", "Organization ID to analyze (Works with --bucket and --refresh; conflicts with --target-project or --target--folder)")
-	//Cmd.Flags().StringVar(&flags.targetProjectID, "project", "", "Project to analyze (conflicts with --organization)")
-	Cmd.Flags().StringVar(&flags.bucketName, "bucket", "", "GCS bucket name for storing inventory (conflicts with --dir-path and --stdin)")
-	Cmd.Flags().StringVar(&flags.dirPath, "dir-path", "", "Local directory path for storing inventory (conflicts with --bucket and --stdin)")
-	Cmd.Flags().BoolVar(&flags.stdin, "stdin", false, "Whether inventory will be passed as standard input or not (conflicts with --dir-path and --bucket)")
-	Cmd.Flags().StringVar(&flags.controlProjectID, "control-project", "", "Control project to use for API calls")
-	viper.BindPFlag("google_project", Cmd.Flags().Lookup("control-project"))
-	Cmd.Flags().StringSliceVar(&flags.metadata, "output-metadata", []string{}, "List of comma delimited violation metadata fields of string type to include in output. Works when --output-format is txt or csv. By default no metadata fields in output when --output-format is txt or csv. All metadata will be in output when output-format is json.")
 	
 }
 

--- a/cli/scorecard/cmd.go
+++ b/cli/scorecard/cmd.go
@@ -34,7 +34,7 @@ func init() {
 	viper.SetDefault("output-format", "txt")
 	viper.BindPFlag("output-format", Cmd.Flags().Lookup("output-format"))
 
-	Cmd.Flags().StringSliceVar(&flags.metadata, "output-metadata", []string{}, "List of comma delimited violation metadata fields of string type to include in output. Works when --output-format is txt or csv. By default no metadata fields in output when --output-format is txt or csv. All metadata will be in output when output-format is json.")
+	Cmd.Flags().StringSliceVar(&flags.metadata, "output-metadata", []string{}, "List of comma delimited violation metadata fields of string type to include in output. Works when --output-format is txt or csv. By default no metadata fields in output when --output-format is txt or csv. All metadata will be in output when --output-format is json.")
 
 	Cmd.Flags().StringVar(&flags.bucketName, "bucket", "", "GCS bucket name for storing inventory (conflicts with --dir-path or --stdin)")
 	Cmd.Flags().StringVar(&flags.dirPath, "dir-path", "", "Local directory path for storing inventory (conflicts with --bucket or --stdin)")

--- a/cli/scorecard/score.go
+++ b/cli/scorecard/score.go
@@ -166,7 +166,7 @@ func (config *ScoringConfig) attachViolations(audit *validator.AuditResponse) er
 }
 
 // Score creates a Scorecard for an inventory
-func (inventory *InventoryConfig) Score(config *ScoringConfig, outputPath string, outputFormat string, outputMetadata []string) error {
+func (inventory *InventoryConfig) Score(config *ScoringConfig, outputPath string, outputFormat string, outputMetadataFields []string) error {
 	auditResult, err := getViolations(inventory, config)
 	if err != nil {
 		return err
@@ -208,7 +208,7 @@ func (inventory *InventoryConfig) Score(config *ScoringConfig, outputPath string
 		case "csv":
 			w := csv.NewWriter(dest)
 			header := []string{"Category", "Constraint", "Resource", "Message"}
-			for _, field:= range outputMetadata{
+			for _, field:= range outputMetadataFields{
 				header = append(header, field)
 			}
 			w.Write(header)
@@ -217,7 +217,7 @@ func (inventory *InventoryConfig) Score(config *ScoringConfig, outputPath string
 				for _, cv := range category.constraints {
 					for _, v := range cv.Violations {
 						record := []string{category.Name, v.Constraint, v.Resource, v.Message}
-						for _, field:= range outputMetadata{
+						for _, field:= range outputMetadataFields{
 							metadata := v.Metadata.GetStructValue()
 							value := metadata.Fields[field].GetStringValue()
 							record = append(record, value)
@@ -237,7 +237,7 @@ func (inventory *InventoryConfig) Score(config *ScoringConfig, outputPath string
 					io.WriteString(dest, fmt.Sprintf("%v: %v issues\n", cv.GetName(), cv.Count()))
 					for _, v := range cv.Violations {
 						io.WriteString(dest, fmt.Sprintf("- %v\n",v.Message))
-						for _, field:= range outputMetadata{
+						for _, field:= range outputMetadataFields{
 							metadata := v.Metadata.GetStructValue()
 							value := metadata.Fields[field].GetStringValue()
 							if value != "" {

--- a/cli/scorecard/score.go
+++ b/cli/scorecard/score.go
@@ -208,10 +208,8 @@ func (inventory *InventoryConfig) Score(config *ScoringConfig, outputPath string
 		case "csv":
 			w := csv.NewWriter(dest)
 			header := []string{"Category", "Constraint", "Resource", "Message"}
-			if (len(outputMetadata) >0) {
-				for _, field:= range outputMetadata{
-					header = append(header, field)
-				}
+			for _, field:= range outputMetadata{
+				header = append(header, field)
 			}
 			w.Write(header)
 			w.Flush()
@@ -219,12 +217,10 @@ func (inventory *InventoryConfig) Score(config *ScoringConfig, outputPath string
 				for _, cv := range category.constraints {
 					for _, v := range cv.Violations {
 						record := []string{category.Name, v.Constraint, v.Resource, v.Message}
-						if (len(outputMetadata) >0) {
-							for _, field:= range outputMetadata{
-								metadata := v.Metadata.GetStructValue()
-								value := metadata.Fields[field].GetStringValue()
-								record = append(record, value)
-							}
+						for _, field:= range outputMetadata{
+							metadata := v.Metadata.GetStructValue()
+							value := metadata.Fields[field].GetStringValue()
+							record = append(record, value)
 						}
 						w.Write(record)
 						w.Flush()
@@ -241,13 +237,11 @@ func (inventory *InventoryConfig) Score(config *ScoringConfig, outputPath string
 					io.WriteString(dest, fmt.Sprintf("%v: %v issues\n", cv.GetName(), cv.Count()))
 					for _, v := range cv.Violations {
 						io.WriteString(dest, fmt.Sprintf("- %v\n",v.Message))
-						if (len(outputMetadata) >0) {
-							for _, field:= range outputMetadata{
-								metadata := v.Metadata.GetStructValue()
-								value := metadata.Fields[field].GetStringValue()
-								if value != "" {
-									io.WriteString(dest, fmt.Sprintf("  %v: %v\n", field, value))
-								}
+						for _, field:= range outputMetadata{
+							metadata := v.Metadata.GetStructValue()
+							value := metadata.Fields[field].GetStringValue()
+							if value != "" {
+								io.WriteString(dest, fmt.Sprintf("  %v: %v\n", field, value))
 							}
 						}
 						io.WriteString(dest, "\n")


### PR DESCRIPTION
New scorecard feature to include violation metadata fields of string type in txt or csv output. 

Use cases include a user-defined priority for each constraint, resource parent/project number/project id, or any additional information that is not covered in resource name and violation message.

The expectation is that these metadata fields need to be defined in constraint templates. 