### PR TITLE
Revert changes from #559 and import the subnetwork.py template

### DIFF
--- a/dm/templates/network/network.py.schema
+++ b/dm/templates/network/network.py.schema
@@ -26,6 +26,9 @@ info:
     - gcp-types/compute-v1:networks =>
         https://cloud.google.com/compute/docs/reference/rest/v1/networks/insert
 
+imports:
+  - path: subnetwork.py
+
 additionalProperties: false
 
 oneOf:


### PR DESCRIPTION
During fixing issue #559 this template was incorrectly changed braking existing templates. This PR reverts the change.