### PR TITLE
Add Config Connector solution member-iam

### DIFF
--- a/config-connector/solutions/iam/README.md
+++ b/config-connector/solutions/iam/README.md
@@ -1,0 +1,7 @@
+# Config Connector IAM Solutions
+
+This is a collection of Config Connector solutions that make it easier to non-destructively manage multiple IAM roles for resources on Google Cloud Platform:
+
+- [Member IAM](./kpt/member-iam)
+
+Details about usage can be found in each solution.

--- a/config-connector/solutions/iam/kpt/README.md
+++ b/config-connector/solutions/iam/kpt/README.md
@@ -1,0 +1,25 @@
+# Kpt Project Solutions
+
+## Installing kpt
+
+Follow the instructions on [the kpt
+GitHub](https://github.com/GoogleContainerTools/kpt).
+
+## Listing setters
+
+See which values are available for kpt to change:
+
+```
+kpt cfg list-setters DIR
+```
+
+## Setting setters
+
+```
+kpt cfg set DIR SETTER_NAME VALUE --set-by SET_BY_NAME
+```
+
+## SEE ALSO
+
+Comprehensive documentation at
+[https://googlecontainertools.github.io/kpt/](https://googlecontainertools.github.io/kpt/).

--- a/config-connector/solutions/iam/kpt/README.md
+++ b/config-connector/solutions/iam/kpt/README.md
@@ -1,4 +1,4 @@
-# Kpt Project Solutions
+# Solutions Using kpt
 
 ## Installing kpt
 

--- a/config-connector/solutions/iam/kpt/member-iam/0-namespace.yaml
+++ b/config-connector/solutions/iam/kpt/member-iam/0-namespace.yaml
@@ -12,17 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: iam.cnrm.cloud.google.com/v1beta1
-kind: IAMPolicyMember
+apiVersion: v1
+kind: Namespace
 metadata:
-  name: project-iam-member
-  namespace: member-iam-solution
-spec:
-  # Replace the ${PROJECT_ID?} below with your desired project ID.
-  member: serviceAccount:member-iam-test@${PROJECT_ID?}.iam.gserviceaccount.com # {"$ref":"#/definitions/io.k8s.cli.substitutions.project-id-in-sa-sub"}
-  role: roles/compute.networkAdmin # {"$ref":"#/definitions/io.k8s.cli.substitutions.role-sub"}
-  resourceRef:
+  annotations:
     # Replace the ${PROJECT_ID?} below with your desired project ID.
-    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
-    kind: Project
-    external: projects/${PROJECT_ID?} # {"$ref":"#/definitions/io.k8s.cli.substitutions.project-id-sub"}
+    cnrm.cloud.google.com/project-id: ${PROJECT_ID?} # {"$ref":"#/definitions/io.k8s.cli.setters.project-id"}
+  name: member-iam-solution

--- a/config-connector/solutions/iam/kpt/member-iam/Kptfile
+++ b/config-connector/solutions/iam/kpt/member-iam/Kptfile
@@ -1,0 +1,63 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: .
+packageMetadata:
+  shortDescription: sample description
+openAPI:
+  definitions:
+    io.k8s.cli.setters.project-id:
+      x-k8s-cli:
+        setter:
+          name: project-id
+          value: ${PROJECT_ID?}
+          setBy: PLACEHOLDER
+      description: The target project where you want to create service accounts and
+        grant permissions.
+    io.k8s.cli.substitutions.project-id-in-sa-sub:
+      x-k8s-cli:
+        substitution:
+          name: project-id-in-sa-sub
+          pattern: serviceAccount:SERVICE_ACCOUNT_NAME_SETTER@PROJECT_ID_SETTER.iam.gserviceaccount.com
+          values:
+          - marker: PROJECT_ID_SETTER
+            ref: '#/definitions/io.k8s.cli.setters.project-id'
+          - marker: SERVICE_ACCOUNT_NAME_SETTER
+            ref: '#/definitions/io.k8s.cli.setters.service-account-name'
+    io.k8s.cli.substitutions.project-id-sub:
+      x-k8s-cli:
+        substitution:
+          name: project-id-sub
+          pattern: projects/PROJECT_ID_SETTER
+          values:
+          - marker: PROJECT_ID_SETTER
+            ref: '#/definitions/io.k8s.cli.setters.project-id'
+    io.k8s.cli.setters.policy-member-name:
+      x-k8s-cli:
+        setter:
+          name: policy-member-name
+          value: project-iam-member
+          setBy: package-default
+      description: The name of the instantiated KCC IAMPolicyMember resource.
+    io.k8s.cli.setters.service-account-name:
+      x-k8s-cli:
+        setter:
+          name: service-account-name
+          value: member-iam-test
+          setBy: package-default
+      description: The name of the new IAM service account.
+    io.k8s.cli.setters.role:
+      x-k8s-cli:
+        setter:
+          name: role
+          value: compute.networkAdmin
+          setBy: package-default
+      description: The role you want to grant the service account with.
+    io.k8s.cli.substitutions.role-sub:
+      x-k8s-cli:
+        substitution:
+          name: role-sub
+          pattern: roles/ROLE_SETTER
+          values:
+          - marker: ROLE_SETTER
+            ref: '#/definitions/io.k8s.cli.setters.role'

--- a/config-connector/solutions/iam/kpt/member-iam/Kptfile
+++ b/config-connector/solutions/iam/kpt/member-iam/Kptfile
@@ -3,7 +3,7 @@ kind: Kptfile
 metadata:
   name: .
 packageMetadata:
-  shortDescription: sample description
+  shortDescription: Create a service account and grant it permissions to access the desired project.
 openAPI:
   definitions:
     io.k8s.cli.setters.project-id:

--- a/config-connector/solutions/iam/kpt/member-iam/Kptfile
+++ b/config-connector/solutions/iam/kpt/member-iam/Kptfile
@@ -43,14 +43,6 @@ openAPI:
       x-k8s-cli:
         setter:
           name: role
-          value: compute.networkAdmin
+          value: roles/compute.networkAdmin
           setBy: package-default
       description: The role you want to grant the service account with.
-    io.k8s.cli.substitutions.role-sub:
-      x-k8s-cli:
-        substitution:
-          name: role-sub
-          pattern: roles/ROLE_SETTER
-          values:
-          - marker: ROLE_SETTER
-            ref: '#/definitions/io.k8s.cli.setters.role'

--- a/config-connector/solutions/iam/kpt/member-iam/Kptfile
+++ b/config-connector/solutions/iam/kpt/member-iam/Kptfile
@@ -32,13 +32,6 @@ openAPI:
           values:
           - marker: PROJECT_ID_SETTER
             ref: '#/definitions/io.k8s.cli.setters.project-id'
-    io.k8s.cli.setters.policy-member-name:
-      x-k8s-cli:
-        setter:
-          name: policy-member-name
-          value: project-iam-member
-          setBy: package-default
-      description: The name of the instantiated KCC IAMPolicyMember resource.
     io.k8s.cli.setters.service-account-name:
       x-k8s-cli:
         setter:

--- a/config-connector/solutions/iam/kpt/member-iam/README.md
+++ b/config-connector/solutions/iam/kpt/member-iam/README.md
@@ -1,0 +1,84 @@
+Member IAM
+==================================================
+
+# NAME
+
+  member-iam
+
+# SYNOPSIS
+
+  Config Connector compatible YAML files to create a service account in your desired project, and grant it a specific role (defaults to `compute.networkAdmin`) in the project.
+
+  You can also create any number of service accounts and grant them any number of roles by altering and applying the altered config YAMLs.
+
+# CONSUMPTION
+
+  Using [kpt](https://googlecontainertools.github.io/kpt/):
+
+  ```
+  kpt pkg get https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit.git/config-connector/solutions/iam/kpt/member-iam member-iam
+  ```
+
+# REQUIREMENTS
+
+  A working Config Connector cluster using a service account 
+  (`cnrm-system@[PROJECT_ID].iam.gserviceaccount.com`) with the following 
+  roles in your desired project (it doesn't need to be the project where you 
+  installed Config Connector):
+
+  - roles/resourcemanager.projectIamAdmin
+  - roles/iam.serviceAccountAdmin
+
+# USAGE
+
+  Replace `${PROJECT_ID?}` with your desired project ID value from 
+  within this directory:
+
+  ```
+  kpt cfg set . project-id VALUE
+  ```
+
+  Once the project ID is set in the configs, simply apply the YAMLs:
+
+  ```
+  kubectl apply -f .
+  ```
+
+## OPTIONAL WORKFLOW
+
+  Optionally, you may want to create a different service account, grant a 
+  different role to the service account, or grant multiple roles to the 
+  service account, etc. Here are the instructions.
+
+**Create a Different Service Account**
+
+  Change the service account name and apply the YAMLs:
+
+  ```
+  kpt cfg set . service-account-name VALUE
+  kubectl apply -f .
+  ```
+
+**Grant a Different Role**
+  
+  Change the role([predefined GCP IAM roles](https://cloud.google.com/iam/docs/understanding-roles#predefined_roles)) and apply the YAMLs:
+
+  ```
+  kpt cfg set . role VALUE
+  kubectl apply -f .
+  ```
+
+**Grant Multiple Roles**
+
+  Change the KCC resource name and the role each time before you grant a new
+  role to the service account:
+
+  ```
+  kpt cfg set . policy-member-name VALUE_1
+  kpt cfg set . role VALUE_2
+  kubectl apply -f iampolicymember.yaml
+  ```
+
+# LICENSE
+
+  Apache 2.0 - See [LICENSE](/LICENSE) for more information.

--- a/config-connector/solutions/iam/kpt/member-iam/README.md
+++ b/config-connector/solutions/iam/kpt/member-iam/README.md
@@ -9,8 +9,6 @@ Member IAM
 
   Config Connector compatible YAML files to create a service account in your desired project, and grant it a specific role (defaults to `compute.networkAdmin`) in the project.
 
-  You can also create any number of service accounts and grant them any number of roles by altering and applying the altered config YAMLs.
-
 # CONSUMPTION
 
   Using [kpt](https://googlecontainertools.github.io/kpt/):
@@ -37,45 +35,27 @@ Member IAM
   kpt cfg set . project-id VALUE
   ```
 
-  Once the project ID is set in the configs, simply apply the YAMLs:
-
-  ```
-  kubectl apply -f .
-  ```
-
-# OPTIONAL WORKFLOW
-
-  Optionally, you may want to create a different service account, grant a 
-  different role to the service account, or grant multiple roles to the 
-  service account, etc. Here are the instructions.
-
-## Create a Different Service Account
-
-  Change the service account name and apply the YAMLs:
+  _Optionally_, you can also change the service acocunt name and role
+  (you can find all the predefined GCP IAM roles
+  [here](https://cloud.google.com/iam/docs/understanding-roles#predefined_roles)):
 
   ```
   kpt cfg set . service-account-name VALUE
-  kubectl apply -f .
-  ```
-
-## Grant a Different Role
-  
-  Change the role ([predefined GCP IAM roles](https://cloud.google.com/iam/docs/understanding-roles#predefined_roles)) and apply the YAMLs:
-
-  ```
   kpt cfg set . role VALUE
+
+  ```
+
+  Once the fields are set in the configs, apply the YAMLs:
+
+  ```
   kubectl apply -f .
   ```
 
-## Grant Multiple Roles
-
-  Change the KCC resource name and the role each time before you grant a new
-  role to the service account:
+  You can check the resources you just created:
 
   ```
-  kpt cfg set . policy-member-name VALUE_1
-  kpt cfg set . role VALUE_2
-  kubectl apply -f iampolicymember.yaml
+  kubectl get iamserviceaccount --namespace member-iam-solution
+  kubectl get iampolicymember --namespace member-iam-solution
   ```
 
 # LICENSE

--- a/config-connector/solutions/iam/kpt/member-iam/README.md
+++ b/config-connector/solutions/iam/kpt/member-iam/README.md
@@ -21,10 +21,9 @@ Member IAM
 
 # REQUIREMENTS
 
-  A working Config Connector cluster using a service account 
-  (`cnrm-system@[PROJECT_ID].iam.gserviceaccount.com`) with the following 
-  roles in your desired project (it doesn't need to be the project where you 
-  installed Config Connector):
+  A working Config Connector cluster using "cnrm-system" service account that
+  has the following roles in your desired project (it doesn't need to be the
+  project where you installed Config Connector):
 
   - roles/resourcemanager.projectIamAdmin
   - roles/iam.serviceAccountAdmin
@@ -44,13 +43,13 @@ Member IAM
   kubectl apply -f .
   ```
 
-## OPTIONAL WORKFLOW
+# OPTIONAL WORKFLOW
 
   Optionally, you may want to create a different service account, grant a 
   different role to the service account, or grant multiple roles to the 
   service account, etc. Here are the instructions.
 
-**Create a Different Service Account**
+## Create a Different Service Account
 
   Change the service account name and apply the YAMLs:
 
@@ -59,7 +58,7 @@ Member IAM
   kubectl apply -f .
   ```
 
-**Grant a Different Role**
+## Grant a Different Role
   
   Change the role([predefined GCP IAM roles](https://cloud.google.com/iam/docs/understanding-roles#predefined_roles)) and apply the YAMLs:
 
@@ -68,7 +67,7 @@ Member IAM
   kubectl apply -f .
   ```
 
-**Grant Multiple Roles**
+## Grant Multiple Roles
 
   Change the KCC resource name and the role each time before you grant a new
   role to the service account:

--- a/config-connector/solutions/iam/kpt/member-iam/README.md
+++ b/config-connector/solutions/iam/kpt/member-iam/README.md
@@ -60,7 +60,7 @@ Member IAM
 
 ## Grant a Different Role
   
-  Change the role([predefined GCP IAM roles](https://cloud.google.com/iam/docs/understanding-roles#predefined_roles)) and apply the YAMLs:
+  Change the role ([predefined GCP IAM roles](https://cloud.google.com/iam/docs/understanding-roles#predefined_roles)) and apply the YAMLs:
 
   ```
   kpt cfg set . role VALUE

--- a/config-connector/solutions/iam/kpt/member-iam/README.md
+++ b/config-connector/solutions/iam/kpt/member-iam/README.md
@@ -42,7 +42,6 @@ Member IAM
   ```
   kpt cfg set . service-account-name VALUE
   kpt cfg set . role VALUE
-
   ```
 
   Once the fields are set in the configs, apply the YAMLs:

--- a/config-connector/solutions/iam/kpt/member-iam/README.md
+++ b/config-connector/solutions/iam/kpt/member-iam/README.md
@@ -35,7 +35,7 @@ Member IAM
   kpt cfg set . project-id VALUE
   ```
 
-  _Optionally_, you can also change the service acocunt name and role
+  _Optionally_, you can also change the service account name and role
   (you can find all the predefined GCP IAM roles
   [here](https://cloud.google.com/iam/docs/understanding-roles#predefined_roles)):
 

--- a/config-connector/solutions/iam/kpt/member-iam/iampolicymember.yaml
+++ b/config-connector/solutions/iam/kpt/member-iam/iampolicymember.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-iam-member # {"$ref":"#/definitions/io.k8s.cli.setters.policy-member-name"}
+spec:
+  # Replace the ${PROJECT_ID?} below with your desired project ID.
+  member: serviceAccount:member-iam-test@${PROJECT_ID?}.iam.gserviceaccount.com # {"$ref":"#/definitions/io.k8s.cli.substitutions.project-id-in-sa-sub"}
+  role: roles/compute.networkAdmin # {"$ref":"#/definitions/io.k8s.cli.substitutions.role-sub"}
+  resourceRef:
+    # Replace the ${PROJECT_ID?} below with your desired project ID.
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: projects/${PROJECT_ID?} # {"$ref":"#/definitions/io.k8s.cli.substitutions.project-id-sub"}

--- a/config-connector/solutions/iam/kpt/member-iam/iampolicymember.yaml
+++ b/config-connector/solutions/iam/kpt/member-iam/iampolicymember.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   # Replace the ${PROJECT_ID?} below with your desired project ID.
   member: serviceAccount:member-iam-test@${PROJECT_ID?}.iam.gserviceaccount.com # {"$ref":"#/definitions/io.k8s.cli.substitutions.project-id-in-sa-sub"}
-  role: roles/compute.networkAdmin # {"$ref":"#/definitions/io.k8s.cli.substitutions.role-sub"}
+  role: roles/compute.networkAdmin # {"$ref":"#/definitions/io.k8s.cli.setters.role"}
   resourceRef:
     # Replace the ${PROJECT_ID?} below with your desired project ID.
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1

--- a/config-connector/solutions/iam/kpt/member-iam/iamserviceaccount.yaml
+++ b/config-connector/solutions/iam/kpt/member-iam/iamserviceaccount.yaml
@@ -1,0 +1,21 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  annotations:
+    # Replace the ${PROJECT_ID?} below with your desired project ID.
+    cnrm.cloud.google.com/project-id: ${PROJECT_ID?} # {"$ref":"#/definitions/io.k8s.cli.setters.project-id"}
+  name: member-iam-test # {"$ref":"#/definitions/io.k8s.cli.setters.service-account-name"}

--- a/config-connector/solutions/iam/kpt/member-iam/iamserviceaccount.yaml
+++ b/config-connector/solutions/iam/kpt/member-iam/iamserviceaccount.yaml
@@ -15,7 +15,5 @@
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
-  annotations:
-    # Replace the ${PROJECT_ID?} below with your desired project ID.
-    cnrm.cloud.google.com/project-id: ${PROJECT_ID?} # {"$ref":"#/definitions/io.k8s.cli.setters.project-id"}
   name: member-iam-test # {"$ref":"#/definitions/io.k8s.cli.setters.service-account-name"}
+  namespace: member-iam-solution


### PR DESCRIPTION
Adding a new solution for Config Connector. This solution comes from the TF CFT member_iam [example](https://github.com/terraform-google-modules/terraform-google-iam/tree/master/examples/member_iam)/[submodule](https://github.com/terraform-google-modules/terraform-google-iam/tree/master/modules/member_iam).