### PR TITLE
Remove enum from initializeParams diskType

### DIFF
--- a/dm/templates/instance/instance.py.schema
+++ b/dm/templates/instance/instance.py.schema
@@ -398,10 +398,6 @@ properties:
                 projects/project/zones/zone/diskTypes/diskType
                 zones/zone/diskTypes/diskType
                 Note that for InstanceTemplate, this is the name of the disk type, not URL.
-              enum:
-                - pd-standard
-                - pd-ssd
-                - local-ssd
             sourceImageEncryptionKey:
               type: object
               additionalProperties: false


### PR DESCRIPTION
The `enum` values were incorrect for initializeParams.

See docs here: https://cloud.google.com/compute/docs/reference/rest/v1/instances#Instance.FIELDS.inlinedField_29