### PR TITLE
Cloud Function upload python 3 compatibility #608

### DIFF
--- a/dm/templates/cloud_function/upload.py
+++ b/dm/templates/cloud_function/upload.py
@@ -55,11 +55,12 @@ def upload_source(context_name, project, function, imports, local_path, source_a
 
     # Creates an in-memory archive of the Cloud Function source files.
     sources = extract_source_files(imports, local_path)
-    archive_base64 = base64.b64encode(archive_files(sources)).decode("utf-8") 
+    archive = archive_files(sources)
+    archive_base64 = base64.b64encode(archive).decode("utf-8")
 
     # The Cloud Function knows it was updated when MD5 changes.
     md5 = hashlib.md5()
-    md5.update(archive_base64)
+    md5.update(archive)
 
     # Splits the upload path into the bucket and archive names.
     bucket_name = source_archive_url[:source_archive_url.index('/', GS_SCHEMA_LENGTH)] # pylint: disable=line-too-long


### PR DESCRIPTION
It appears the initial commit didn't fix the issue. I still got the following error:

The template is incompatible with Python3. Please fix the following errors: Exception in cloud_function.py Traceback (most recent call last): return constructor[m](evaluation_context) File "cloud_function.py", line 203, in generate_config File "cloud_function.py", line 181, in create_function_resource File "cloud_function.py", line 87, in append_source_code File "cloud_function.py", line 46, in append_cloud_storage_sources File "upload.py", line 62, in upload_source TypeError: Unicode-objects must be encoded before hashing Resource: cloud_function.py Resource: config https://cloud.google.com/deployment-manager/docs/migrate-to-python3

As a result, the zip file has incorrect content. This commit fixed the problem. Thus the PR.

