### PR TITLE
Restrict building new dev tools images only when pushed to master

### DIFF
--- a/.github/workflows/build-push-cft-devtools.yml
+++ b/.github/workflows/build-push-cft-devtools.yml
@@ -1,6 +1,8 @@
 name: Build and push new dev tools image
 on:
   push:
+    branches: 
+      - "master"
     paths:
       - "infra/build/**"
 env:


### PR DESCRIPTION
Build CFT dev tools image only when pushed to `master`