### PR TITLE
[DM] add dependsOn and fix schema

### DIFF
--- a/dm/templates/bigquery/bigquery_dataset.py
+++ b/dm/templates/bigquery/bigquery_dataset.py
@@ -78,6 +78,9 @@ def generate_config(context):
         }
     ]
 
+    if 'dependsOn' in context.properties:
+        resources[0]['metadata'] = {'dependsOn': context.properties['dependsOn']}
+
     outputs = [
         {
             'name': 'selfLink',

--- a/dm/templates/bigquery/bigquery_dataset.py.schema
+++ b/dm/templates/bigquery/bigquery_dataset.py.schema
@@ -188,6 +188,13 @@ properties:
         name: wrench
         mass: 1.3kg
         count: 3
+  dependsOn:
+    type: array
+    description: |
+      The list of the resources that must be created before this template is applied.
+    items:
+      type: string
+      description: The resource name.
 
 outputs:
   properties:

--- a/dm/templates/cloud_sql/cloud_sql.py.schema
+++ b/dm/templates/cloud_sql/cloud_sql.py.schema
@@ -229,7 +229,7 @@ properties:
       availabilityType:
         type: string
         description: |
-          The availability type (PostgreSQL instances only). Potential values:
+          The availability type. Potential values:
           ZONAL: The instance serves data from only one zone. Outages in that
           zone affect data accessibility.
           REGIONAL: The instance can serve data from more than one zone in a

--- a/dm/templates/gcs_bucket/gcs_bucket.py
+++ b/dm/templates/gcs_bucket/gcs_bucket.py
@@ -85,6 +85,8 @@ def generate_config(context):
         dependson = {}
         dependson_root = []
 
+    bucket.update(dependson)
+
     if bindings:
         for role in bindings:
             for member in role['members']:

--- a/dm/templates/gcs_bucket/gcs_bucket.py.schema
+++ b/dm/templates/gcs_bucket/gcs_bucket.py.schema
@@ -90,6 +90,13 @@ properties:
     type: string
     default: us-east1
     description: The region name where the bucket is deployed.
+  dependsOn:
+    type: array
+    description: |
+      The list of the resources that must be created before this template is applied.
+    items:
+      type: string
+      description: The resource name.
   defaultEventBasedHold:
     type: boolean
     description: Whether or not to automatically apply an eventBasedHold to new objects added to the bucket.


### PR DESCRIPTION
This PR has two changes:
1. add dependsOn to bigquery_dataset and gcs_bucket
2. fix cloud_sql.py.schema. mysql also supports REGIONAL HA.