### PR TITLE
Fix condition bug in comment bot

### DIFF
--- a/infra/terraform/test-org/ci-comment-build-trigger-function/function_source/main.py
+++ b/infra/terraform/test-org/ci-comment-build-trigger-function/function_source/main.py
@@ -75,7 +75,7 @@ def main(event, context):
         '-c',
         'git clone $$REPO_URL && cd $$REPO_NAME && git checkout $$COMMIT_SHA && git status',
     ]
-    if not PR_NUMBER or _HEAD_REPO_URL:
+    if not (PR_NUMBER or _HEAD_REPO_URL):
         logging.warn('Unable to infer PR number via Cloud Build. Trying via GH API')
         # get list of github PRs that have this SHA
         response = requests.get(


### PR DESCRIPTION
- Fix nor condition bug 

@morgante there is another _bug_ where if the [`_DOCKER_TAG_VERSION_DEVELOPER_TOOLS` in a lint.cloubuild.yaml ](https://github.com/terraform-google-modules/terraform-google-cloud-storage/blob/805a6d897443f99bae3c6e877ccb586837a64c86/build/lint.cloudbuild.yaml#L24)is less that `0.11.0` then the comment will fail as the comment helper is not in any image below `0.11.0`.  

We can fix this using `distutils.version` but I was thinking of keeping as is. My thoughts are, this way we can make sure all modules that use this feature are at a min version `0.11.0`. WDYT?