### PR TITLE
Quote orgID and folderID using helm

### DIFF
--- a/config-connector/solutions/projects/helm/owned-project/templates/project.yaml
+++ b/config-connector/solutions/projects/helm/owned-project/templates/project.yaml
@@ -16,7 +16,7 @@ apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: Project
 metadata:
   annotations:
-    cnrm.cloud.google.com/folder-id: {{ required "Folder ID is required!" .Values.folderID }}
+    cnrm.cloud.google.com/folder-id: {{ required "Folder ID is required!" .Values.folderID | quote }}
   name: {{ required "Project ID is required!" .Values.projectID }}
 spec:
   name: {{ required "Project ID is required!" .Values.projectID }}

--- a/config-connector/solutions/projects/helm/simple-project/templates/project.yaml
+++ b/config-connector/solutions/projects/helm/simple-project/templates/project.yaml
@@ -16,7 +16,7 @@ apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: Project
 metadata:
   annotations:
-    cnrm.cloud.google.com/organization-id: {{ required "Organization ID is required!" .Values.orgID }}
+    cnrm.cloud.google.com/organization-id: {{ required "Organization ID is required!" .Values.orgID | quote }}
   name: {{ required "Project ID is required!" .Values.projectID }}
 spec:
   name: {{ required "Project ID is required!" .Values.projectID }}


### PR DESCRIPTION
The numerical IDs need to be quoted from within Helm to work robustly.