### PR TITLE
Fix example-foundation name exclusion

### DIFF
--- a/infra/terraform/test-org/ci-triggers/locals.tf
+++ b/infra/terraform/test-org/ci-triggers/locals.tf
@@ -22,7 +22,7 @@ locals {
     "ci-shared",
   ]
   exclude_repos = [
-    "example-foundation",
+    "ci-example-foundation",
   ]
   repo_folder              = { for key, value in data.terraform_remote_state.org.outputs.folders : contains(local.exclude_repos, key) ? replace(key, "ci-", "terraform-") : replace(key, "ci-", "terraform-google-") => replace(value, "folders/", "") if ! contains(local.exclude_folders, key) }
   org_id                   = data.terraform_remote_state.org.outputs.org_id


### PR DESCRIPTION
- We should exclude by the name of the folder created, which has ` ci-` prepended.