### PR TITLE
fix: CFT bot ignore autogen fmt

### DIFF
--- a/infra/terraform/test-org/ci-comment-build-trigger-function/function_source/main.py
+++ b/infra/terraform/test-org/ci-comment-build-trigger-function/function_source/main.py
@@ -116,7 +116,7 @@ def main(event, context):
     # lint comment step
     lint_args = [
         '-c',
-        'source /usr/local/bin/task_helper_functions.sh && printenv && post_lint_status_pr_comment',
+        'source /usr/local/bin/task_helper_functions.sh && printenv && cd $$REPO_NAME && post_lint_status_pr_comment',
     ]
     lint_step = BuildStep(
         name=f'{CFT_TOOLS_DEFAULT_IMAGE}:{CFT_TOOLS_DEFAULT_IMAGE_VERSION}',


### PR DESCRIPTION
Fix issue where bot was not ignoring `autogen` dir
Example: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/602#issuecomment-664090306

Cause:
- as we are cloning a repo manually within the buildstep we need to cd into the REPO_DIR for each stage
- this was resulting in [`find_files` unable to match the `autogen` folder ](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/blob/d427b256faca6721f20418fae3ac8a4555d2faa4/infra/build/developer-tools/build/scripts/task_helper_functions.sh#L62)to ignore fmt
