### PR TITLE
Update install_shellcheck in devtools image

### DIFF
--- a/infra/build/developer-tools/build/install_shellcheck.sh
+++ b/infra/build/developer-tools/build/install_shellcheck.sh
@@ -18,7 +18,7 @@ set -u
 
 cd /build
 
-wget https://shellcheck.storage.googleapis.com/shellcheck-v0.6.0.linux.x86_64.tar.xz
+wget https://github.com/koalaman/shellcheck/releases/download/v0.6.0/shellcheck-v0.6.0.linux.x86_64.tar.xz
 tar -xf shellcheck-v0.6.0.linux.x86_64.tar.xz
 install -o 0 -g 0 -m 0755 shellcheck-v0.6.0/shellcheck /usr/local/bin/shellcheck
 rm -rf shellcheck-v0.6.0 shellcheck-v0.6.0.linux.x86_64.tar.xz


### PR DESCRIPTION
Builds are breaking due to https://github.com/koalaman/shellcheck/issues/1871 and hence updating as recommended.