### PR TITLE
Fix wrong handling of prefixLength property

### DIFF
--- a/dm/templates/ip_reservation/ip_address.py
+++ b/dm/templates/ip_reservation/ip_address.py
@@ -62,7 +62,11 @@ def generate_config(context):
 
     for prop in optional_properties:
         if prop in context.properties:
-            res_properties[prop] = str(context.properties[prop])
+            if prop == "prefixLength":
+                # Unlike other optional props, prefixLength is an integer, not a string
+                res_properties[prop] = context.properties[prop]
+            else:
+                res_properties[prop] = str(context.properties[prop])
 
     resources = [
         {


### PR DESCRIPTION
The [API](https://cloud.google.com/compute/docs/reference/rest/v1/addresses) expects `prefixLength` to be an integer so it shouldn't be coerced into a string like other optional properties.