### PR TITLE
Fix Cloud Build trigger example & template schema

### DIFF
--- a/dm/templates/cloudbuild/examples/cloudbuild_trigger.yaml
+++ b/dm/templates/cloudbuild/examples/cloudbuild_trigger.yaml
@@ -28,7 +28,7 @@ resources:
       triggerTemplate:
         repoName: '<FIXME:repo_name>'
         branchName: 'master'
-      buildTemplate:
+      build:
         steps:
           - name: 'gcr.io/cloud-builders/docker'
             args:

--- a/dm/templates/cloudbuild/trigger.py.schema
+++ b/dm/templates/cloudbuild/trigger.py.schema
@@ -51,6 +51,13 @@ properties:
       Branch and tag names in the trigger templates are interpreted as regular
       expressions. Any branch or tag change that matches that regular
       expression triggers a build.
+    oneOf:
+      - required:
+          - branchName
+      - required:
+          - tagName
+      - required:
+          - commitSha
     properties:
       projectId:
         type: string
@@ -68,12 +75,12 @@ properties:
           The directory to run the build in (path relative to the source root).
           If a step's dir value is specified as an absolute path, this value
           is ignored for that step's execution.
-      revision:
-        type: string
-        oneOf:
-          - "$ref": "#/definitions/branchName"
-          - "$ref": "#/definitions/tagName"
-          - "$ref": "#/definitions/commitSha"
+      branchName:
+        $ref: "#/definitions/branchName"
+      tagName:
+        $ref: "#/definitions/tagName"
+      commitSha:
+        $ref: "#/definitions/commitSha"
   github:
     type: object
     additionalProperties: false
@@ -132,8 +139,6 @@ properties:
                 Regexes matching tags to build.
                 
                 The syntax of the regular expressions accepted is the syntax accepted by RE2 and described at https://github.com/google/re2/wiki/Syntax
-
-
   disabled:
     type: boolean
     default: False


### PR DESCRIPTION
Fixes #602 

Revert `triggerTemplate` schema to match
https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/RepoSource

Fix example to match
https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.trigger