### PR TITLE
Updated cloud_sql.py.schema to allow new versions

### DIFF
--- a/dm/templates/cloud_sql/cloud_sql.py.schema
+++ b/dm/templates/cloud_sql/cloud_sql.py.schema
@@ -41,16 +41,17 @@ properties:
     description: |
       The database engine type and version.
       The databaseVersion field can not be changed after instance creation.
-      MySQL Second Generation instances: MYSQL_5_7 (default) or MYSQL_5_6.
-      PostgreSQL instances: POSTGRES_9_6
-      MySQL First Generation instances: MYSQL_5_6 (default) or MYSQL_5_5
+      MySQL Second Generation instances: MYSQL_8_0, MYSQL_5_7 (default) or MYSQL_5_6.
+      PostgreSQL instances: POSTGRES_9_6 (default), or POSTGRES_10, or POSTGRES_11 Beta, or POSTGRES_12.
+      SQL Server instances: SQLSERVER_2017_STANDARD (default), SQLSERVER_2017_ENTERPRISE, SQLSERVER_2017_EXPRESS, or SQLSERVER_2017_WEB.
     enum:
-      - MYSQL_5_5 # Deprecated
       - MYSQL_5_6
       - MYSQL_5_7
+      - MYSQL_8_0
       - POSTGRES_9_6
+      - POSTGRES_10
       - POSTGRES_11
-      - SQLSERVER_ENTERPRISE_2016
+      - POSTGRES_12
       - SQLSERVER_2017_STANDARD
       - SQLSERVER_2017_ENTERPRISE
       - SQLSERVER_2017_EXPRESS


### PR DESCRIPTION
Currently, Google Cloud SQL APIs allow the new versions of database engines and remove the oldest one:
- MySQL: add v8.0, remove v5.5
- PostgreSQL: add v10 and v12
- SQLServer: remove ENTERPRISE 2016
Changed schema to embrace this change.