### PR TITLE
Add recurringWindow to the GKE maintenancePolicy

### DIFF
--- a/dm/templates/gke/gke.py.schema
+++ b/dm/templates/gke/gke.py.schema
@@ -906,6 +906,28 @@ properties:
                       Time within the maintenance window to start the 
                       maintenance operations. It must be in the HH:MM
                       format, where HH 00-23 and MM 00-59 GMT.
+              recurringWindow:
+                type: object
+                additionalProperties: false
+                description: Some number of recurring time periods for maintenance to occur
+                properties:
+                  window:
+                    type: object
+                    additionalProperties: false
+                    description: The window of the first recurrence
+                    properties:
+                      startTime:
+                        type: string
+                        additionalProperties: false
+                        description: The time that the window first starts
+                      endTime:
+                        type: string
+                        additionalProperties: false
+                        description: The time that the window first ends
+                  recurrence:
+                    type: string
+                    additionalProperties: false
+                    description: The recurrence rule for how the window reccurs
       defaultMaxPodsConstraint:
         type: object
         additionalProperties: false


### PR DESCRIPTION
This schema is missing the recurringWindow and this does not allow me to create a GKE cluster with a specific maintenance policy, as specified i the official documentation: https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#Cluster.RecurringTimeWindow
This simple edit will permit this (lines 909 to 930). All property descriptions are the same as the official documentation.

Thank you.
Sincerely,
Fausto