### PR TITLE
fix: Update set-env commands for tooling and release GitHub workflows

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -26,7 +26,7 @@ jobs:
         run: |-
           LAST_VERSION=$(curl --silent "${{env.RELEASE_URL}}" | \
             jq --raw-output .tag_name)
-          echo ::set-env name=LAST_VERSION::$LAST_VERSION
+          echo "LAST_VERSION=${LAST_VERSION}" >> $GITHUB_ENV
 
       - name: Build
         working-directory: ./cli
@@ -44,7 +44,7 @@ jobs:
         working-directory: ./cli
         run: |-
           CURRENT_VERSION=$(./bin/cft-linux-amd64 version)
-          echo ::set-env name=CURRENT_VERSION::$CURRENT_VERSION
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_ENV
 
       - name: Release new version
         if: env.LAST_VERSION != env.CURRENT_VERSION

--- a/.github/workflows/update-tooling.yml
+++ b/.github/workflows/update-tooling.yml
@@ -18,11 +18,11 @@ jobs:
 
           if [ "$CURRENT_TERRAFORM" == "$LATEST_TERRAFORM" ]; then
               echo "Terraform is latest"
-              echo ::set-env name=LATEST_TERRAFORM::$(echo "is latest")
+              echo "LATEST_TERRAFORM=is latest" >> $GITHUB_ENV
           else
               echo "Terraform needs to be updated to ${LATEST_TERRAFORM}"
               sed -i "s/TERRAFORM_VERSION := ${CURRENT_TERRAFORM}/TERRAFORM_VERSION := ${LATEST_TERRAFORM}/g" infra/build/Makefile
-              echo ::set-env name=LATEST_TERRAFORM::$LATEST_TERRAFORM
+              echo "LATEST_TERRAFORM=${LATEST_TERRAFORM}" >> $GITHUB_ENV
           fi
       - name: Update gCloud SDK Version
         run: |
@@ -31,11 +31,11 @@ jobs:
 
           if [ "$CURRENT_GCLOUD" == "$LATEST_GCLOUD" ]; then
               echo "gcloud sdk is latest"
-              echo ::set-env name=LATEST_GCLOUD::$(echo "is latest")
+              echo "LATEST_GCLOUD=is latest" >> $GITHUB_ENV
           else
               echo "gcloud sdk needs to be updated to ${LATEST_GCLOUD}"
               sed -i "s/CLOUD_SDK_VERSION := ${CURRENT_GCLOUD}/CLOUD_SDK_VERSION := ${LATEST_GCLOUD}/g" infra/build/Makefile
-              echo ::set-env name=LATEST_GCLOUD::$LATEST_GCLOUD
+              echo "LATEST_GCLOUD=${LATEST_GCLOUD}" >> $GITHUB_ENV
           fi
       - name: Bump image patch version
         if: env.LATEST_TERRAFORM != 'is latest' || env.LATEST_GCLOUD != 'is latest'
@@ -43,7 +43,7 @@ jobs:
           CURRENT_IMG_VERSION=$(cat infra/build/Makefile  | grep 'DOCKER_TAG_VERSION_DEVELOPER_TOOLS :=' | awk -F" " '{print $3}')
           NEW_IMG_VERSION=$(echo $CURRENT_IMG_VERSION | awk -F. '{$NF+=1; print $0}' OFS=".")
           sed -i "s/DOCKER_TAG_VERSION_DEVELOPER_TOOLS := ${CURRENT_IMG_VERSION}/DOCKER_TAG_VERSION_DEVELOPER_TOOLS := ${NEW_IMG_VERSION}/g" infra/build/Makefile
-          echo ::set-env name=NEW_IMG_VERSION::$NEW_IMG_VERSION
+          echo "NEW_IMG_VERSION=${NEW_IMG_VERSION}" >> $GITHUB_ENV
       - name: Commit Makefile
         if: env.LATEST_TERRAFORM != 'is latest' || env.LATEST_GCLOUD != 'is latest'
         run: |


### PR DESCRIPTION
`set-env` commands are now deprecated due to a security vulnerability and will be fully disabled soon. This PR migrates them to the new approach.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
