### PR TITLE
chore: update setup-gcloud actions repo

### DIFF
--- a/.github/workflows/build-push-cft-devtools.yml
+++ b/.github/workflows/build-push-cft-devtools.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@master
         with:
           version: "286.0.0"
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@master
         with:
           version: "286.0.0"
           service_account_key: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
`GoogleCloudPlatform/github-actions/setup-gcloud` is now deprecated and replaced by[`google-github-actions/setup-gcloud`](https://github.com/google-github-actions/setup-gcloud) for new features/fixes.