### PR TITLE
fix: disable comment bot on example foundation

### DIFF
--- a/infra/terraform/test-org/ci-comment-build-trigger-function/function_source/main.py
+++ b/infra/terraform/test-org/ci-comment-build-trigger-function/function_source/main.py
@@ -24,9 +24,8 @@ from google.cloud.devtools.cloudbuild_v1.types import BuildStep, Build, BuildOpt
 from google.protobuf import duration_pb2 as duration
 
 CFT_TOOLS_DEFAULT_IMAGE = 'gcr.io/cloud-foundation-cicd/cft/developer-tools'
-CFT_TOOLS_DEFAULT_IMAGE_VERSION = '0.11.0'
-DISABLED_MODULES = [
-]
+CFT_TOOLS_DEFAULT_IMAGE_VERSION = '0.12'
+DISABLED_MODULES = ["terraform-example-foundation"]
 
 
 def main(event, context):


### PR DESCRIPTION
Example foundations lint test requires a specific pre-step (https://github.com/terraform-google-modules/terraform-example-foundation/pull/298/commits/85dec2517f5990a8487f7b59c072934784a0dff5) to work around nested providers in 0.13. 

This will be added as a step in the cloud build lint pipeline (https://github.com/terraform-google-modules/terraform-example-foundation/pull/323) but not incorporated into the bot as it not useful for general modules.