### PR TITLE
Fixing the `outputs` section in the schema files

### DIFF
--- a/dm/templates/autoscaler/autoscaler.py.schema
+++ b/dm/templates/autoscaler/autoscaler.py.schema
@@ -151,23 +151,22 @@ properties:
             of the Stackdriver Monitoring metric is expressed.
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The autoscaler name.
-    - selfLink:
-        type: string
-        description: The autoscaler URL.
-    - region:
-        type: string
-        description: |
-          The region where the instance group resides (for regionally
-          scoped autoscalers).
-    - zone:
-        type: string
-        description: |
-          The zone where the instance group resides (for zonally scoped
-          autoscalers).
+  name:
+    type: string
+    description: The autoscaler name.
+  selfLink:
+    type: string
+    description: The autoscaler URL.
+  region:
+    type: string
+    description: |
+      The region where the instance group resides (for regionally
+      scoped autoscalers).
+  zone:
+    type: string
+    description: |
+      The zone where the instance group resides (for zonally scoped
+      autoscalers).
 
 documentation:
   - templates/autoscaler/README.md

--- a/dm/templates/backend_service/backend_service.py.schema
+++ b/dm/templates/backend_service/backend_service.py.schema
@@ -392,17 +392,16 @@ properties:
           served in responses are not altered.
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The backend name.
-    - region:
-        type: string
-        description: |
-            The URL of the region where the regional backend service resides.
-    - selfLink:
-        type: string
-        description: The URI (SelfLink) of the backend service resource.
+  name:
+    type: string
+    description: The backend name.
+  region:
+    type: string
+    description: |
+        The URL of the region where the regional backend service resides.
+  selfLink:
+    type: string
+    description: The URI (SelfLink) of the backend service resource.
 
 documentation:
   - templates/backend_service/README.md

--- a/dm/templates/bastion/bastion.py.schema
+++ b/dm/templates/bastion/bastion.py.schema
@@ -205,43 +205,42 @@ properties:
           type: string
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The name of the Bastion host.
-    - selfLink:
-        type: string
-        description: |
-          The URI (SelfLink) of the Bastion host.
-    - internalIp:
-        type: string
-        description: |
-          The internal IP address of the Bastion host.
-    - externalIp:
-        type: array
-        description: |
-          The external IP address of the Bastion host.
-    - sshToBastionRuleName:
-        type: array
-        description: |
-          If created, the name of the firewall rule controlling the SSH traffic
-          flow to the Bastion host.
-    - sshToBastionRuleSelfLink:
-        type: array
-        description: |
-          If created, the URI (SelfLink) of the firewall rule controlling the
-          SSH traffic flow to the Bastion host.
-    - sshFromBastionRuleName:
-        type: array
-        description: |
-          If created, the name of the firewall rule controlling the SSH traffic
-          flow from the Bastion host to other instances in the same network.
-    - sshFromBastionRuleSelfLink:
-        type: array
-        description: |
-          If created, the URI (SelfLink) of the firewall rule controlling the
-          SSH traffic flow from the Bastion host to other instances in the
-          same network.
+  name:
+    type: string
+    description: The name of the Bastion host.
+  selfLink:
+    type: string
+    description: |
+      The URI (SelfLink) of the Bastion host.
+  internalIp:
+    type: string
+    description: |
+      The internal IP address of the Bastion host.
+  externalIp:
+    type: array
+    description: |
+      The external IP address of the Bastion host.
+  sshToBastionRuleName:
+    type: array
+    description: |
+      If created, the name of the firewall rule controlling the SSH traffic
+      flow to the Bastion host.
+  sshToBastionRuleSelfLink:
+    type: array
+    description: |
+      If created, the URI (SelfLink) of the firewall rule controlling the
+      SSH traffic flow to the Bastion host.
+  sshFromBastionRuleName:
+    type: array
+    description: |
+      If created, the name of the firewall rule controlling the SSH traffic
+      flow from the Bastion host to other instances in the same network.
+  sshFromBastionRuleSelfLink:
+    type: array
+    description: |
+      If created, the URI (SelfLink) of the firewall rule controlling the
+      SSH traffic flow from the Bastion host to other instances in the
+      same network.
 
 documentation:
   - templates/bastion/README.md

--- a/dm/templates/bigquery/bigquery_dataset.py.schema
+++ b/dm/templates/bigquery/bigquery_dataset.py.schema
@@ -190,24 +190,23 @@ properties:
         count: 3
 
 outputs:
-  properties:
-    - selfLink:
-        type: string
-        description: The URI of the created resource.
-    - etag:
-        type: string
-        description: The hash of the resource.
-    - creationTime:
-        type: string
-        description: |
-          The time when the dataset was created, in milliseconds since
-          epoch. For example, 1535739430.
-    - lastModifiedTime:
-        type: string
-        description: |
-          The time when the dataset or any of its tables was last
-          modified, in milliseconds since the epoch. For example,
-          1535739430.
+  selfLink:
+    type: string
+    description: The URI of the created resource.
+  etag:
+    type: string
+    description: The hash of the resource.
+  creationTime:
+    type: string
+    description: |
+      The time when the dataset was created, in milliseconds since
+      epoch. For example, 1535739430.
+  lastModifiedTime:
+    type: string
+    description: |
+      The time when the dataset or any of its tables was last
+      modified, in milliseconds since the epoch. For example,
+      1535739430.
 
 documentation:
   - templates/bigquery/README.md

--- a/dm/templates/bigquery/bigquery_table.py.schema
+++ b/dm/templates/bigquery/bigquery_table.py.schema
@@ -500,53 +500,52 @@ properties:
         count: 3
 
 outputs:
-  properties:
-    - selfLink:
-        type: string
-        description: The URI of the created resource.
-    - etag:
-        type: string
-        description: The hash of the resource.
-    - creationTime:
-        type: string
-        description: |
-          The time when the dataset was created, in milliseconds since
-          epoch.
-    - lastModifiedTime:
-        type: string
-        description: |
-          The date when the dataset (or any of its tables) was last 
-          modified, in milliseconds since the epoch.
-    - location:
-        type: string
-        description: |
-          The geographic location where the table resides. This value is
-          inherited from the dataset.
-    - numBytes:
-        type: string
-        description: |
-          The size of the table in bytes, excluding data in the streaming
-          buffer.
-    - numLongTermBytes:
-        type: string
-        format: int64
-        description: |
-          The number of bytes in the table that are considered
-          \"long-term storage\".
-    - numRows:
-        type: string
-        description: |
-          The number of rows of data in the table, excluding data in the
-          streaming buffer.
-    - type:
-        type: string
-        description: |
-          The table type. The following values are supported: 
-           TABLE - a normal BigQuery table
-           VIEW - a virtual table defined by an SQL query
-           EXTERNAL - a table that references data stored in an external
-           storage system, such as Google Cloud Storage. 
-          The default value is TABLE.
+  selfLink:
+    type: string
+    description: The URI of the created resource.
+  etag:
+    type: string
+    description: The hash of the resource.
+  creationTime:
+    type: string
+    description: |
+      The time when the dataset was created, in milliseconds since
+      epoch.
+  lastModifiedTime:
+    type: string
+    description: |
+      The date when the dataset (or any of its tables) was last
+      modified, in milliseconds since the epoch.
+  location:
+    type: string
+    description: |
+      The geographic location where the table resides. This value is
+      inherited from the dataset.
+  numBytes:
+    type: string
+    description: |
+      The size of the table in bytes, excluding data in the streaming
+      buffer.
+  numLongTermBytes:
+    type: string
+    format: int64
+    description: |
+      The number of bytes in the table that are considered
+      \"long-term storage\".
+  numRows:
+    type: string
+    description: |
+      The number of rows of data in the table, excluding data in the
+      streaming buffer.
+  type:
+    type: string
+    description: |
+      The table type. The following values are supported:
+       TABLE - a normal BigQuery table
+       VIEW - a virtual table defined by an SQL query
+       EXTERNAL - a table that references data stored in an external
+       storage system, such as Google Cloud Storage.
+      The default value is TABLE.
 
 documentation:
   - templates/bigquery/README.md

--- a/dm/templates/cloud_filestore/cloud_filestore.py.schema
+++ b/dm/templates/cloud_filestore/cloud_filestore.py.schema
@@ -120,10 +120,9 @@ properties:
             overlap with either existing subnets or assigned IP address ranges for other Cloud Filestore instances in the selected VPC network.
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The resource name of the instance.
+  name:
+    type: string
+    description: The resource name of the instance.
 
 documentation:
   - templates/cloud_filestore/README.md

--- a/dm/templates/cloud_function/cloud_function.py.schema
+++ b/dm/templates/cloud_function/cloud_function.py.schema
@@ -188,24 +188,23 @@ properties:
       This feature is currently in alpha, available only for whitelisted users.
 
 outputs:
-  properties:
-    - region:
-      description: The region where the function is deployed.
-      type: string
-    - name:
-      description: The function name.
-      type: string
-    - httpsTriggerUrl:
-      description: For HTTPS-triggered functions, the trigger URL.
-      type: string
-    - sourceRepositoryUrl:
-      description: |
-        For functions deployed from cloud repositories, 
-        the repository URL.
-      type: string
-    - sourceArchiveUrl:
-      description: For functions deployed from Cloud Storage, the bucket URL.
-      type: string
+  region:
+    description: The region where the function is deployed.
+    type: string
+  name:
+    description: The function name.
+    type: string
+  httpsTriggerUrl:
+    description: For HTTPS-triggered functions, the trigger URL.
+    type: string
+  sourceRepositoryUrl:
+    description: |
+      For functions deployed from cloud repositories,
+      the repository URL.
+    type: string
+  sourceArchiveUrl:
+    description: For functions deployed from Cloud Storage, the bucket URL.
+    type: string
 
 documentation:
   - templates/cloud_function/README.md

--- a/dm/templates/cloud_router/cloud_router.py.schema
+++ b/dm/templates/cloud_router/cloud_router.py.schema
@@ -408,16 +408,15 @@ properties:
       DEPRECATED. Alias for bgp->asn
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The name of the Cloud Router resource.
-    - selfLink:
-        type: string
-        description: The URI (SelfLink) of the Cloud Router resource.
-    - creationTimestamp:
-        type: string
-        description: Creation timestamp in RFC3339 text format.
+  name:
+    type: string
+    description: The name of the Cloud Router resource.
+  selfLink:
+    type: string
+    description: The URI (SelfLink) of the Cloud Router resource.
+  creationTimestamp:
+    type: string
+    description: Creation timestamp in RFC3339 text format.
 
 documentation:
   - templates/cloud_router/README.md

--- a/dm/templates/cloud_spanner/cloud_spanner.py.schema
+++ b/dm/templates/cloud_spanner/cloud_spanner.py.schema
@@ -93,33 +93,32 @@ properties:
           description: The name of the database created under the instance cluster.
 
 outputs:
-  properties:
-    name:
-      type: string
-      description: The name of the cloud spanner instance.
-    state:
-      type: string
-      description: |
-        The current cloud spanner instance state. For more information:
-        - https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances#State
-    databases:
-      type: array
-      description: |
-        Array of database details. For example, the output can be referenced
-        as: `$(ref.<my-instance>.databases.<database-name>.state)`
-      items:
-        description: The name of the address resource.
-        patternProperties:
-          ".*":
-            type: object
-            additionalProperties: false
-            description: Details for an address resource.
-            properties:
-              state:
-                type: string
-                description: |
-                  The current database state. For more information:
-                  - https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances.databases#Database
+  name:
+    type: string
+    description: The name of the cloud spanner instance.
+  state:
+    type: string
+    description: |
+      The current cloud spanner instance state. For more information:
+      - https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances#State
+  databases:
+    type: array
+    description: |
+      Array of database details. For example, the output can be referenced
+      as: `$(ref.<my-instance>.databases.<database-name>.state)`
+    items:
+      description: The name of the address resource.
+      patternProperties:
+        ".*":
+          type: object
+          additionalProperties: false
+          description: Details for an address resource.
+          properties:
+            state:
+              type: string
+              description: |
+                The current database state. For more information:
+                - https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances.databases#Database
 
 documentation:
   - templates/cloud_spanner/README.md

--- a/dm/templates/cloud_sql/cloud_sql.py.schema
+++ b/dm/templates/cloud_sql/cloud_sql.py.schema
@@ -525,49 +525,48 @@ properties:
       description: The resource name.
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The resource name.
-    - selfLink:
-        type: string
-        description: |
-          The URL (SelfLink) of the Cloud SQL instance resource.
-    - gceZone:
-        type: string
-        description: |
-          The Compute Engine zone the instance is currently serving from.
-          This value could be different from the zone that was specified when
-          the instance was created if the instance has failed over to its
-          secondary zone.
-    - connectionName:
-        type: string
-        description: |
-          The connection name of the Cloud SQL instance (used in connection
-          strings).
-    - backendType:
-        type: string
-        description: Database generation.
-    - ipAddress:
-        type: string
-        description: |
-          The first IP address assigned to the instance.
-    - userNames:
-        type: array
-        description: The names of the created users.
-    - databaseNames:
-        type: array
-        description: The names of the created databases.
-    - databaseSelfLinks:
-        type: array
-        description: |
-          The URLs (SelfLinks) of the Cloud SQL database resources.
-    - resources:
-        type: array
-        description: |
-          Names of the resources the template creates. Because Cloud SQL
-          usually requires resources to be created sequentially, this output
-          can be used as synchronization context.
+  name:
+    type: string
+    description: The resource name.
+  selfLink:
+    type: string
+    description: |
+      The URL (SelfLink) of the Cloud SQL instance resource.
+  gceZone:
+    type: string
+    description: |
+      The Compute Engine zone the instance is currently serving from.
+      This value could be different from the zone that was specified when
+      the instance was created if the instance has failed over to its
+      secondary zone.
+  connectionName:
+    type: string
+    description: |
+      The connection name of the Cloud SQL instance (used in connection
+      strings).
+  backendType:
+    type: string
+    description: Database generation.
+  ipAddress:
+    type: string
+    description: |
+      The first IP address assigned to the instance.
+  userNames:
+    type: array
+    description: The names of the created users.
+  databaseNames:
+    type: array
+    description: The names of the created databases.
+  databaseSelfLinks:
+    type: array
+    description: |
+      The URLs (SelfLinks) of the Cloud SQL database resources.
+  resources:
+    type: array
+    description: |
+      Names of the resources the template creates. Because Cloud SQL
+      usually requires resources to be created sequentially, this output
+      can be used as synchronization context.
 
 documentation:
   - templates/cloud_sql/README.md

--- a/dm/templates/cloud_tasks/queue.py.schema
+++ b/dm/templates/cloud_tasks/queue.py.schema
@@ -206,18 +206,17 @@ properties:
               https://cloud.google.com/appengine/docs/flexible/python/how-requests-are-routed
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The queue name.
-    - state:
-        type: string
-        description: The state of the queue.
-        enum:
-          - STATE_UNSPECIFIED
-          - RUNNING
-          - PAUSED
-          - DISABLED
+  name:
+    type: string
+    description: The queue name.
+  state:
+    type: string
+    description: The state of the queue.
+    enum:
+      - STATE_UNSPECIFIED
+      - RUNNING
+      - PAUSED
+      - DISABLED
 
 documentation:
   - templates/cloud_tasks/README.md

--- a/dm/templates/cloud_tasks/task.py.schema
+++ b/dm/templates/cloud_tasks/task.py.schema
@@ -164,28 +164,27 @@ properties:
               with an incompatible HttpMethod. A base64-encoded string.
 
 outputs:
-  properties:
-    name:
-      type: string
-      description: The name of the task resource.
-    createTime:
-      type: string
-      description: |
-        The time when the task was created. createTime is truncated to the
-        nearest second.
-    view:
-      type: string
-      description: The subset of the Task data.
-      enum:
-        - VIEW_UNSPECIFIED
-        - BASIC
-        - FULL
-    scheduleTime:
-      type: string
-      description: |
-        The time when the task is scheduled to be attempted. For App Engine
-        queues, this is when the task will be attempted or retried.
-        `schedule_time` will be truncated to the nearest microsecond.
+  name:
+    type: string
+    description: The name of the task resource.
+  createTime:
+    type: string
+    description: |
+      The time when the task was created. createTime is truncated to the
+      nearest second.
+  view:
+    type: string
+    description: The subset of the Task data.
+    enum:
+      - VIEW_UNSPECIFIED
+      - BASIC
+      - FULL
+  scheduleTime:
+    type: string
+    description: |
+      The time when the task is scheduled to be attempted. For App Engine
+      queues, this is when the task will be attempted or retried.
+      `schedule_time` will be truncated to the nearest microsecond.
 
 documentation:
   - templates/cloud_tasks/README.md

--- a/dm/templates/cloudbuild/cloudbuild.py.schema
+++ b/dm/templates/cloudbuild/cloudbuild.py.schema
@@ -442,35 +442,34 @@ definitions:
     description: The explicit commit SHA to build.
 
 outputs:
-  properties:
-    - id:
-        type: string
-        description: Build Unique identifier.
-    - status:
-        type: string
-        description: The build status.
-    - results:
-        type: object
-        description: The build results.
-    - createTime:
-        type: string
-        description: | 
-          The time the build was requested, in the RFC3339 UTC "Zulu" format.
-    - startTime:
-        type: string
-        description: |
-          The time the build execution started, in the RFC3339 UTC "Zulu" format.
-    - finishTime:
-        type: string
-        description: |
-          The time the build finished, in the RFC3339 UTC "Zulu" format.
-    - logUrl:
-        type: string
-        description: The URL to the build logs in the Google Cloud console.
-    - sourceProvenance:
-        type: object
-        description: |
-          Fixed identifier to used to describe the original source, or verify that some source was used for this build.
+  id:
+    type: string
+    description: Build Unique identifier.
+  status:
+    type: string
+    description: The build status.
+  results:
+    type: object
+    description: The build results.
+  createTime:
+    type: string
+    description: | 
+      The time the build was requested, in the RFC3339 UTC "Zulu" format.
+  startTime:
+    type: string
+    description: |
+      The time the build execution started, in the RFC3339 UTC "Zulu" format.
+  finishTime:
+    type: string
+    description: |
+      The time the build finished, in the RFC3339 UTC "Zulu" format.
+  logUrl:
+    type: string
+    description: The URL to the build logs in the Google Cloud console.
+  sourceProvenance:
+    type: object
+    description: |
+      Fixed identifier to used to describe the original source, or verify that some source was used for this build.
             
 documentation:
   - templates/cloudbuild/README.md

--- a/dm/templates/dataproc/dataproc.py.schema
+++ b/dm/templates/dataproc/dataproc.py.schema
@@ -261,32 +261,32 @@ properties:
       The Compute Engine config settings for additional worker instances in
       the cluster.
     $ref: '#/definitions/nodeConfig'
+
 outputs:
-  properties:
-    - masterInstanceNames:
-        type: array
-        description: When configured, the list of master instance names.
-        items:
-          type: string
-    - workerInstanceNames:
-        type: array
-        description: When configured, the list of worker instance names.
-        items:
-          type: string
-    - secondaryWorkerInstanceNames:
-        type: array
-        description: |
-          When configured, the list of additional worker instance names.
-        items:
-          type: string
-    - name:
-        type: string
-        description: The cluster name.
-    - configBucket:
-        type: string
-        description: |
-          A Cloud Storage staging bucket used for sharing generated SSH keys
-          and config.
+  masterInstanceNames:
+    type: array
+    description: When configured, the list of master instance names.
+    items:
+      type: string
+  workerInstanceNames:
+    type: array
+    description: When configured, the list of worker instance names.
+    items:
+      type: string
+  secondaryWorkerInstanceNames:
+    type: array
+    description: |
+      When configured, the list of additional worker instance names.
+    items:
+      type: string
+  name:
+    type: string
+    description: The cluster name.
+  configBucket:
+    type: string
+    description: |
+      A Cloud Storage staging bucket used for sharing generated SSH keys
+      and config.
 
 documentation:
   - templates/dataproc/README.md

--- a/dm/templates/dns_managed_zone/dns_managed_zone.py.schema
+++ b/dm/templates/dns_managed_zone/dns_managed_zone.py.schema
@@ -215,34 +215,34 @@ properties:
       Acceptable values are "private" and "public".
 
 outputs:
-  properties:
-    - dnsName:
-        type: string
-        description: The DNS name of the managed zone.
-    - managedZoneDescription:
-        type: string
-        description: The description of the managed zone.
-    - nameServers:
-        type: array
-        description: |
-          The list of nameservers that will be authoritative for this domain.
-    - managedZoneName:
-        type: string
-        description: The managed zone's resource name.
-    - visibility:
-        type: string
-        description: |
-          The zone's visibility. Public zones are exposed to the Internet,
-          while private zones are visible only to Virtual Private Cloud
-          resources.
-    - privateVisibilityConfig:
-        type: object
-        description: |
-          For privately visible zones, the set of Virtual Private Cloud
-          resources that the zone is visible from.
-    - dnssecConfig:
-        type: object
-        description: DNSSEC configuration.
+  dnsName:
+    type: string
+    description: The DNS name of the managed zone.
+  managedZoneDescription:
+    type: string
+    description: The description of the managed zone.
+  nameServers:
+    type: array
+    description: |
+      The list of nameservers that will be authoritative for this domain.
+  managedZoneName:
+    type: string
+    description: The managed zone's resource name.
+  visibility:
+    type: string
+    description: |
+      The zone's visibility. Public zones are exposed to the Internet,
+      while private zones are visible only to Virtual Private Cloud
+      resources.
+  privateVisibilityConfig:
+    type: object
+    description: |
+      For privately visible zones, the set of Virtual Private Cloud
+      resources that the zone is visible from.
+  dnssecConfig:
+    type: object
+    description: DNSSEC configuration.
+
 documentation:
   - templates/dns_managed_zone/README.md
 

--- a/dm/templates/external_load_balancer/external_load_balancer.py.schema
+++ b/dm/templates/external_load_balancer/external_load_balancer.py.schema
@@ -591,46 +591,45 @@ properties:
 
 
 outputs:
-  properties:
-    - forwardingRuleName:
-        type: string
-        description: The name of the external load balancer's forwarding rule.
-    - forwardingRuleSelfLink:
-        type: string
-        description: |
-          The URI (SelfLink) of the external load balancer's forwarding rule.
-    - IPAddress:
-        type: string
-        description: |
-          The IP address on whose behalf the external load balancer
-          (the forwarding rule) operates.
-    - backendServiceNames:
-        type: array
-        description: |
-          The names of the external load balancer's backend services.
-    - backendServiceSelfLinks:
-        type: string
-        description: The URIs (SelfLinks) of the backend service resources.
-    - targetProxyName:
-        type: string
-        description: |
-          The name of the target proxy resource created for the load balancer.
-    - targetProxySelfLink:
-        type: string
-        description: |
-          The URI (SelfLink) of the URL target proxy resource.
-    - targetProxyKind:
-        type: string
-        description: |
-          The type of the target proxy resource created for the load balancer.
-    - certificateName:
-        type: string
-        description: |
-          The name of the SSL certificate, if one is to be created.
-    - certificateSelfLink:
-        type: string
-        description: |
-          The URI (SelfLink) of the SSL certificate, if one is to be created.
+  forwardingRuleName:
+    type: string
+    description: The name of the external load balancer's forwarding rule.
+  forwardingRuleSelfLink:
+    type: string
+    description: |
+      The URI (SelfLink) of the external load balancer's forwarding rule.
+  IPAddress:
+    type: string
+    description: |
+      The IP address on whose behalf the external load balancer
+      (the forwarding rule) operates.
+  backendServiceNames:
+    type: array
+    description: |
+      The names of the external load balancer's backend services.
+  backendServiceSelfLinks:
+    type: string
+    description: The URIs (SelfLinks) of the backend service resources.
+  targetProxyName:
+    type: string
+    description: |
+      The name of the target proxy resource created for the load balancer.
+  targetProxySelfLink:
+    type: string
+    description: |
+      The URI (SelfLink) of the URL target proxy resource.
+  targetProxyKind:
+    type: string
+    description: |
+      The type of the target proxy resource created for the load balancer.
+  certificateName:
+    type: string
+    description: |
+      The name of the SSL certificate, if one is to be created.
+  certificateSelfLink:
+    type: string
+    description: |
+      The URI (SelfLink) of the SSL certificate, if one is to be created.
 
 documentation:
   - templates/external_load_balancer/README.md

--- a/dm/templates/firewall/firewall.py.schema
+++ b/dm/templates/firewall/firewall.py.schema
@@ -261,26 +261,25 @@ properties:
 
 
 outputs:
-  properties:
-    rules:
-      type: array
-      description: |
-        Array of firewall rule details. For example, the output can be
-        referenced as:
-        $(ref.<my-firewall>.rules.<firewall-rule-name>.selfLink)
-      items:
-        description: The name of the firewall rule resource.
-        patternProperties:
-          ".*":
-            type: object
-            description: Details for a firewall rule resource.
-            properties:
-              selfLink:
-                type: string
-                description: The URI (SelfLink) of the firewall rule resource.
-              creationTimestamp:
-                type: string
-                description: Creation timestamp in RFC3339 text format.
+  rules:
+    type: array
+    description: |
+      Array of firewall rule details. For example, the output can be
+      referenced as:
+      $(ref.<my-firewall>.rules.<firewall-rule-name>.selfLink)
+    items:
+      description: The name of the firewall rule resource.
+      patternProperties:
+        ".*":
+          type: object
+          description: Details for a firewall rule resource.
+          properties:
+            selfLink:
+              type: string
+              description: The URI (SelfLink) of the firewall rule resource.
+            creationTimestamp:
+              type: string
+              description: Creation timestamp in RFC3339 text format.
 
 documentation:
   - templates/firewall/README.md

--- a/dm/templates/folder/folder.py.schema
+++ b/dm/templates/folder/folder.py.schema
@@ -103,37 +103,36 @@ properties:
             can be no longer than 30 characters.
 
 outputs:
-  properties:
-    folders:
-      type: array
-      description: Array of folder resource information.
-      items:
-        description: |
-          The name of the folder resource. For example, the output can be
-          referenced as: $(ref.<my-folder>.folders.<folder-name>.parent)
-        patternProperties:
-          ".*":
-            type: object
-            description: Details for a folder resource.
-            properties:
-              name:
-                type: string
-                description: |
-                  Name of the folder resource in the format
-                  `folders/<folderID>`.
-              parent:
-                type: string
-                description: |
-                  The resource name of the parent Folder or Organization.
-              displayName:
-                type: string
-                description: The folder's display name.
-              createTime:
-                type: string
-                description: Creation timestamp in RFC3339 text format.
-              lifecycleState:
-                type: string
-                description: The Folder's current lifecycle state.
+  folders:
+    type: array
+    description: Array of folder resource information.
+    items:
+      description: |
+        The name of the folder resource. For example, the output can be
+        referenced as: $(ref.<my-folder>.folders.<folder-name>.parent)
+      patternProperties:
+        ".*":
+          type: object
+          description: Details for a folder resource.
+          properties:
+            name:
+              type: string
+              description: |
+                Name of the folder resource in the format
+                `folders/<folderID>`.
+            parent:
+              type: string
+              description: |
+                The resource name of the parent Folder or Organization.
+            displayName:
+              type: string
+              description: The folder's display name.
+            createTime:
+              type: string
+              description: Creation timestamp in RFC3339 text format.
+            lifecycleState:
+              type: string
+              description: The Folder's current lifecycle state.
 
 documentation:
   - templates/folder/README.md

--- a/dm/templates/forwarding_rule/forwarding_rule.py.schema
+++ b/dm/templates/forwarding_rule/forwarding_rule.py.schema
@@ -328,21 +328,20 @@ properties:
       addressed to any ports will be forwarded to the backends configured with this forwarding rule.
 
 outputs:
-  properties:
-    - region:
-        type: string
-        description: |
-          The URL of the region where the regional forwarding rule resides.
-    - name:
-        type: string
-        description: The resource name.
-    - selfLink:
-        type: string
-        description: The URI (SelfLink) of the forwarding rule resource.
-    - IPAddress:
-        type: string
-        description: |
-          The IP address on behalf of which the forwarding rule serves.
+  region:
+    type: string
+    description: |
+      The URL of the region where the regional forwarding rule resides.
+  name:
+    type: string
+    description: The resource name.
+  selfLink:
+    type: string
+    description: The URI (SelfLink) of the forwarding rule resource.
+  IPAddress:
+    type: string
+    description: |
+      The IP address on behalf of which the forwarding rule serves.
 
 documentation:
   - templates/forwarding_rule/README.md

--- a/dm/templates/gcs_bucket/gcs_bucket.py.schema
+++ b/dm/templates/gcs_bucket/gcs_bucket.py.schema
@@ -479,17 +479,16 @@ properties:
           content for the 404 Not Found result if the requested object path
           is missing, and no mainPageSuffix object is provided.
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The name of the storage bucket resource.
-    - selfLink:
-        type: string
-        description: The URI (SelfLink) of the storage bucket resource.
-    - url:
-        type: string
-        description: |
-          The base URL of the bucket in the gs://<bucket-name> format.
+  name:
+    type: string
+    description: The name of the storage bucket resource.
+  selfLink:
+    type: string
+    description: The URI (SelfLink) of the storage bucket resource.
+  url:
+    type: string
+    description: |
+      The base URL of the bucket in the gs://<bucket-name> format.
 
 documentation:
   - templates/gcs_bucket/README.md

--- a/dm/templates/gke/gke.py.schema
+++ b/dm/templates/gke/gke.py.schema
@@ -1083,62 +1083,61 @@ properties:
           This prefix will be used for assigning private IP addresses to the master or set of masters, as well as
           the ILB VIP. This field is deprecated, use privateClusterConfig.master_ipv4_cidr_block instead.
 outputs:
-  properties:
-    - selfLink:
-        type: string
-        description: The server-defined resource URL.
-    - endpoint:
-        type: string
-        description: The IP address of the cluster's Kubernetes Master.
-    - currentMasterVersion:
-        type: string
-        description: The current version of the master in the cluster.
-    - currentNodeVersion:
-        type: string
-        description: |
-          The current version of the node software components. In case of 
-          multiple versions (e.g., when the components are in the process
-          of being upgraded), this parameter reflects the minimum version
-          among all nodes.
-    - nodeIpv4CidrSize:
-        type: number
-        description: |
-          The size of the address space on each node for hosting containers.
-          This is provisioned from within the container_ipv4_cidr range.
-    - servicesIpv4Cidr:
-        type: string
-        description: |
-          The IP address range of the Kubernetes services in the cluster, 
-          in the CIDR notation (e.g., 1.2.3.4/29). Service addresses are
-          typically put in the last /16 of the container CIDR.
-    - instanceGroupUrls:
-        type: array
-        items:
-          type: string
-          description: |
-            A list of instance group URLs that have been assigned to the
-            cluster.
-    - clientCertificate:
-        type: string
-        description: |
-          The Base64-encoded public certificate the clients use to authenticate
-          to the cluster endpoint.
-    - clientKey:
-        type: string
-        description: |
-          The Base64-encoded private key the clients use to authenticate
-          to the cluster endpoint.
-    - clusterCaCertificate:
-        type: string
-        description: |
-          The Base64-encoded public certificate that is the root of trust for
-          the cluster.
-    - maintenanceWindowDuration:
-        type: string
-        description: |
-          Duration of the maintenance time window; automatically chosen to be
-          the smallest possible in the given scenario. The duration is in the
-          RFC3339 format PTnHnMnS e.g., "PT4H0M0S".
+  selfLink:
+    type: string
+    description: The server-defined resource URL.
+  endpoint:
+    type: string
+    description: The IP address of the cluster's Kubernetes Master.
+  currentMasterVersion:
+    type: string
+    description: The current version of the master in the cluster.
+  currentNodeVersion:
+    type: string
+    description: |
+      The current version of the node software components. In case of 
+      multiple versions (e.g., when the components are in the process
+      of being upgraded), this parameter reflects the minimum version
+      among all nodes.
+  nodeIpv4CidrSize:
+    type: number
+    description: |
+      The size of the address space on each node for hosting containers.
+      This is provisioned from within the container_ipv4_cidr range.
+  servicesIpv4Cidr:
+    type: string
+    description: |
+      The IP address range of the Kubernetes services in the cluster, 
+      in the CIDR notation (e.g., 1.2.3.4/29). Service addresses are
+      typically put in the last /16 of the container CIDR.
+  instanceGroupUrls:
+    type: array
+    items:
+      type: string
+      description: |
+        A list of instance group URLs that have been assigned to the
+        cluster.
+  clientCertificate:
+    type: string
+    description: |
+      The Base64-encoded public certificate the clients use to authenticate
+      to the cluster endpoint.
+  clientKey:
+    type: string
+    description: |
+      The Base64-encoded private key the clients use to authenticate
+      to the cluster endpoint.
+  clusterCaCertificate:
+    type: string
+    description: |
+      The Base64-encoded public certificate that is the root of trust for
+      the cluster.
+  maintenanceWindowDuration:
+    type: string
+    description: |
+      Duration of the maintenance time window; automatically chosen to be
+      the smallest possible in the given scenario. The duration is in the
+      RFC3339 format PTnHnMnS e.g., "PT4H0M0S".
 
 documentation:
   - templates/gke/README.md

--- a/dm/templates/haproxy/haproxy.py.schema
+++ b/dm/templates/haproxy/haproxy.py.schema
@@ -117,23 +117,22 @@ properties:
           Specifies how often the list of instances should be refreshed.
 
 outputs:
-  properties:
-    - externalIp:
-        type: string
-        description: Reference to an external IP address of the load balancer.
-    - internalIp:
-        type: string
-        description: Reference to an internal IP address of the load balancer.
-    - name:
-        type: string
-        description: The load balancer name.
-    - selfLink:
-        type: string
-        description: Link to the load balancer instance.
-    - port:
-        type: integer
-        description: |
-          Number of the port where the HAProxy load balancer will accept requests.
+  externalIp:
+    type: string
+    description: Reference to an external IP address of the load balancer.
+  internalIp:
+    type: string
+    description: Reference to an internal IP address of the load balancer.
+  name:
+    type: string
+    description: The load balancer name.
+  selfLink:
+    type: string
+    description: Link to the load balancer instance.
+  port:
+    type: integer
+    description: |
+      Number of the port where the HAProxy load balancer will accept requests.
 
 documentation:
   - templates/haproxy/README.md

--- a/dm/templates/healthcheck/healthcheck.py.schema
+++ b/dm/templates/healthcheck/healthcheck.py.schema
@@ -171,17 +171,16 @@ properties:
       - USE_SERVING_PORT
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The HealthCheck resource name.
-    - selfLink:
-        type: string
-        description: The Deployment Manager-defined URL for the resource.
-    - creationTimestamp:
-        type: datetime
-        description: |
-          The resource creation timestamp in the RFC3339 text format.
+  name:
+    type: string
+    description: The HealthCheck resource name.
+  selfLink:
+    type: string
+    description: The Deployment Manager-defined URL for the resource.
+  creationTimestamp:
+    type: datetime
+    description: |
+      The resource creation timestamp in the RFC3339 text format.
 
 documentation:
   - templates/healthcheck/README.md

--- a/dm/templates/instance/instance.py.schema
+++ b/dm/templates/instance/instance.py.schema
@@ -721,27 +721,27 @@ properties:
       Specifies instance template to create the instance.
       This field is optional. It can be a full or partial URL.
       See https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert for details.
+
 outputs:
-  properties:
-    - networkInterfaces:
-      type: array
-      description: |
-        A list of network interfaces of the new instance.
-      items:
-        type: object
-        properties:
-          externalIp:
-            type: string
-            description: Reference to the external ip address of the new instance
-          internalIp:
-            type: string
-            description: Reference to tbe internal ip address of the new instance
-    - name:
+  networkInterfaces:
+  type: array
+  description: |
+    A list of network interfaces of the new instance.
+  items:
+    type: object
+    properties:
+      externalIp:
         type: string
-        description: A name of the instance resource
-    - selfLink:
+        description: Reference to the external ip address of the new instance
+      internalIp:
         type: string
-        description: The URI (SelfLink) of the instance resource.
+        description: Reference to tbe internal ip address of the new instance
+  name:
+    type: string
+    description: A name of the instance resource
+  selfLink:
+    type: string
+    description: The URI (SelfLink) of the instance resource.
 
 documentation:
   - templates/instance/README.md

--- a/dm/templates/instance_template/instance_template.py.schema
+++ b/dm/templates/instance_template/instance_template.py.schema
@@ -754,13 +754,12 @@ properties:
         count: 3
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The instance template name.
-    - selfLink:
-        type: string
-        description: The URI (SelfLink) of the instance template resource.
+  name:
+    type: string
+    description: The instance template name.
+  selfLink:
+    type: string
+    description: The URI (SelfLink) of the instance template resource.
 
 documentation:
   - templates/instance_template/README.md

--- a/dm/templates/interconnect/interconnect.py.schema
+++ b/dm/templates/interconnect/interconnect.py.schema
@@ -91,13 +91,12 @@ properties:
       such as Stackdriver log alerting and Cloud Notifications.
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The Interconnect name.
-    - selfLink:
-        type: string
-        description: The server-defined URL for the resource.
+  name:
+    type: string
+    description: The Interconnect name.
+  selfLink:
+    type: string
+    description: The server-defined URL for the resource.
 
 documentation:
   - templates/interconnect/README.md

--- a/dm/templates/interconnect_attachment/interconnect_attachment.py.schema
+++ b/dm/templates/interconnect_attachment/interconnect_attachment.py.schema
@@ -198,13 +198,12 @@ properties:
       - AVAILABILITY_DOMAIN_ANY
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The created attachments name.
-    - selfLink:
-        type: string
-        description: Server-defined URL for the resource.
+  name:
+    type: string
+    description: The created attachments name.
+  selfLink:
+    type: string
+    description: Server-defined URL for the resource.
 
 documentation:
   - templates/interconnect_attachment/README.md

--- a/dm/templates/internal_load_balancer/internal_load_balancer.py.schema
+++ b/dm/templates/internal_load_balancer/internal_load_balancer.py.schema
@@ -172,28 +172,27 @@ properties:
               earlier).
 
 outputs:
-  properties:
-    - forwardingRuleName:
-        type: string
-        description: The name of the internal load balancer's forwarding rule.
-    - backendServiceName:
-        type: string
-        description: The name of the internal load balancer's backend service.
-    - region:
-        type: string
-        description: |
-            The URL of the region where the internal load balancer resides.
-    - forwardingRuleSelfLink:
-        type: string
-        description: The URI (SelfLink) of the forwarding rule resource.
-    - backendServiceSelfLink:
-        type: string
-        description: The URI (SelfLink) of the backend service resource.
-    - IPAddress:
-        type: string
-        description: |
-          The IP address on whose behalf the internal load balancer
-          (the forwarding rule) operates.
+  forwardingRuleName:
+    type: string
+    description: The name of the internal load balancer's forwarding rule.
+  backendServiceName:
+    type: string
+    description: The name of the internal load balancer's backend service.
+  region:
+    type: string
+    description: |
+        The URL of the region where the internal load balancer resides.
+  forwardingRuleSelfLink:
+    type: string
+    description: The URI (SelfLink) of the forwarding rule resource.
+  backendServiceSelfLink:
+    type: string
+    description: The URI (SelfLink) of the backend service resource.
+  IPAddress:
+    type: string
+    description: |
+      The IP address on whose behalf the internal load balancer
+      (the forwarding rule) operates.
 
 documentation:
   - templates/internal_load_balancer/README.md

--- a/dm/templates/ip_reservation/ip_address.py.schema
+++ b/dm/templates/ip_reservation/ip_address.py.schema
@@ -171,23 +171,22 @@ properties:
       The region where the regional address resides.
 
 outputs:
-  properties:
-    selfLink:
-      type: string
-      description: The URI (SelfLink) of the address resource.
-    address:
-      type: string
-      description: |
-        The static IP address represented by this resource.
-    status:
-      type: string
-      description: |
-        The status of the address, which can be one of RESERVING,
-        RESERVED, or IN_USE. An address that is RESERVING is
-        currently in the process of being reserved. A RESERVED
-        address is currently reserved and available to use. An IN_USE
-        address is currently being used by another resource and is
-        not available.
+  selfLink:
+    type: string
+    description: The URI (SelfLink) of the address resource.
+  address:
+    type: string
+    description: |
+      The static IP address represented by this resource.
+  status:
+    type: string
+    description: |
+      The status of the address, which can be one of RESERVING,
+      RESERVED, or IN_USE. An address that is RESERVING is
+      currently in the process of being reserved. A RESERVED
+      address is currently reserved and available to use. An IN_USE
+      address is currently being used by another resource and is
+      not available.
 
 documentation:
   - templates/ip_reservation/README.md

--- a/dm/templates/ip_reservation/ip_reservation.py.schema
+++ b/dm/templates/ip_reservation/ip_reservation.py.schema
@@ -139,35 +139,34 @@ properties:
             The region where the regional address resides.
 
 outputs:
-  properties:
-    addresses:
-      type: array
-      description: |
-        Array of address details. For example, the output can be referenced
-        as: `$(ref.<my-address>.addresses.<address-name>.selfLink)`
-      items:
-        description: The name of the address resource.
-        patternProperties:
-          ".*":
-            type: object
-            description: Details for an address resource.
-            properties:
-              selfLink:
-                type: string
-                description: The URI (SelfLink) of the address resource.
-              address:
-                type: string
-                description: |
-                  The static IP address represented by this resource.
-              status:
-                type: string
-                description: |
-                  The status of the address, which can be one of RESERVING,
-                  RESERVED, or IN_USE. An address that is RESERVING is
-                  currently in the process of being reserved. A RESERVED
-                  address is currently reserved and available to use. An IN_USE
-                  address is currently being used by another resource and is
-                  not available.
+  addresses:
+    type: array
+    description: |
+      Array of address details. For example, the output can be referenced
+      as: `$(ref.<my-address>.addresses.<address-name>.selfLink)`
+    items:
+      description: The name of the address resource.
+      patternProperties:
+        ".*":
+          type: object
+          description: Details for an address resource.
+          properties:
+            selfLink:
+              type: string
+              description: The URI (SelfLink) of the address resource.
+            address:
+              type: string
+              description: |
+                The static IP address represented by this resource.
+            status:
+              type: string
+              description: |
+                The status of the address, which can be one of RESERVING,
+                RESERVED, or IN_USE. An address that is RESERVING is
+                currently in the process of being reserved. A RESERVED
+                address is currently reserved and available to use. An IN_USE
+                address is currently being used by another resource and is
+                not available.
 
 documentation:
   - templates/ip_reservation/README.md

--- a/dm/templates/kms/kms.py.schema
+++ b/dm/templates/kms/kms.py.schema
@@ -139,10 +139,9 @@ properties:
             https://cloud.google.com/kms/docs/labeling-keys.
 
 outputs:
-  properties:
-    - keyRing:
-        type: string
-        description: Path to the KeyRing resource.
+  keyRing:
+    type: string
+    description: Path to the KeyRing resource.
 
 documentation:
   - templates/kms/README.md

--- a/dm/templates/managed_instance_group/managed_instance_group.py.schema
+++ b/dm/templates/managed_instance_group/managed_instance_group.py.schema
@@ -967,37 +967,36 @@ properties:
                 Stackdriver Monitoring metric is expressed.
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The name of the managed instance group manager resource.
-    - selfLink:
-        type: string
-        description: |
-          The URL (SelfLink) of the managed instance group manager resource.
-    - instanceGroupSelfLink:
-        type: string
-        description: The URL (SelfLink) of the managed instance group resource.
-    - region:
-        type: string
-        description: |
-          The URL of the region where the managed instance group resides
-          (for regional resources).
-    - zone:
-        type: string
-        description: |
-          The URL of the zone where the managed instance group is located
-          (for zonal resources).
-    - autoscalerSelfLink:
-        type: string
-        description: |
-          The URL (SelfLink) of the autoscaler resource (if the group is used
-          with the autoscaler).
-    - instanceTemplateSelfLink:
-        type: string
-        description: |
-          The URL (SelfLink) of the instance template resource (if new instance
-          template was created for the group).
+  name:
+    type: string
+    description: The name of the managed instance group manager resource.
+  selfLink:
+    type: string
+    description: |
+      The URL (SelfLink) of the managed instance group manager resource.
+  instanceGroupSelfLink:
+    type: string
+    description: The URL (SelfLink) of the managed instance group resource.
+  region:
+    type: string
+    description: |
+      The URL of the region where the managed instance group resides
+      (for regional resources).
+  zone:
+    type: string
+    description: |
+      The URL of the zone where the managed instance group is located
+      (for zonal resources).
+  autoscalerSelfLink:
+    type: string
+    description: |
+      The URL (SelfLink) of the autoscaler resource (if the group is used
+      with the autoscaler).
+  instanceTemplateSelfLink:
+    type: string
+    description: |
+      The URL (SelfLink) of the instance template resource (if new instance
+      template was created for the group).
 
 documentation:
   - templates/managed_instance_group/README.md

--- a/dm/templates/nat_gateway/nat_gateway.py.schema
+++ b/dm/templates/nat_gateway/nat_gateway.py.schema
@@ -122,68 +122,67 @@ properties:
     maximum: 65535
 
 outputs:
-  properties:
-    natGateways:
-      type: array
-      description: |
-        The list of the NAT gateways created. For example, the output can be
-        referenced as:
-        $(ref.<my-natgateway>.natGateways.<natgatewaybasename>.externalIP).
-        Note that `natgatewaybasename` is the base instance name to use for
-        instances in the group, and is not the exact name for the deployed
-        instance. For example, if the `natgatewaybasename` value is `my-nat`,
-        the provisioned instance name could be `my-nat-xkje`.
-      items:
-        instanceGroupManagerName:
-          type: string
-          description: |
-            The name of the Instance Group Manager used for monitoring and
-            autohealing.
-        instanceGroupManagerSelflink:
-          type: string
-          description: The URI of the Instance Group Manager resource.
-        externalIP:
-          type: string
-          description: The external IP addresses set to the NAT gateway VM.
-        internalIP:
-          type: string
-          description: The internal IP addresses set to the NAT gateway VM.
-        instanceTemplateName:
-          type: string
-          description: |
-            The name of the Instance Template to be used by the Instance
-            Group Manager for monitoring and autohealing.
-        baseInstanceName:
-          type: string
-          description: The base instance name to use for instances in the group.
-        routeName:
-          type: string
-          description: |
-            The name of the route that forwards traffic through the NAT
-            gateways.
-        zones:
-          type: array
-          description: Zones where the NAT gateways are deployed for HA.
-      networkName:
-        type: string
-        description: The VPC network on which the NAT is performed.
-      subnetworkName:
-        type: string
-        description: The NAT'd subnet/IP range.
-      natGatewayTag:
-        type: string
-        description: The tag used to pin the NAT gateway VMs.
-      nattedVmTag:
-        type: string
-        description: The tag used for the internal VMs to be NAT'd.
-      region:
-        type: string
-        description: The region where the NAT gateways are deployed.
-      healthCheckName:
+  natGateways:
+    type: array
+    description: |
+      The list of the NAT gateways created. For example, the output can be
+      referenced as:
+      $(ref.<my-natgateway>.natGateways.<natgatewaybasename>.externalIP).
+      Note that `natgatewaybasename` is the base instance name to use for
+      instances in the group, and is not the exact name for the deployed
+      instance. For example, if the `natgatewaybasename` value is `my-nat`,
+      the provisioned instance name could be `my-nat-xkje`.
+    items:
+      instanceGroupManagerName:
         type: string
         description: |
-          The name of the healthCheck counter used by the Instance Group
-          Manager.
+          The name of the Instance Group Manager used for monitoring and
+          autohealing.
+      instanceGroupManagerSelflink:
+        type: string
+        description: The URI of the Instance Group Manager resource.
+      externalIP:
+        type: string
+        description: The external IP addresses set to the NAT gateway VM.
+      internalIP:
+        type: string
+        description: The internal IP addresses set to the NAT gateway VM.
+      instanceTemplateName:
+        type: string
+        description: |
+          The name of the Instance Template to be used by the Instance
+          Group Manager for monitoring and autohealing.
+      baseInstanceName:
+        type: string
+        description: The base instance name to use for instances in the group.
+      routeName:
+        type: string
+        description: |
+          The name of the route that forwards traffic through the NAT
+          gateways.
+      zones:
+        type: array
+        description: Zones where the NAT gateways are deployed for HA.
+    networkName:
+      type: string
+      description: The VPC network on which the NAT is performed.
+    subnetworkName:
+      type: string
+      description: The NAT'd subnet/IP range.
+    natGatewayTag:
+      type: string
+      description: The tag used to pin the NAT gateway VMs.
+    nattedVmTag:
+      type: string
+      description: The tag used for the internal VMs to be NAT'd.
+    region:
+      type: string
+      description: The region where the NAT gateways are deployed.
+    healthCheckName:
+      type: string
+      description: |
+        The name of the healthCheck counter used by the Instance Group
+        Manager.
 
 documentation:
   - templates/nat_gateway/README.md

--- a/dm/templates/network/network.py.schema
+++ b/dm/templates/network/network.py.schema
@@ -116,43 +116,42 @@ properties:
               - network
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The network resource name.
-    - selfLink:
-        type: string
-        description: The URI (SelfLink) of the network resource.
-    - subnetworks:
-      type: array
-      description: Array of subnetwork` information.
-      items:
-        description: |
-          The name of the subnetwork resource. For example, the output can be
-          referenced as: $(ref.<my-network>.subnetworks.<subnetwork-name>.selfLink)
-        patternProperties:
-          ".*":
-            type: object
-            description: Details for a subnetwork resource.
-            properties:
-              - selfLink:
-                  type: string
-                  description: The URI (SelfLink) of the subnet resource.
-              - region:
-                  type: string
-                  description: The name of the region where the subnetwork resides.
-              - network:
-                  type: string
-                  description: The URL of the network to which the subnetwork belongs.
-              - ipCidrRange:
-                  type: string
-                  description: |
-                    The range of internal addresses owned by the subnetwork.
-              - gatewayAddress:
-                  type: string
-                  description: |
-                    The gateway address for default routes to reach destination addresses
-                    outside this subnetwork.
+  name:
+    type: string
+    description: The network resource name.
+  selfLink:
+    type: string
+    description: The URI (SelfLink) of the network resource.
+  subnetworks:
+    type: array
+    description: Array of subnetwork` information.
+    items:
+      description: |
+        The name of the subnetwork resource. For example, the output can be
+        referenced as: $(ref.<my-network>.subnetworks.<subnetwork-name>.selfLink)
+      patternProperties:
+        ".*":
+          type: object
+          description: Details for a subnetwork resource.
+          properties:
+            - selfLink:
+                type: string
+                description: The URI (SelfLink) of the subnet resource.
+            - region:
+                type: string
+                description: The name of the region where the subnetwork resides.
+            - network:
+                type: string
+                description: The URL of the network to which the subnetwork belongs.
+            - ipCidrRange:
+                type: string
+                description: |
+                  The range of internal addresses owned by the subnetwork.
+            - gatewayAddress:
+                type: string
+                description: |
+                  The gateway address for default routes to reach destination addresses
+                  outside this subnetwork.
 
 documentation:
   - templates/network/README.md

--- a/dm/templates/network/subnetwork.py.schema
+++ b/dm/templates/network/subnetwork.py.schema
@@ -105,28 +105,27 @@ properties:
     description: If "true", enables flow logging for the subnetwork.
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The subnet resource name.
-    - selfLink:
-        type: string
-        description: The URI (SelfLink) of the subnet resource.
-    - region:
-        type: string
-        description: The name of the region where the subnetwork resides.
-    - network:
-        type: string
-        description: The URL of the network to which the subnetwork belongs.
-    - ipCidrRange:
-        type: string
-        description: |
-          The range of internal addresses owned by the subnetwork.
-    - gatewayAddress:
-        type: string
-        description: |
-          The gateway address for default routes to reach destination addresses
-          outside this subnetwork.
+  name:
+    type: string
+    description: The subnet resource name.
+  selfLink:
+    type: string
+    description: The URI (SelfLink) of the subnet resource.
+  region:
+    type: string
+    description: The name of the region where the subnetwork resides.
+  network:
+    type: string
+    description: The URL of the network to which the subnetwork belongs.
+  ipCidrRange:
+    type: string
+    description: |
+      The range of internal addresses owned by the subnetwork.
+  gatewayAddress:
+    type: string
+    description: |
+      The gateway address for default routes to reach destination addresses
+      outside this subnetwork.
 
 documentation:
   - templates/network/README.md

--- a/dm/templates/project/project.py.schema
+++ b/dm/templates/project/project.py.schema
@@ -324,28 +324,27 @@ properties:
       If this project is *NOT* a guest project, this value is ignored. 
 
 outputs:
-  properties:
-    - projectId:
-        type: string
-        description: The unique, user-assigned ID of the Project.
-    - projectNumber:
-        type: string
-        description: The number uniquely identifying the project.
-    - containerSA:
-        type: string
-        description: The built-in ServieAccount name for container services. (With 'śerviceAccount:' prefix.) ( Only exists if container.googleapis.com is enabled.)
-    - containerSADisplayName:
-        type: string
-        description: The built-in ServieAccount name for container services. ( Only exists if container.googleapis.com is enabled.)
-    - serviceAccountDisplayName:
-        type: string
-        description: Name of the default service account for the project.
-    - resources:
-        type: array
-        description: |
-          Names of the resources the template creates. This output can be used
-          by other templates for explicit waiting for all project configuration
-          steps to finish.
+  projectId:
+    type: string
+    description: The unique, user-assigned ID of the Project.
+  projectNumber:
+    type: string
+    description: The number uniquely identifying the project.
+  containerSA:
+    type: string
+    description: The built-in ServieAccount name for container services. (With 'śerviceAccount:' prefix.) ( Only exists if container.googleapis.com is enabled.)
+  containerSADisplayName:
+    type: string
+    description: The built-in ServieAccount name for container services. ( Only exists if container.googleapis.com is enabled.)
+  serviceAccountDisplayName:
+    type: string
+    description: Name of the default service account for the project.
+  resources:
+    type: array
+    description: |
+      Names of the resources the template creates. This output can be used
+      by other templates for explicit waiting for all project configuration
+      steps to finish.
 
 documentation:
   - templates/project/README.md

--- a/dm/templates/pubsub/pubsub.py.schema
+++ b/dm/templates/pubsub/pubsub.py.schema
@@ -194,13 +194,11 @@ properties:
                 of the associated resource, as well. If ttl is not set, the associated resource never expires.
 
                 A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
-        
 
 outputs:
-  properties:
-    - topicName:
-        type: string
-        description: The created topic's name.
+  topicName:
+    type: string
+    description: The created topic's name.
 
 documentation:
   - templates/pubsub/README.md

--- a/dm/templates/resource_policy/resource_policy.py.schema
+++ b/dm/templates/resource_policy/resource_policy.py.schema
@@ -214,10 +214,9 @@ schemas:
     type: object
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The resource policy name.
+  name:
+    type: string
+    description: The resource policy name.
 
 documentation:
   - templates/resource_policy/README.md

--- a/dm/templates/route/route.py.schema
+++ b/dm/templates/route/route.py.schema
@@ -59,20 +59,19 @@ properties:
         - destRange
 
 outputs:
-  properties:
-    routes:
-      type: array
-      description: Array of route information.
-      items:
-        description: |
-          The name of the firewall rule resource. For example, the output can
-          be referenced as: $(ref.<my-routes>.routes.<route-name>.selfLink)
-        patternProperties:
-          ".*":
-            type: object
-            description: |
-              Details for a route resource. Please check the outputs in
-              single_route.py.schema for details.
+  routes:
+    type: array
+    description: Array of route information.
+    items:
+      description: |
+        The name of the firewall rule resource. For example, the output can
+        be referenced as: $(ref.<my-routes>.routes.<route-name>.selfLink)
+      patternProperties:
+        ".*":
+          type: object
+          description: |
+            Details for a route resource. Please check the outputs in
+            single_route.py.schema for details.
 
 documentation:
   - templates/route/README.md

--- a/dm/templates/route/single_route.py.schema
+++ b/dm/templates/route/single_route.py.schema
@@ -230,10 +230,9 @@ properties:
             The region where the VPN tunnel resides.
 
 outputs:
-  properties:
-    selfLink:
-      type: string
-      description: The URI (SelfLink) of the firewall rule resource.
-    nextHopNetwork:
-      type: string
-      description: URL to a Network that should handle matching packets.
+  selfLink:
+    type: string
+    description: The URI (SelfLink) of the firewall rule resource.
+  nextHopNetwork:
+    type: string
+    description: URL to a Network that should handle matching packets.

--- a/dm/templates/runtime_config/variable.py.schema
+++ b/dm/templates/runtime_config/variable.py.schema
@@ -84,10 +84,9 @@ properties:
       A base64-encoded string.
 
 outputs:
-  properties:
-    - updateTime:
-        type: string
-        description: The time when the variable was last updated.
+  updateTime:
+    type: string
+    description: The time when the variable was last updated.
 
 documentation:
   - templates/runtime_config/README.md

--- a/dm/templates/runtime_config/waiter.py.schema
+++ b/dm/templates/runtime_config/waiter.py.schema
@@ -124,13 +124,12 @@ properties:
               this condition. If not specified, defaults to 1.
 
 outputs:
- properties:
-   - createTime:
-       type: string
-       description: |
-         The instant at which the waiter resource was created.
-         A timestamp in the RFC3339 UTC "Zulu" format, accurate to nanoseconds.
-         Example: "2014-10-02T15:01:23.045123456Z".
+  createTime:
+   type: string
+   description: |
+     The instant at which the waiter resource was created.
+     A timestamp in the RFC3339 UTC "Zulu" format, accurate to nanoseconds.
+     Example: "2014-10-02T15:01:23.045123456Z".
 
 documentation:
   - templates/runtime_config/README.md

--- a/dm/templates/shared_vpc_subnet_iam/shared_vpc_subnet_iam.py.schema
+++ b/dm/templates/shared_vpc_subnet_iam/shared_vpc_subnet_iam.py.schema
@@ -184,24 +184,23 @@ properties:
     $ref: '#/definitions/policy/properties/etag'
 
 outputs:
-  properties:
-    policies:
-      type: array
-      description: Array of IAM policy resource information.
-      items:
-        description: |
-          IAM policy resource name. Will be in the format
-          'iam-subnet-policy-<subnetId>'. For example, the output
-          can be referenced as:
-          $(ref.<my-policies>.policies.iam-subnet-policy-<subnet1>.selfLink)
-        patternProperties:
-          ".*":
-            type: object
-            description: Details for a subnetwork IAM policy.
-            properties:
-              etag:
-                type: string
-                description: The etag of the subnetwork's IAM policy.
+  policies:
+    type: array
+    description: Array of IAM policy resource information.
+    items:
+      description: |
+        IAM policy resource name. Will be in the format
+        'iam-subnet-policy-<subnetId>'. For example, the output
+        can be referenced as:
+        $(ref.<my-policies>.policies.iam-subnet-policy-<subnet1>.selfLink)
+      patternProperties:
+        ".*":
+          type: object
+          description: Details for a subnetwork IAM policy.
+          properties:
+            etag:
+              type: string
+              description: The etag of the subnetwork's IAM policy.
 
 documentation:
   - templates/shared_vpc_subnet_iam/README.md

--- a/dm/templates/ssl_certificate/ssl_certificate.py.schema
+++ b/dm/templates/ssl_certificate/ssl_certificate.py.schema
@@ -125,13 +125,12 @@ properties:
       If this flag is enabled, beta properties can be used and the beta type will be used.
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The resource name.
-    - selfLink:
-        type: string
-        description: The URI (SelfLink) of the SSL certificate resource.
+  name:
+    type: string
+    description: The resource name.
+  selfLink:
+    type: string
+    description: The URI (SelfLink) of the SSL certificate resource.
 
 documentation:
   - templates/ssl_certificate/README.md

--- a/dm/templates/stackdriver_metric_descriptor/stackdriver_metric_descriptor.py.schema
+++ b/dm/templates/stackdriver_metric_descriptor/stackdriver_metric_descriptor.py.schema
@@ -205,36 +205,35 @@ properties:
           https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration.
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The name of the Metric Descriptor.
-    - type:
-        type: string
-        description: The metric type as defined in the descriptor.
-    - labels:
-        type: array
-        description: List of the defined labels.
-        items:
-          type: string
-    - metricKind:
-        type: string
-        description: The metric kind as defined.
-    - valueType:
-        type: string
-        description: The measurement type (int, string, etc.).
-    - unit:
-        type: string
-        description: The unit in which the metric value is reported.
-    - description:
-        type: string
-        description: The metric description.
-    - displayName:
-        type: string
-        description: The display name of the metric.
-    - metadata:
-        type: object
-        description: Metadata associated with the metric.
+  name:
+    type: string
+    description: The name of the Metric Descriptor.
+  type:
+    type: string
+    description: The metric type as defined in the descriptor.
+  labels:
+    type: array
+    description: List of the defined labels.
+    items:
+      type: string
+  metricKind:
+    type: string
+    description: The metric kind as defined.
+  valueType:
+    type: string
+    description: The measurement type (int, string, etc.).
+  unit:
+    type: string
+    description: The unit in which the metric value is reported.
+  description:
+    type: string
+    description: The metric description.
+  displayName:
+    type: string
+    description: The display name of the metric.
+  metadata:
+    type: object
+    description: Metadata associated with the metric.
 
 documentation:
   - templates/stackdriver_metric_descriptor/README.md

--- a/dm/templates/stackdriver_notification_channels/stackdriver_notification_channels.py.schema
+++ b/dm/templates/stackdriver_notification_channels/stackdriver_notification_channels.py.schema
@@ -115,38 +115,37 @@ properties:
           type: string
           default: text/markdown
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The name of the Metric Descriptor.
-    - type:
-        type: string
-        description: The metric type as defined in the descriptor.
-    - labels:
-        type: array
-        description: List of the defined labels.
-        minItems: 0
-        items:
-          type: string
-    - metricKind:
-        type: string
-        description: The metric kind as defined.
-    - valueType:
-        type: string
-        description: The measurement type (int, string, etc.).
-    - unit:
-        type: string
-        description: The unit in which the metric value is reported.
-    - description:
-        type: string
-        description: The metric description.
-    - displayName:
-        type: string
-        description: The display name of the metric.
-    - metadata:
-        type: object
-        additionalProperties: false
-        description: Metadata associated with the metric.
+  name:
+    type: string
+    description: The name of the Metric Descriptor.
+  type:
+    type: string
+    description: The metric type as defined in the descriptor.
+  labels:
+    type: array
+    description: List of the defined labels.
+    minItems: 0
+    items:
+      type: string
+  metricKind:
+    type: string
+    description: The metric kind as defined.
+  valueType:
+    type: string
+    description: The measurement type (int, string, etc.).
+  unit:
+    type: string
+    description: The unit in which the metric value is reported.
+  description:
+    type: string
+    description: The metric description.
+  displayName:
+    type: string
+    description: The display name of the metric.
+  metadata:
+    type: object
+    additionalProperties: false
+    description: Metadata associated with the metric.
 
 documentation:
   - templates/stackdriver_metric_descriptor/README.md

--- a/dm/templates/target_proxy/target_proxy.py.schema
+++ b/dm/templates/target_proxy/target_proxy.py.schema
@@ -164,23 +164,22 @@ properties:
       - DISABLE
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The resource name.
-    - selfLink:
-        type: string
-        description: The URI (SelfLink) of the URL target proxy resource.
-    - kind:
-        type: string
-        description: The resource kind.
-    - certificateName:
-        type: string
-        description: The name of the SSL certificate, if one is to be created.
-    - certificateSelfLink:
-        type: string
-        description: |
-          The URI (SelfLink) of the SSL certificate, if one is to be created.
+  name:
+    type: string
+    description: The resource name.
+  selfLink:
+    type: string
+    description: The URI (SelfLink) of the URL target proxy resource.
+  kind:
+    type: string
+    description: The resource kind.
+  certificateName:
+    type: string
+    description: The name of the SSL certificate, if one is to be created.
+  certificateSelfLink:
+    type: string
+    description: |
+      The URI (SelfLink) of the SSL certificate, if one is to be created.
 
 documentation:
   - templates/target_proxy/README.md

--- a/dm/templates/unmanaged_instance_group/unmanaged_instance_group.py.schema
+++ b/dm/templates/unmanaged_instance_group/unmanaged_instance_group.py.schema
@@ -73,18 +73,18 @@ properties:
     type: string
     description: |
       The URL of the network to which all instances in the instance group belong.
+      
 outputs:
-  properties:
-    - selfLink:
-        type: string
-        description: The URL (SelfLink) of the unmanaged instance group resource.
-    - name:
-        type: string
-        description: The name of the unmanaged instance group resource.
-    - zone:
-        type: string
-        description: |
-          The name of the zone where the unmanaged instance group is located.
+  selfLink:
+    type: string
+    description: The URL (SelfLink) of the unmanaged instance group resource.
+  name:
+    type: string
+    description: The name of the unmanaged instance group resource.
+  zone:
+    type: string
+    description: |
+      The name of the zone where the unmanaged instance group is located.
 
 documentation:
   - templates/unmanaged_instance_group/README.md

--- a/dm/templates/url_map/url_map.py.schema
+++ b/dm/templates/url_map/url_map.py.schema
@@ -233,13 +233,12 @@ properties:
             to.
 
 outputs:
-  properties:
-    - name:
-        type: string
-        description: The resource name.
-    - selfLink:
-        type: string
-        description: The URI (SelfLink) of the URL map rule resource.
+  name:
+    type: string
+    description: The resource name.
+  selfLink:
+    type: string
+    description: The URI (SelfLink) of the URL map rule resource.
 
 documentation:
   - templates/url_map/README.md

--- a/dm/templates/vpn/vpn.py.schema
+++ b/dm/templates/vpn/vpn.py.schema
@@ -132,28 +132,27 @@ properties:
       IP address will be created.
 
 outputs:
-  properties:
-    - targetVpnGateway:
-        type: string
-        description: The name of the target VPN gateway resource.
-    - staticIp:
-        type: string
-        description: The name of the reserved address resource.
-    - espRule:
-        type: string
-        description: The name of the ForwardingRule resource for the ESP traffic.
-    - udp4500Rule:
-        type: string
-        description: The name of the ForwardingRule resource for the UDP 4500 traffic.
-    - udp500Rule:
-        type: string
-        description: The name of the ForwardingRule resource for the UDP 500 traffic.
-    - vpnTunnel:
-        type: string
-        description: The name of the VPN tunnel resource.
-    - vpnTunnelUri:
-        type: string
-        description: The URI of the VPN tunnel resource.
+  targetVpnGateway:
+    type: string
+    description: The name of the target VPN gateway resource.
+  staticIp:
+    type: string
+    description: The name of the reserved address resource.
+  espRule:
+    type: string
+    description: The name of the ForwardingRule resource for the ESP traffic.
+  udp4500Rule:
+    type: string
+    description: The name of the ForwardingRule resource for the UDP 4500 traffic.
+  udp500Rule:
+    type: string
+    description: The name of the ForwardingRule resource for the UDP 500 traffic.
+  vpnTunnel:
+    type: string
+    description: The name of the VPN tunnel resource.
+  vpnTunnelUri:
+    type: string
+    description: The URI of the VPN tunnel resource.
 
 documentation:
   - templates/vpn/README.md


### PR DESCRIPTION
The `outputs` section of the schema files had the output variables under `properties` incorrectly. Correcting this in all the schema files as per the [public doc](https://cloud.google.com/deployment-manager/docs/configuration/expose-information-outputs#describing_outputs_in_schemas). This hierarchy can also be confirmed by looking at the [configuration layout](https://cloud.google.com/deployment-manager/docs/configuration/expose-information-outputs#looking_up_final_output_values).