### PR TITLE
Add external data for testing with Terraform BigQuery module

### DIFF
--- a/infra/terraform/test-org/org/bigquery_external_data.tf
+++ b/infra/terraform/test-org/org/bigquery_external_data.tf
@@ -23,10 +23,10 @@ module "ci_bq_external_data_project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 4.0"
 
-  name       = "ci-bq-external-data-project"
-  project_id = "ci-bq-external-data-project"
+  name            = "ci-bq-external-data-project"
+  project_id      = "ci-bq-external-data-project"
   org_id          = local.org_id
-  folder_id = google_folder.ci_bq_external_data_folder.id
+  folder_id       = google_folder.ci_bq_external_data_folder.id
   billing_account = local.billing_account
 
   labels = {
@@ -39,7 +39,7 @@ module "ci_bq_external_data_project" {
 }
 
 resource "google_storage_bucket" "ci_bq_external_data_storage_bucket" {
-  name                        = "ci-bq-external-data"
+  name    = "ci-bq-external-data"
   project = module.ci_bq_external_data_project.project_id
 }
 

--- a/infra/terraform/test-org/org/bigquery_external_data.tf
+++ b/infra/terraform/test-org/org/bigquery_external_data.tf
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_folder" "ci_bq_external_data_folder" {
+  display_name = "ci-bq-external-data-folder"
+  parent       = "folders/${replace(local.folders["ci-projects"], "folders/", "")}"
+}
+
+module "ci_bq_external_data_project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 4.0"
+
+  name       = "ci-bq-external-data-project"
+  project_id = "ci-bq-external-data-project"
+  org_id          = local.org_id
+  folder_id = google_folder.ci_bq_external_data_folder.id
+  billing_account = local.billing_account
+
+  labels = {
+    cft-ci = "permanent"
+  }
+
+  activate_apis = [
+    "storage.googleapis.com",
+  ]
+}
+
+resource "google_storage_bucket" "ci_bq_external_data_storage_bucket" {
+  name                        = "ci-bq-external-data"
+  project = module.ci_bq_external_data_project.project_id
+}
+
+resource "google_storage_bucket_iam_member" "ci_bq_external_data_storage_bucket_member" {
+  bucket = google_storage_bucket.ci_bq_external_data_storage_bucket.name
+  role   = "roles/storage.legacyObjectReader"
+  member = "allUsers"
+}
+
+resource "google_storage_bucket_object" "ci_bq_external_csv_file" {
+  name   = "bigquery-external-table-test.csv"
+  source = "external_data/bigquery-external-table-test.csv"
+  bucket = google_storage_bucket.ci_bq_external_data_storage_bucket.name
+}
+
+resource "google_storage_bucket_object" "ci_bq_external_hive_file_foo" {
+  name   = "hive_partition_example/year=2012/foo.csv"
+  source = "external_data/foo.csv"
+  bucket = google_storage_bucket.ci_bq_external_data_storage_bucket.name
+}
+
+resource "google_storage_bucket_object" "ci_bq_external_hive_file_bar" {
+  name   = "hive_partition_example/year=2013/bar.csv"
+  source = "external_data/bar.csv"
+  bucket = google_storage_bucket.ci_bq_external_data_storage_bucket.name
+}

--- a/infra/terraform/test-org/org/external_data/bar.csv
+++ b/infra/terraform/test-org/org/external_data/bar.csv
@@ -1,0 +1,3 @@
+id,name,dept
+3,Amy,SC
+4,Jacob,SC

--- a/infra/terraform/test-org/org/external_data/bigquery-external-table-test.csv
+++ b/infra/terraform/test-org/org/external_data/bigquery-external-table-test.csv
@@ -1,0 +1,2 @@
+column_a,column_b
+foo,bar

--- a/infra/terraform/test-org/org/external_data/foo.csv
+++ b/infra/terraform/test-org/org/external_data/foo.csv
@@ -1,0 +1,3 @@
+id,name,dept
+1,Keith,TP
+2,Madeline,HR

--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -78,7 +78,7 @@ locals {
     "healthcare",
     "gke-gitlab",
     "example-foundation", # Not module
-    "anthos-platform",  # Not module
+    "anthos-platform",    # Not module
     "cloud-operations",
     "cloud-foundation-training", # Not module
     "cloud-router",

--- a/infra/terraform/test-org/org/outputs.tf
+++ b/infra/terraform/test-org/org/outputs.tf
@@ -58,3 +58,27 @@ output "ci_gsuite_sa_bucket" {
 output "ci_gsuite_sa_bucket_path" {
   value = google_storage_bucket_object.ci_gsuite_sa_json.name
 }
+
+output "ci_bq_external_data_folder_id" {
+  value = google_folder.ci_bq_external_data_folder.id
+}
+
+output "ci_bq_external_data_project_id" {
+  value = module.ci_bq_external_data_project.project_id
+}
+
+output "ci_bq_external_data_storage_bucket" {
+  value = google_storage_bucket.ci_bq_external_data_storage_bucket.name
+}
+
+output "ci_bq_external_csv_file" {
+  value = google_storage_bucket_object.ci_bq_external_csv_file.name
+}
+
+output "ci_bq_external_hive_file_foo" {
+  value = google_storage_bucket_object.ci_bq_external_hive_file_foo.name
+}
+
+output "ci_bq_external_hive_file_bar" {
+  value = google_storage_bucket_object.ci_bq_external_hive_file_bar.name
+}


### PR DESCRIPTION
This PR adds publicly accessible static files to be used in CI testing for the (terraform-google-bigquery)[https://github.com/terraform-google-modules/terraform-google-bigquery] module. The PR: https://github.com/terraform-google-modules/terraform-google-bigquery/pull/105 introduces a feature that allows provisioning external tables, and we want to ensure that we have proper integration testing in place for this feature. 

This PR creates a new project, bucket, bucket IAM member, and 3 bucket objects (all CSV files) that will be used in integration testing. 

I was pointed to this spot in this repository by @morgante who has reviewed my work. 

To develop this, I switched out the backend locally and applied the configuration to my own personal GCP project, and verified that the integration tests on the terraform-google-bigquery module passed when pointing at these files. 