### PR TITLE
fix: move helper config to build step

### DIFF
--- a/.github/workflows/build-push-cft-devtools.yml
+++ b/.github/workflows/build-push-cft-devtools.yml
@@ -24,9 +24,9 @@ jobs:
 
       - name: Build
         run: |-
+          gcloud auth configure-docker -q
           cd infra/build && make build-image-developer-tools
 
       - name: Push
         run: |-
-          gcloud auth configure-docker -q
           cd infra/build && make release-image-developer-tools


### PR DESCRIPTION
[Looks like](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/runs/2116609256?check_suite_focus=true#step:4:1449) for pulling `gcr.io/cloud-marketplace/google/ubuntu1804:latest`, we need to be authed. This moves the auth to build step.