### PR TITLE
fix: add action yaml to trigger

### DIFF
--- a/.github/workflows/build-push-cft-devtools.yml
+++ b/.github/workflows/build-push-cft-devtools.yml
@@ -1,10 +1,11 @@
 name: Build and push new dev tools image
 on:
   push:
-    branches: 
+    branches:
       - "master"
     paths:
       - "infra/build/**"
+      - ".github/workflows/build-push-cft-devtools.yml"
 env:
   PROJECT_ID: ${{ secrets.GCR_PROJECT_ID }}
 


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/pull/886 was not triggered as no changes were made to `"infra/build/**"`. This adds the action config to triggers.