### PR TITLE
feat: enable module tests on GoogleCloudPlatform org

### DIFF
--- a/infra/terraform/test-org/ci-triggers/locals.tf
+++ b/infra/terraform/test-org/ci-triggers/locals.tf
@@ -21,14 +21,18 @@ locals {
     "ci-projects",
     "ci-shared",
     "ci-anthos-platform",
-    "ci-example-foundation"
+    "ci-example-foundation",
+    "ci-gcp-example-foundation-app"
   ]
-  example_foundation                = { repo = "terraform-example-foundation", folder_id = replace(data.terraform_remote_state.org.outputs.folders["ci-example-foundation"], "folders/", "") }
+  gcp_org_prefix                    = "gcp-"
+  example_foundation                = { "terraform-example-foundation" = { folder_id = replace(data.terraform_remote_state.org.outputs.folders["ci-example-foundation"], "folders/", ""), gh_org = "terraform-google-modules" } }
+  example_foundation_app            = { "terraform-example-foundation-app" = { folder_id = replace(data.terraform_remote_state.org.outputs.folders["ci-gcp-example-foundation-app"], "folders/", ""), gh_org = "GoogleCloudPlatform" } }
   example_foundation_int_test_modes = ["default", "HubAndSpoke"]
   training_repos = [
     "ci-cloud-foundation-training"
   ]
-  repo_folder              = { for key, value in data.terraform_remote_state.org.outputs.folders : contains(local.training_repos, key) ? replace(key, "ci-", "") : replace(key, "ci-", "terraform-google-") => replace(value, "folders/", "") if ! contains(local.exclude_folders, key) }
+  repo_folder              = { for key, value in data.terraform_remote_state.org.outputs.folders : contains(local.training_repos, key) ? replace(key, "ci-", "") : replace(key, "ci-", "terraform-google-") => { "folder_id" = replace(value, "folders/", ""), "gh_org" = "terraform-google-modules" } if ! contains(local.exclude_folders, key) && ! (replace(key, local.gcp_org_prefix, "") != key) }
+  repo_folder_gcp_org      = merge({ for key, value in data.terraform_remote_state.org.outputs.folders : replace(key, "ci-gcp-", "terraform-google-") => { "folder_id" = replace(value, "folders/", ""), "gh_org" = "GoogleCloudPlatform" } if ! contains(local.exclude_folders, key) && replace(key, local.gcp_org_prefix, "") != key }, local.example_foundation_app)
   org_id                   = data.terraform_remote_state.org.outputs.org_id
   billing_account          = data.terraform_remote_state.org.outputs.billing_account
   tf_validator_project_id  = data.terraform_remote_state.tf-validator.outputs.project_id

--- a/infra/terraform/test-org/ci-triggers/outputs.tf
+++ b/infra/terraform/test-org/ci-triggers/outputs.tf
@@ -15,7 +15,11 @@
  */
 
 output "repo_folder" {
-  value = local.repo_folder
+  value = { for k, v in local.repo_folder : k => v.folder_id }
+}
+
+output "repo_folder_gcp_org" {
+  value = { for k, v in local.repo_folder_gcp_org : k => v.folder_id }
 }
 
 output "lint_triggers" {

--- a/infra/terraform/test-org/ci-triggers/triggers.tf
+++ b/infra/terraform/test-org/ci-triggers/triggers.tf
@@ -18,9 +18,9 @@ resource "google_cloudbuild_trigger" "lint_trigger" {
   provider    = google-beta
   project     = local.project_id
   description = "Lint tests on pull request for ${each.key}"
-  for_each    = merge(local.repo_folder, { "${local.example_foundation.repo}" = local.example_foundation.folder_id })
+  for_each    = merge(local.repo_folder, local.example_foundation, local.repo_folder_gcp_org)
   github {
-    owner = "terraform-google-modules"
+    owner = each.value.gh_org
     name  = each.key
     pull_request {
       branch = ".*"
@@ -34,9 +34,9 @@ resource "google_cloudbuild_trigger" "int_trigger" {
   provider    = google-beta
   project     = local.project_id
   description = "Integration tests on pull request for ${each.key}"
-  for_each    = local.repo_folder
+  for_each    = merge(local.repo_folder, local.repo_folder_gcp_org)
   github {
-    owner = "terraform-google-modules"
+    owner = each.value.gh_org
     name  = each.key
     pull_request {
       branch = ".*"
@@ -44,7 +44,7 @@ resource "google_cloudbuild_trigger" "int_trigger" {
   }
   substitutions = {
     _BILLING_ACCOUNT          = local.billing_account
-    _FOLDER_ID                = each.value
+    _FOLDER_ID                = each.value.folder_id
     _ORG_ID                   = local.org_id
     _BILLING_IAM_TEST_ACCOUNT = each.key == "terraform-google-iam" ? local.billing_iam_test_account : null
   }
@@ -146,15 +146,15 @@ resource "google_cloudbuild_trigger" "example_foundations_int_trigger" {
   description = "Integration tests on pull request for example_foundations in ${each.value} mode"
   for_each    = toset(local.example_foundation_int_test_modes)
   github {
-    owner = "terraform-google-modules"
-    name  = local.example_foundation.repo
+    owner = values(local.example_foundation)[0]["gh_org"]
+    name  = keys(local.example_foundation)[0]
     pull_request {
       branch = ".*"
     }
   }
   substitutions = {
     _BILLING_ACCOUNT               = local.billing_account
-    _FOLDER_ID                     = local.example_foundation.folder_id
+    _FOLDER_ID                     = values(local.example_foundation)[0]["folder_id"]
     _ORG_ID                        = local.org_id
     _EXAMPLE_FOUNDATIONS_TEST_MODE = each.value
   }

--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -83,5 +83,6 @@ locals {
     "cloud-foundation-training", # Not module
     "cloud-router",
     "group",
+    "gcp-example-foundation-app", # Not module, in GoogleCloudPlatform org
   ]
 }


### PR DESCRIPTION
Adds logic for enabling tests within `GoogleCloudPlatform` GH org. 

- Test folders created for these modules will be of the form `ci-gcp-${module-name}` which enabled us to distinguish between orgs.
- Adds https://github.com/GoogleCloudPlatform/terraform-example-foundation-app to tests (not a module)

- [x] Folder creation done (to test logic in `ci-triggers`)
- [ ] Apply ci-triggers TODO (Plan shows 2 to add, 0 to change, 0 to destroy as expected.)