### PR TITLE
Test stringViaJSON structure, not exact string

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/briandowns/spinner v1.6.1
 	github.com/forseti-security/config-validator v0.0.0-20200505040130-17dc60b21dc8
 	github.com/golang/protobuf v1.3.3
+	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/hashicorp/terraform v0.12.2 // indirect
 	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec
 	github.com/open-policy-agent/opa v0.17.2


### PR DESCRIPTION
In #902, I suggested eventually moving to protojson.

According to https://github.com/golang/protobuf/issues/1121#issuecomment-627554847, that library does not support a stable serialization output. That means that the test in proto_test.go would become flaky.

The suggestion there is "Instead of syntactically comparing the serialized form of a message, the test should semantically compare the structured form of a message", so I've done that here by loading the got and want strings as JSON and comparing the structured JSON.