### PR TITLE
fix: bump TF installer 

### DIFF
--- a/infra/build/developer-tools-light/Dockerfile
+++ b/infra/build/developer-tools-light/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 # Download and verify the integrity of the download first
 
-FROM sethvargo/hashicorp-installer:0.1.3 AS installer
+FROM sethvargo/hashicorp-installer:0.2.0 AS installer
 # Required to download and install Terraform
 ARG TERRAFORM_VERSION
 ENV TERRAFORM_VERSION ${TERRAFORM_VERSION}

--- a/infra/build/developer-tools/Dockerfile
+++ b/infra/build/developer-tools/Dockerfile
@@ -15,7 +15,7 @@
 ARG RUBY_VERSION
 ARG GOLANG_VERSION
 
-FROM sethvargo/hashicorp-installer:0.1.3 AS installer
+FROM sethvargo/hashicorp-installer:0.2.0 AS installer
 # Required to download and install Terraform
 ARG TERRAFORM_VERSION
 ENV TERRAFORM_VERSION ${TERRAFORM_VERSION}


### PR DESCRIPTION
bumps TF installer to newer image with new GPG key

https://discuss.hashicorp.com/t/terraform-updates-for-hcsec-2021-12/23570
https://github.com/sethvargo/hashicorp-installer/commit/8ce045027fcdeebd82e9b0a33026f717f3fadf8c