### PR TITLE
fix: remove tf-bundler, add caching

### DIFF
--- a/infra/build/developer-tools/Dockerfile
+++ b/infra/build/developer-tools/Dockerfile
@@ -21,15 +21,6 @@ ARG TERRAFORM_VERSION
 ENV TERRAFORM_VERSION ${TERRAFORM_VERSION}
 RUN /install-hashicorp-tool "terraform" "$TERRAFORM_VERSION"
 
-FROM golang:$GOLANG_VERSION-alpine AS terraform-bundle-builder
-# Builds terraform-bundle
-ARG TERRAFORM_VERSION
-ENV TERRAFORM_VERSION ${TERRAFORM_VERSION}
-RUN apk add git unzip
-RUN git clone --depth 1 --branch v"$TERRAFORM_VERSION" https://github.com/hashicorp/terraform && \
-    cd terraform/tools/terraform-bundle && \
-    go install .
-
 # Builds module-swapper
 FROM golang:$GOLANG_VERSION-alpine AS module-swapper-builder
 WORKDIR /go/src/github.com/GoogleCloudPlatform/infra/developer-tools/build/scripts/module-swapper
@@ -112,9 +103,6 @@ COPY --from=go /usr/local/go/ /usr/local/go/
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go
 RUN ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 
-# Installs terraform-bundler
-COPY --from=terraform-bundle-builder /go/bin/terraform-bundle /bin/terraform-bundle
-
 # Install module swapper
 COPY --from=module-swapper-builder /usr/local/bin/module-swapper /usr/local/bin/module-swapper
 
@@ -174,6 +162,10 @@ ADD ./build/scripts/gh_lint_comment.py /usr/local/bin/
 # Intended to help developers iterate quickly
 ADD ./build/home/bash_history /root/.bash_history
 ADD ./build/home/bashrc /root/.bashrc
+
+# Set TF cache dir
+ENV TF_PLUGIN_CACHE_DIR /workspace/test/integration/tmp/.terraform
+RUN mkdir -p ${TF_PLUGIN_CACHE_DIR}
 
 WORKDIR $WORKSPACE
 RUN terraform --version && \

--- a/infra/build/developer-tools/build/scripts/task_helper_functions.sh
+++ b/infra/build/developer-tools/build/scripts/task_helper_functions.sh
@@ -134,17 +134,6 @@ function check_terraform() {
   set -e
   local rval rc
   rval=0
-  # if bundler filer exists, download
-  BUNDLE=/workspace/test/bundle.hcl
-if [[ -f "$BUNDLE" ]]; then
-    echo "Attempting to download $BUNDLE bundle."
-    mkdir -p /tmp/bundler
-    pushd /tmp/bundler
-    terraform-bundle package -os=linux -arch=amd64 $BUNDLE
-    # -n so that unzip does not overwrite any existing files
-    unzip -n -d /usr/local/bin terraform_*.zip
-    popd
-fi
 
   # fmt is before validate for faster feedback, validate requires terraform
   # init which takes time.


### PR DESCRIPTION
fixes #934 

Tested lint check with [GKE module](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine)
Overall in time in serial ~50% improvement, parallel ~40% improvement.
Disk space savings of ~11GB

benchmarks:
with cache, in serial, 8m33.596s, ~ 700 MB on disk
no cache, in serial, 17m50.396s,  ~ 12 GB on disk
with cache, in parallel,  2m14.301s, ~ 700 MB on disk
without cache, in parallel,  6m11.804s, ~ 12 GB on disk
