### PR TITLE
Added cloud-run to gcp_org_modules trigger

### DIFF
--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -93,5 +93,6 @@ locals {
     "anthos-samples",
     "secure-cicd",
     "secured-data-warehouse",
+    "cloud-run",
   ]
 }


### PR DESCRIPTION
This pull request adds **`cloud-run`** to **`gcp_org_modules`** to generate the test build.

@bharathkkb 