### PR TITLE
fix(krm-test): add option for custom setters

### DIFF
--- a/infra/blueprint-test/examples/krm_blueprints_with_test/test/integration/vpc-example-custom/vpc_custom_test.go
+++ b/infra/blueprint-test/examples/krm_blueprints_with_test/test/integration/vpc-example-custom/vpc_custom_test.go
@@ -11,13 +11,15 @@ import (
 )
 
 func TestVPCCustomBlueprint(t *testing.T) {
+	networkName := "test-network"
 	networkBlueprint := krmt.NewKRMBlueprintTest(t,
 		krmt.WithUpdateCommit("2b93fd6d4f1a3eabdf4dfce05b93ccb1f9f671c5"),
+		krmt.WithSetters(map[string]string{"network-name": networkName}),
 	)
 	networkBlueprint.DefineVerify(
 		func(assert *assert.Assertions) {
 			networkBlueprint.DefaultVerify(assert)
-			op := gcloud.Run(t, fmt.Sprintf("compute networks describe custom-network --project %s", utils.ValFromEnv(t, "PROJECT_ID")))
+			op := gcloud.Run(t, fmt.Sprintf("compute networks describe %s --project %s", networkName, utils.ValFromEnv(t, "PROJECT_ID")))
 			assert.Equal("GLOBAL", op.Get("routingConfig.routingMode").String(), "should be GLOBAL")
 			assert.Equal("false", op.Get("autoCreateSubnetworks").String(), "autoCreateSubnetworks should not be enabled")
 		})

--- a/infra/blueprint-test/pkg/krmt/krm.go
+++ b/infra/blueprint-test/pkg/krmt/krm.go
@@ -78,6 +78,12 @@ func WithLogger(logger *logger.Logger) krmtOption {
 	}
 }
 
+func WithSetters(setters map[string]string) krmtOption {
+	return func(f *KRMBlueprintTest) {
+		f.setters = setters
+	}
+}
+
 // NewKRMBlueprintTest sets defaults, validates and returns a KRMBlueprintTest.
 func NewKRMBlueprintTest(t testing.TB, opts ...krmtOption) *KRMBlueprintTest {
 	krmt := &KRMBlueprintTest{


### PR DESCRIPTION
Exposes option for passing in additional setters to upsert. This is useful for global resources that require a random unique name.