### PR TITLE
Add Java compiled files and terraform lock file to the excluded list of files

### DIFF
--- a/infra/build/developer-tools/build/scripts/task_helper_functions.sh
+++ b/infra/build/developer-tools/build/scripts/task_helper_functions.sh
@@ -67,7 +67,9 @@ maketemp() {
 find_files() {
   local pth="$1" find_path_regex="(" exclude_dirs=( ".*/\.git"
     ".*/\.terraform"
+    ".*/\.terraform.lock.hcl"
     ".*/\.kitchen"
+    ".*/.*\.class"
     ".*/.*\.png"
     ".*/.*\.jpg"
     ".*/.*\.jpeg"


### PR DESCRIPTION
This PR adds Java compiled files ,`.class`, and terraform lock files,`.terraform.lock.hcl`, to the list of excluded files to be checked in the lint checks.

This is useful when running `make docker_test_lint` locally to stop false positives.