### PR TITLE
Add magic_modules service account to project perm list

### DIFF
--- a/infra/terraform/test-org/tf-validator/iam.tf
+++ b/infra/terraform/test-org/tf-validator/iam.tf
@@ -35,7 +35,7 @@ resource "google_project_iam_member" "kokoro_test_1" {
   member  = "serviceAccount:kokoro-trampoline@cloud-devrel-kokoro-resources.iam.gserviceaccount.com"
 }
 
-resource "google_project_iam_member" "magic_modules_cloudbuild_SA" {
+resource "google_project_iam_member" "magic_modules_cloudbuild_sa" {
   project = module.terraform_validator_test_project.project_id
   role    = "roles/editor"
   member  = "serviceAccount:2843445864@cloudbuild.gserviceaccount.com"

--- a/infra/terraform/test-org/tf-validator/iam.tf
+++ b/infra/terraform/test-org/tf-validator/iam.tf
@@ -34,3 +34,9 @@ resource "google_project_iam_member" "kokoro_test_1" {
   role    = "roles/editor"
   member  = "serviceAccount:kokoro-trampoline@cloud-devrel-kokoro-resources.iam.gserviceaccount.com"
 }
+
+resource "google_project_iam_member" "magic_modules_cloudbuild_SA" {
+  project = module.terraform_validator_test_project.project_id
+  role    = "roles/editor"
+  member  = "serviceAccount:2843445864@cloudbuild.gserviceaccount.com"
+}


### PR DESCRIPTION
In order to run tests during magic modules ci we need to add it's service account to the permissions list here.