### PR TITLE
chore: trigger CLI release job on workflow file changes

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -5,6 +5,7 @@ on:
       - "master"
     paths:
       - "cli/Makefile"
+      - ".github/workflows/release-cli.yml"
 env:
   CLI_BUCKET: gs://cft-cli
   RELEASE_URL: https://api.github.com/repos/GoogleCloudPlatform/cloud-foundation-toolkit/releases/latest


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/1009 release

This adds the workflow file to triggers for CLI build release. Since publish steps are gated by `if: env.LAST_VERSION != env.CURRENT_VERSION`, this should be no op when re run after a release.