### PR TITLE
fix: CLI release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: 'read'
+      contents: 'write'
       id-token: 'write'
 
     steps:


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/1031

In #1028, I restricted the permissions granted to GITHUB_TOKEN in workflows. After some debugging it seems like write [permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) are needed on `contents` to create a release.