### PR TITLE
chore: use correct version of go for CLI release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -21,6 +21,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '~1.16'
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'


### PR DESCRIPTION
Recent [release](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/runs/4887033451?check_suite_focus=true) failed due to old default go version in the runner. This sets up correct version similar to [test workflow](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/blob/0573029a7c8d7aaad072e2feccfef7645579ce64/.github/workflows/test-cli.yml#L35)