### PR TITLE
fix: pin gcloud to 375.0.0 to fix devtools build

### DIFF
--- a/.github/workflows/build-push-cft-devtools.yml
+++ b/.github/workflows/build-push-cft-devtools.yml
@@ -41,3 +41,16 @@ jobs:
       - name: Push
         run: |-
           cd infra/build && make release-image-developer-tools
+
+      - name: Open issue if failed
+        if: ${{ failure() }}
+        uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e
+        with:
+          script: |-
+              github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: 'build-push-dev-tools job failed',
+                  body: 'Logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+                  assignee: 'bharathkkb'
+                })

--- a/.github/workflows/test-cft-devtools.yml
+++ b/.github/workflows/test-cft-devtools.yml
@@ -1,0 +1,24 @@
+name: Test devtools image build
+on:
+  pull_request:
+    branches:
+      - "master"
+    paths:
+      - "infra/build/**"
+      - ".github/workflows/test-cft-devtools.yml"
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  build-dev-tools:
+    name: Build CFT dev tools image
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build
+        run: |-
+          cd infra/build && make build-image-developer-tools

--- a/infra/build/Makefile
+++ b/infra/build/Makefile
@@ -46,7 +46,7 @@ REGISTRY_URL := gcr.io/cloud-foundation-cicd
 .PHONY: build-image-developer-tools
 build-image-developer-tools:
 	docker build \
-		--build-arg CLOUD_SDK_VERSION=${CLOUD_SDK_VERSION} \
+		--build-arg CLOUD_SDK_VERSION=375.0.0 \
 		--build-arg GSUITE_PROVIDER_VERSION=${GSUITE_PROVIDER_VERSION} \
 		--build-arg TERRAFORM_VERSION=${TERRAFORM_VERSION} \
 		--build-arg TERRAFORM_VALIDATOR_VERSION=${TERRAFORM_VALIDATOR_VERSION} \

--- a/infra/build/Makefile
+++ b/infra/build/Makefile
@@ -45,6 +45,7 @@ REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
 .PHONY: build-image-developer-tools
 build-image-developer-tools:
+	# TODO(bharathkkb): unpin gcloud version after https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/1095 is resolved
 	docker build \
 		--build-arg CLOUD_SDK_VERSION=375.0.0 \
 		--build-arg GSUITE_PROVIDER_VERSION=${GSUITE_PROVIDER_VERSION} \


### PR DESCRIPTION
- workaround for https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/1095 by pinning gcloud to last known working version 375.0.0
- fixes https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/1096 by adding a job to test build in PR and adding a step for opening an issue for failed builds on main 
