### PR TITLE
feat: add experimental convert command for cli test

### DIFF
--- a/cli/bptest/cmd.go
+++ b/cli/bptest/cmd.go
@@ -108,6 +108,6 @@ var convertCmd = &cobra.Command{
 
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return convert()
+		return convertKitchenTests()
 	},
 }

--- a/cli/bptest/cmd.go
+++ b/cli/bptest/cmd.go
@@ -18,6 +18,7 @@ func init() {
 	viper.AutomaticEnv()
 	Cmd.AddCommand(listCmd)
 	Cmd.AddCommand(runCmd)
+	Cmd.AddCommand(convertCmd)
 
 	Cmd.PersistentFlags().StringVar(&flags.testDir, "test-dir", "", "Path to directory containing integration tests (default is computed by scanning current working directory)")
 	runCmd.Flags().StringVar(&flags.testStage, "stage", "", "Test stage to execute (default is running all stages in order - init, apply, verify, teardown)")
@@ -97,5 +98,16 @@ var runCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		return nil
+	},
+}
+
+var convertCmd = &cobra.Command{
+	Use:   "convert",
+	Short: "convert kitchen tests (experimental)",
+	Long:  "Convert all kitchen tests to blueprint tests (experimental)",
+
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return convert()
 	},
 }

--- a/cli/bptest/convert.go
+++ b/cli/bptest/convert.go
@@ -1,0 +1,186 @@
+package bptest
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/iancoleman/strcase"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	intTestPath      = "test/integration"
+	inspecInputsFile = "inspec.yml"
+	discoverTest     = `package test
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+)
+
+func TestAll(t *testing.T) {
+	tft.AutoDiscoverAndTest(t)
+}`
+)
+
+func getCurrentTestDirs() ([]string, error) {
+	files, err := ioutil.ReadDir(intTestPath)
+	if err != nil {
+		return nil, err
+	}
+	var dirs []string
+	for _, f := range files {
+		if f.IsDir() {
+			dirs = append(dirs, f.Name())
+		}
+	}
+	return dirs, nil
+}
+
+type inspecInputs struct {
+	Name       string `yaml:"name"`
+	Attributes []struct {
+		Name string `yaml:"name"`
+	} `yaml:"attributes"`
+}
+
+func convertTest(dir string) error {
+	// read inspec.yaml
+	f, err := ioutil.ReadFile(path.Join(dir, inspecInputsFile))
+	if err != nil {
+		return err
+	}
+	var inspec inspecInputs
+	err = yaml.Unmarshal(f, &inspec)
+	if err != nil {
+		return err
+	}
+
+	// get inputs
+	var inputs []string
+	for _, i := range inspec.Attributes {
+		inputs = append(inputs, i.Name)
+	}
+
+	// get bpt skeleton
+	testName := path.Base(dir)
+	bpTest, err := getBPTestTmpl(testName, inputs)
+	if err != nil {
+		return err
+	}
+	// remove old test
+	err = os.RemoveAll(dir)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(dir, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	// write bpt
+	err = ioutil.WriteFile(path.Join(dir, fmt.Sprintf("%s_test.go", strcase.ToSnake(testName))), []byte(bpTest), os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func getBPTestTmpl(testName string, inputs []string) (string, error) {
+	pkgName := strcase.ToSnake(testName)
+	fnName := fmt.Sprintf("Test%s", strcase.ToCamel(testName))
+	tmpl := `package {{.PkgName}}
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/stretchr/testify/assert"
+)
+
+func {{.FnName}}(t *testing.T) {
+	bpt := tft.NewTFBlueprintTest(t)
+
+	bpt.DefineVerify(func(assert *assert.Assertions) {
+		bpt.DefaultVerify(assert)
+		{{range .Inputs}}
+		{{toLowerCamel .}} := bpt.GetStringOutput("{{.}}"){{end}}
+
+		op := gcloud.Run(t,"")
+		assert.Contains(op.Get("result").String(), randomFileString, "contains random string")
+	})
+
+	bpt.Test()
+}`
+	t, err := template.New("test").Funcs(template.FuncMap{"toLowerCamel": strcase.ToLowerCamel}).Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+	var tpl bytes.Buffer
+	err = t.Execute(&tpl, struct {
+		PkgName string
+		FnName  string
+		Inputs  []string
+	}{
+		PkgName: pkgName,
+		FnName:  fnName,
+		Inputs:  inputs,
+	},
+	)
+	if err != nil {
+		return "", err
+	}
+	return tpl.String(), nil
+}
+
+func getGoMod(dir string) string {
+	return fmt.Sprintf(`module github.com/terraform-google-modules/%s/test/integration
+
+go 1.16
+
+require (
+	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.0.0-20220203183701-08c972c3768c
+	github.com/gruntwork-io/terratest v0.35.6 // indirect
+	github.com/stretchr/testify v1.7.0
+)
+`, path.Base(dir))
+}
+
+func writeFile(p string, content string) error {
+	return ioutil.WriteFile(path.Join(intTestPath, p), []byte(content), os.ModePerm)
+}
+
+func convert() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	currentMod := path.Base(cwd)
+	// write go mod
+	err = writeFile("go.mod", getGoMod(currentMod))
+	if err != nil {
+		return err
+	}
+	// write discover test
+	err = writeFile("discover_test.go", discoverTest)
+	if err != nil {
+		return err
+	}
+	testDirs, err := getCurrentTestDirs()
+	if err != nil {
+		return err
+	}
+	for _, dir := range testDirs {
+		err = convertTest(path.Join(intTestPath, dir))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cli/bptest/convert.go
+++ b/cli/bptest/convert.go
@@ -211,7 +211,7 @@ require (
 `, path.Base(dir))
 }
 
-// writeFile writes content to  file p
+// writeFile writes content to file path
 func writeFile(p string, content string) error {
 	return ioutil.WriteFile(p, []byte(content), os.ModePerm)
 }

--- a/cli/bptest/convert.go
+++ b/cli/bptest/convert.go
@@ -2,20 +2,24 @@ package bptest
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/iancoleman/strcase"
-	"gopkg.in/yaml.v2"
+	cb "google.golang.org/api/cloudbuild/v1"
+	"sigs.k8s.io/yaml"
 )
 
 const (
-	intTestPath      = "test/integration"
-	inspecInputsFile = "inspec.yml"
-	discoverTest     = `package test
+	intTestPath          = "test/integration"
+	intTestBuildFilePath = "build/int.cloudbuild.yaml"
+	inspecInputsFile     = "inspec.yml"
+	discoverTest         = `package test
 
 import (
 	"testing"
@@ -28,6 +32,67 @@ func TestAll(t *testing.T) {
 }`
 )
 
+var kitchenCFTStageMapping = map[string]string{
+	"create":   stages[0],
+	"converge": stages[1],
+	"verify":   stages[2],
+	"destroy":  stages[3],
+}
+
+type inspecInputs struct {
+	Name       string `yaml:"name"`
+	Attributes []struct {
+		Name string `yaml:"name"`
+	} `yaml:"attributes"`
+}
+
+// convertKitchenTests converts all kitchen tests to blueprint tests and updates build files
+func convertKitchenTests() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	currentMod := path.Base(cwd)
+	// write go mod
+	err = writeFile(path.Join(intTestPath, "go.mod"), getGoMod(currentMod))
+	if err != nil {
+		return fmt.Errorf("error writing go mod file: %v", err)
+	}
+	// write discover test
+	err = writeFile(path.Join(intTestPath, "discover_test.go"), discoverTest)
+	if err != nil {
+		return fmt.Errorf("error writing discover_test.go: %v", err)
+	}
+	testDirs, err := getCurrentTestDirs()
+	if err != nil {
+		return fmt.Errorf("error getting current test dirs: %v", err)
+	}
+	for _, dir := range testDirs {
+		err = convertTest(path.Join(intTestPath, dir))
+		if err != nil {
+			return fmt.Errorf("error converting %s: %v", dir, err)
+		}
+	}
+	// remove kitchen
+	err = os.Remove(".kitchen.yml")
+	if err != nil {
+		return fmt.Errorf("error removing .kitchen.yml: %v", err)
+	}
+	// convert build file
+	// We use build to identify commands to update and update the commands in the buildFile.
+	// This minimizes unnecessary diffs in build yaml due to round tripping.
+	build, buildFile, err := getBuildFromFile(intTestBuildFilePath)
+	if err != nil {
+		return fmt.Errorf("error unmarshalling %s: %v", intTestBuildFilePath, err)
+	}
+	newBuildFile, err := transformBuild(build, buildFile)
+	if err != nil {
+		return fmt.Errorf("error transforming buildfile: %v", err)
+	}
+	return writeFile(intTestBuildFilePath, newBuildFile)
+}
+
+// getCurrentTestDirs returns current test dirs in intTestPath
 func getCurrentTestDirs() ([]string, error) {
 	files, err := ioutil.ReadDir(intTestPath)
 	if err != nil {
@@ -42,57 +107,51 @@ func getCurrentTestDirs() ([]string, error) {
 	return dirs, nil
 }
 
-type inspecInputs struct {
-	Name       string `yaml:"name"`
-	Attributes []struct {
-		Name string `yaml:"name"`
-	} `yaml:"attributes"`
-}
-
+// convertTest converts a kitchen test in dir to blueprint test
 func convertTest(dir string) error {
 	// read inspec.yaml
 	f, err := ioutil.ReadFile(path.Join(dir, inspecInputsFile))
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading inspec file: %s", err)
 	}
 	var inspec inspecInputs
 	err = yaml.Unmarshal(f, &inspec)
 	if err != nil {
-		return err
+		return fmt.Errorf("error unmarshalling inspec file: %s", err)
 	}
-
-	// get inputs
+	// get inspec input attributes
 	var inputs []string
 	for _, i := range inspec.Attributes {
 		inputs = append(inputs, i.Name)
 	}
-
 	// get bpt skeleton
 	testName := path.Base(dir)
-	bpTest, err := getBPTestTmpl(testName, inputs)
+	bpTest, err := getBPTestFromTmpl(testName, inputs)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating blueprint test: %s", err)
 	}
 	// remove old test
 	err = os.RemoveAll(dir)
 	if err != nil {
-		return err
-	}
-	err = os.MkdirAll(dir, os.ModePerm)
-	if err != nil {
-		return err
+		return fmt.Errorf("error removing old test dir: %s", err)
 	}
 	// write bpt
-	err = ioutil.WriteFile(path.Join(dir, fmt.Sprintf("%s_test.go", strcase.ToSnake(testName))), []byte(bpTest), os.ModePerm)
+	err = os.MkdirAll(dir, os.ModePerm)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating test dir: %s", err)
 	}
-	return nil
+	return writeFile(path.Join(dir, fmt.Sprintf("%s_test.go", strcase.ToSnake(testName))), bpTest)
 }
 
-func getBPTestTmpl(testName string, inputs []string) (string, error) {
+// getTestFnName returns the go test function name
+func getTestFnName(name string) string {
+	return fmt.Sprintf("Test%s", strcase.ToCamel(name))
+}
+
+// getBPTestFromTmpl returns a skeleton blueprint test
+func getBPTestFromTmpl(testName string, inputs []string) (string, error) {
 	pkgName := strcase.ToSnake(testName)
-	fnName := fmt.Sprintf("Test%s", strcase.ToCamel(testName))
+	fnName := getTestFnName(testName)
 	tmpl := `package {{.PkgName}}
 
 import (
@@ -113,7 +172,7 @@ func {{.FnName}}(t *testing.T) {
 		{{toLowerCamel .}} := bpt.GetStringOutput("{{.}}"){{end}}
 
 		op := gcloud.Run(t,"")
-		assert.Contains(op.Get("result").String(), randomFileString, "contains random string")
+		assert.Contains(op.Get("result").String(), "foo", "contains foo")
 	})
 
 	bpt.Test()
@@ -139,48 +198,84 @@ func {{.FnName}}(t *testing.T) {
 	return tpl.String(), nil
 }
 
+// getGoMod returns a go mod file contents
 func getGoMod(dir string) string {
 	return fmt.Sprintf(`module github.com/terraform-google-modules/%s/test/integration
 
 go 1.16
 
 require (
-	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.0.0-20220203183701-08c972c3768c
-	github.com/gruntwork-io/terratest v0.35.6 // indirect
+	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.0.0-20220317050137-1c8897fbd42c
 	github.com/stretchr/testify v1.7.0
 )
 `, path.Base(dir))
 }
 
+// writeFile writes content to  file p
 func writeFile(p string, content string) error {
-	return ioutil.WriteFile(path.Join(intTestPath, p), []byte(content), os.ModePerm)
+	return ioutil.WriteFile(p, []byte(content), os.ModePerm)
 }
 
-func convert() error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	currentMod := path.Base(cwd)
-	// write go mod
-	err = writeFile("go.mod", getGoMod(currentMod))
-	if err != nil {
-		return err
-	}
-	// write discover test
-	err = writeFile("discover_test.go", discoverTest)
-	if err != nil {
-		return err
-	}
-	testDirs, err := getCurrentTestDirs()
-	if err != nil {
-		return err
-	}
-	for _, dir := range testDirs {
-		err = convertTest(path.Join(intTestPath, dir))
-		if err != nil {
-			return err
+// transformBuild transforms cloudbuild file contents with kitchen commands to CFT cli commands
+func transformBuild(b *cb.Build, f string) (string, error) {
+	for _, step := range b.Steps {
+		// test commands have at least two args
+		if len(step.Args) < 2 {
+			continue
 		}
+		cmd := step.Args[len(step.Args)-1]
+		// skip if not a kitchen command
+		hasKitchenCmd := strings.Index(cmd, "kitchen_do")
+		if hasKitchenCmd == -1 {
+			continue
+		}
+		kitchenCmd := cmd[hasKitchenCmd:]
+		newCmd, err := getCFTCmd(kitchenCmd)
+		if err != nil {
+			return "", err
+		}
+		f = strings.ReplaceAll(f, cmd, newCmd)
 	}
-	return nil
+	return f, nil
+}
+
+// getCFTCmd returns an equivalent CFT command for a kitchen command
+func getCFTCmd(kitchenCmd string) (string, error) {
+	if !strings.Contains(kitchenCmd, "kitchen_do") {
+		return "", fmt.Errorf("invalid kitchen command: %s", kitchenCmd)
+	}
+	cmdArr := strings.Split(kitchenCmd, " ")
+	cftCmd := []string{"cft", "test", "run"}
+	// cmd of form kitchen_do verb
+	if len(cmdArr) == 2 {
+		kitchenStage := cmdArr[len(cmdArr)-1]
+		cftCmd = append(cftCmd, []string{"all", "--stage", kitchenCFTStageMapping[kitchenStage]}...)
+	} else if len(cmdArr) == 3 {
+		// cmd of form kitchen_do verb test-name
+		kitchenTestName := cmdArr[len(cmdArr)-1]
+		kitchenStage := cmdArr[len(cmdArr)-2]
+		cftTestName := getTestFnName(strings.TrimSuffix(kitchenTestName, "-local"))
+		cftCmd = append(cftCmd, []string{cftTestName, "--stage", kitchenCFTStageMapping[kitchenStage]}...)
+	} else {
+		return "", fmt.Errorf("unknown kitchen command: %s", kitchenCmd)
+	}
+	cftCmd = append(cftCmd, "--verbose")
+	return strings.Join(cftCmd, " "), nil
+}
+
+// getBuildFromFile unmarshalls a cloudbuild file
+func getBuildFromFile(fp string) (*cb.Build, string, error) {
+	f, err := ioutil.ReadFile(fp)
+	if err != nil {
+		return nil, "", err
+	}
+	j, err := yaml.YAMLToJSON(f)
+	if err != nil {
+		return nil, "", err
+	}
+	var b cb.Build
+	if err = json.Unmarshal(j, &b); err != nil {
+		fmt.Println(err.Error())
+	}
+	return &b, string(f), nil
 }

--- a/cli/bptest/convert_test.go
+++ b/cli/bptest/convert_test.go
@@ -1,0 +1,160 @@
+package bptest
+
+import (
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"github.com/otiai10/copy"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	cbTestDataDir   = "testdata/cb"
+	kitchenTestData = "testdata/kitchen-tests"
+)
+
+func TestGetCFTCmd(t *testing.T) {
+	tests := []struct {
+		name       string
+		kitchenCmd string
+		want       string
+		errMsg     string
+	}{
+		{
+			name:       "simple",
+			kitchenCmd: "kitchen_do create",
+			want:       "cft test run all --stage init --verbose",
+		},
+		{
+			name:       "explicit test",
+			kitchenCmd: "kitchen_do converge foo",
+			want:       "cft test run TestFoo --stage apply --verbose",
+		},
+		{
+			name:       "not kitchen",
+			kitchenCmd: "foo verify bar",
+			errMsg:     "invalid kitchen command: foo verify bar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			got, err := getCFTCmd(tt.kitchenCmd)
+			if tt.errMsg != "" {
+				assert.NotNil(err)
+				assert.Contains(err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(err)
+				assert.Equal(tt.want, got)
+			}
+		})
+	}
+}
+
+func TestTransformBuild(t *testing.T) {
+	tests := []struct {
+		name   string
+		fp     string
+		wantFp string
+		errMsg string
+	}{
+		{
+			name:   "simple",
+			fp:     path.Join(cbTestDataDir, "oldAll.yaml"),
+			wantFp: path.Join(cbTestDataDir, "newAll.yaml"),
+		},
+		{
+			name:   "targeted",
+			fp:     path.Join(cbTestDataDir, "oldTarget.yaml"),
+			wantFp: path.Join(cbTestDataDir, "newTarget.yaml"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			b, bf, err := getBuildFromFile(tt.fp)
+			assert.NoError(err)
+			gotBf, err := transformBuild(b, bf)
+			if tt.errMsg != "" {
+				assert.NotNil(err)
+				assert.Contains(err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(err)
+				_, wbf, err := getBuildFromFile(tt.wantFp)
+				assert.NoError(err)
+				assert.Equal(wbf, gotBf)
+			}
+		})
+	}
+}
+
+func TestConvertTest(t *testing.T) {
+	tests := []struct {
+		name                  string
+		dir                   string
+		expectedFilesContents map[string]string
+		errMsg                string
+	}{
+		{
+			name: "simple",
+			dir:  "simple-example",
+			expectedFilesContents: map[string]string{"simple_example_test.go": `package simple_example
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimpleExample(t *testing.T) {
+	bpt := tft.NewTFBlueprintTest(t)
+
+	bpt.DefineVerify(func(assert *assert.Assertions) {
+		bpt.DefaultVerify(assert)
+		
+		projectId := bpt.GetStringOutput("project_id")
+		location := bpt.GetStringOutput("location")
+		clusterName := bpt.GetStringOutput("cluster_name")
+		masterKubernetesVersion := bpt.GetStringOutput("master_kubernetes_version")
+		kubernetesEndpoint := bpt.GetStringOutput("kubernetes_endpoint")
+		clientToken := bpt.GetStringOutput("client_token")
+		serviceAccount := bpt.GetStringOutput("service_account")
+		serviceAccount := bpt.GetStringOutput("service_account")
+		databaseEncryptionKeyName := bpt.GetStringOutput("database_encryption_key_name")
+		identityNamespace := bpt.GetStringOutput("identity_namespace")
+
+		op := gcloud.Run(t,"")
+		assert.Contains(op.Get("result").String(), "foo", "contains foo")
+	})
+
+	bpt.Test()
+}`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			tmpDir := path.Join(t.TempDir(), tt.dir)
+			err := copy.Copy(path.Join(kitchenTestData, tt.dir), tmpDir)
+			assert.NoError(err)
+			err = convertTest(tmpDir)
+			if tt.errMsg != "" {
+				assert.NotNil(err)
+				assert.Contains(err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(err)
+				for name, expectedContent := range tt.expectedFilesContents {
+					pth := path.Join(tmpDir, name)
+					assert.FileExists(pth)
+					gotContents, err := ioutil.ReadFile(pth)
+					assert.NoError(err)
+					assert.Equal(expectedContent, string(gotContents))
+				}
+			}
+		})
+	}
+}

--- a/cli/bptest/convert_test.go
+++ b/cli/bptest/convert_test.go
@@ -132,7 +132,8 @@ func TestSimpleExample(t *testing.T) {
 	})
 
 	bpt.Test()
-}`},
+}
+`},
 		},
 	}
 	for _, tt := range tests {

--- a/cli/bptest/templates/blueprint_test.go.tmpl
+++ b/cli/bptest/templates/blueprint_test.go.tmpl
@@ -1,0 +1,25 @@
+package {{.PkgName}}
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/stretchr/testify/assert"
+)
+
+func {{.FnName}}(t *testing.T) {
+	bpt := tft.NewTFBlueprintTest(t)
+
+	bpt.DefineVerify(func(assert *assert.Assertions) {
+		bpt.DefaultVerify(assert)
+		{{range .Inputs}}
+		{{toLowerCamel .}} := bpt.GetStringOutput("{{.}}"){{end}}
+
+		op := gcloud.Run(t,"")
+		assert.Contains(op.Get("result").String(), "foo", "contains foo")
+	})
+
+	bpt.Test()
+}

--- a/cli/bptest/templates/discover_test.go.tmpl
+++ b/cli/bptest/templates/discover_test.go.tmpl
@@ -1,0 +1,11 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+)
+
+func TestAll(t *testing.T) {
+	tft.AutoDiscoverAndTest(t)
+}

--- a/cli/bptest/templates/go.mod.tmpl
+++ b/cli/bptest/templates/go.mod.tmpl
@@ -1,0 +1,8 @@
+module github.com/terraform-google-modules/%s/test/integration
+
+go 1.16
+
+require (
+	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test v0.0.0-20220317050137-1c8897fbd42c
+	github.com/stretchr/testify v1.7.0
+)

--- a/cli/bptest/testdata/cb/newAll.yaml
+++ b/cli/bptest/testdata/cb/newAll.yaml
@@ -1,0 +1,41 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 3600s
+steps:
+- id: prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment']
+  env:
+  - 'TF_VAR_org_id=$_ORG_ID'
+  - 'TF_VAR_folder_id=$_FOLDER_ID'
+  - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
+- id: create
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run all --stage init --verbose']
+- id: converge
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run all --stage apply --verbose']
+- id: verify
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run all --stage verify --verbose']
+- id: destroy
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run all --stage teardown --verbose']
+tags:
+- 'ci'
+- 'integration'
+substitutions:
+  _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'

--- a/cli/bptest/testdata/cb/newTarget.yaml
+++ b/cli/bptest/testdata/cb/newTarget.yaml
@@ -1,0 +1,369 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 12600s
+steps:
+- id: download acm
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && download_acm']
+- id: prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment && chmod 600 /builder/home/.netrc && sleep 120']
+  env:
+  - 'TF_VAR_org_id=$_ORG_ID'
+  - 'TF_VAR_folder_id=$_FOLDER_ID'
+  - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
+- id: create all
+  waitFor:
+    - prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run all --stage init --verbose']
+- id: converge disable-client-cert-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestDisableClientCert --stage apply --verbose']
+- id: verify disable-client-cert-local
+  waitFor:
+    - converge disable-client-cert-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestDisableClientCert --stage verify --verbose']
+- id: destroy disable-client-cert-local
+  waitFor:
+    - verify disable-client-cert-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestDisableClientCert --stage teardown --verbose']
+- id: converge shared-vpc-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSharedVpc --stage apply --verbose']
+- id: verify shared-vpc-local
+  waitFor:
+    - converge shared-vpc-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSharedVpc --stage verify --verbose']
+- id: destroy shared-vpc-local
+  waitFor:
+    - verify shared-vpc-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSharedVpc --stage teardown --verbose']
+- id: converge safer-cluster-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSaferCluster --stage apply --verbose']
+- id: verify safer-cluster-local
+  waitFor:
+    - converge safer-cluster-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSaferCluster --stage verify --verbose']
+- id: destroy safer-cluster-local
+  waitFor:
+    - verify safer-cluster-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSaferCluster --stage teardown --verbose']
+- id: converge simple-regional-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleRegional --stage apply --verbose']
+- id: verify simple-regional-local
+  waitFor:
+    - converge simple-regional-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleRegional --stage verify --verbose']
+- id: destroy simple-regional-local
+  waitFor:
+    - verify simple-regional-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleRegional --stage teardown --verbose']
+- id: converge simple-regional-private-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleRegionalPrivate --stage apply --verbose']
+- id: verify simple-regional-private-local
+  waitFor:
+    - converge simple-regional-private-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleRegionalPrivate --stage verify --verbose']
+- id: destroy simple-regional-private-local
+  waitFor:
+    - verify simple-regional-private-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleRegionalPrivate --stage teardown --verbose']
+- id: converge simple-regional-with-kubeconfig-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleRegionalWithKubeconfig --stage apply --verbose']
+- id: verify simple-regional-with-kubeconfig-local
+  waitFor:
+    - converge simple-regional-with-kubeconfig-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleRegionalWithKubeconfig --stage verify --verbose']
+- id: destroy simple-regional-with-kubeconfig-local
+  waitFor:
+    - verify simple-regional-with-kubeconfig-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleRegionalWithKubeconfig --stage teardown --verbose']
+- id: converge simple-regional-with-networking-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleRegionalWithNetworking --stage apply --verbose']
+- id: verify simple-regional-with-networking-local
+  waitFor:
+    - converge simple-regional-with-networking-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleRegionalWithNetworking --stage verify --verbose']
+- id: destroy simple-regional-with-networking-local
+  waitFor:
+    - verify simple-regional-with-networking-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleRegionalWithNetworking --stage teardown --verbose']
+- id: converge simple-zonal-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleZonal --stage apply --verbose']
+- id: verify simple-zonal-local
+  waitFor:
+    - converge simple-zonal-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleZonal --stage verify --verbose']
+- id: destroy simple-zonal-local
+  waitFor:
+    - verify simple-zonal-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleZonal --stage teardown --verbose']
+- id: converge simple-zonal-private-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleZonalPrivate --stage apply --verbose']
+- id: verify simple-zonal-private-local
+  waitFor:
+    - converge simple-zonal-private-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleZonalPrivate --stage verify --verbose']
+- id: destroy simple-zonal-private-local
+  waitFor:
+    - verify simple-zonal-private-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleZonalPrivate --stage teardown --verbose']
+- id: converge stub-domains-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestStubDomains --stage apply --verbose']
+- id: verify stub-domains-local
+  waitFor:
+    - converge stub-domains-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestStubDomains --stage verify --verbose']
+- id: destroy stub-domains-local
+  waitFor:
+    - verify stub-domains-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestStubDomains --stage teardown --verbose']
+- id: converge upstream-nameservers-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestUpstreamNameservers --stage apply --verbose']
+- id: verify upstream-nameservers-local
+  waitFor:
+    - converge upstream-nameservers-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestUpstreamNameservers --stage verify --verbose']
+- id: destroy upstream-nameservers-local
+  waitFor:
+    - verify upstream-nameservers-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestUpstreamNameservers --stage teardown --verbose']
+- id: converge stub-domains-upstream-nameservers-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestStubDomainsUpstreamNameservers --stage apply --verbose']
+- id: verify stub-domains-upstream-nameservers-local
+  waitFor:
+    - converge stub-domains-upstream-nameservers-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestStubDomainsUpstreamNameservers --stage verify --verbose']
+- id: destroy stub-domains-upstream-nameservers-local
+  waitFor:
+    - verify stub-domains-upstream-nameservers-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestStubDomainsUpstreamNameservers --stage teardown --verbose']
+- id: converge workload-metadata-config-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestWorkloadMetadataConfig --stage apply --verbose']
+- id: verify workload-metadata-config-local
+  waitFor:
+    - converge workload-metadata-config-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestWorkloadMetadataConfig --stage verify --verbose']
+- id: destroy workload-metadata-config-local
+  waitFor:
+    - verify workload-metadata-config-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestWorkloadMetadataConfig --stage teardown --verbose']
+- id: converge beta-cluster-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestBetaCluster --stage apply --verbose']
+- id: verify beta-cluster-local
+  waitFor:
+    - converge beta-cluster-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestBetaCluster --stage verify --verbose']
+- id: destroy beta-cluster-local
+  waitFor:
+    - verify beta-cluster-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestBetaCluster --stage teardown --verbose']
+- id: converge deploy-service-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestDeployService --stage apply --verbose']
+- id: verify deploy-service-local
+  waitFor:
+    - converge deploy-service-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestDeployService --stage verify --verbose']
+- id: destroy deploy-service-local
+  waitFor:
+    - verify deploy-service-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestDeployService --stage teardown --verbose']
+- id: converge node-pool-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestNodePool --stage apply --verbose']
+- id: verify node-pool-local
+  waitFor:
+    - converge node-pool-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestNodePool --stage verify --verbose']
+- id: destroy node-pool-local
+  waitFor:
+    - verify node-pool-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestNodePool --stage teardown --verbose']
+- id: converge sandbox-enabled-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSandboxEnabled --stage apply --verbose']
+- id: verify sandbox-enabled-local
+  waitFor:
+    - converge sandbox-enabled-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSandboxEnabled --stage verify --verbose']
+- id: destroy sandbox-enabled-local
+  waitFor:
+    - verify sandbox-enabled-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSandboxEnabled --stage teardown --verbose']
+- id: converge workload-identity-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestWorkloadIdentity --stage apply --verbose']
+- id: verify workload-identity-local
+  waitFor:
+    - converge workload-identity-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestWorkloadIdentity --stage verify --verbose']
+- id: destroy workload-identity-local
+  waitFor:
+    - verify workload-identity-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestWorkloadIdentity --stage teardown --verbose']
+- id: converge safer-cluster-iap-bastion-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSaferClusterIapBastion --stage apply --verbose']
+- id: verify safer-cluster-iap-bastion-local
+  waitFor:
+    - converge safer-cluster-iap-bastion-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSaferClusterIapBastion --stage verify --verbose']
+- id: destroy safer-cluster-iap-bastion-local
+  waitFor:
+    - verify safer-cluster-iap-bastion-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSaferClusterIapBastion --stage teardown --verbose']
+- id: converge simple-zonal-with-asm-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleZonalWithAsm --stage apply --verbose']
+- id: verify simple-zonal-with-asm-local
+  waitFor:
+    - converge simple-zonal-with-asm-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleZonalWithAsm --stage verify --verbose']
+- id: destroy simple-zonal-with-asm-local
+  waitFor:
+    - verify simple-zonal-with-asm-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleZonalWithAsm --stage teardown --verbose']
+- id: converge simple-autopilot-private-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleAutopilotPrivate --stage apply --verbose']
+- id: verify simple-autopilot-private-local
+  waitFor:
+    - converge simple-autopilot-private-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleAutopilotPrivate --stage verify --verbose']
+- id: destroy simple-autopilot-private-local
+  waitFor:
+    - verify simple-autopilot-private-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleAutopilotPrivate --stage teardown --verbose']
+- id: converge simple-autopilot-public-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleAutopilotPublic --stage apply --verbose']
+- id: verify simple-autopilot-public-local
+  waitFor:
+    - converge simple-autopilot-public-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleAutopilotPublic --stage verify --verbose']
+- id: destroy simple-autopilot-public-local
+  waitFor:
+    - verify simple-autopilot-public-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleAutopilotPublic --stage teardown --verbose']
+tags:
+- 'ci'
+- 'integration'
+substitutions:
+  _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.0'
+options:
+  machineType: 'N1_HIGHCPU_8'

--- a/cli/bptest/testdata/cb/oldAll.yaml
+++ b/cli/bptest/testdata/cb/oldAll.yaml
@@ -1,0 +1,41 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 3600s
+steps:
+- id: prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment']
+  env:
+  - 'TF_VAR_org_id=$_ORG_ID'
+  - 'TF_VAR_folder_id=$_FOLDER_ID'
+  - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
+- id: create
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create']
+- id: converge
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge']
+- id: verify
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify']
+- id: destroy
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy']
+tags:
+- 'ci'
+- 'integration'
+substitutions:
+  _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'

--- a/cli/bptest/testdata/cb/oldTarget.yaml
+++ b/cli/bptest/testdata/cb/oldTarget.yaml
@@ -1,0 +1,369 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 12600s
+steps:
+- id: download acm
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && download_acm']
+- id: prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment && chmod 600 /builder/home/.netrc && sleep 120']
+  env:
+  - 'TF_VAR_org_id=$_ORG_ID'
+  - 'TF_VAR_folder_id=$_FOLDER_ID'
+  - 'TF_VAR_billing_account=$_BILLING_ACCOUNT'
+- id: create all
+  waitFor:
+    - prepare
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create']
+- id: converge disable-client-cert-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge disable-client-cert-local']
+- id: verify disable-client-cert-local
+  waitFor:
+    - converge disable-client-cert-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify disable-client-cert-local']
+- id: destroy disable-client-cert-local
+  waitFor:
+    - verify disable-client-cert-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy disable-client-cert-local']
+- id: converge shared-vpc-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge shared-vpc-local']
+- id: verify shared-vpc-local
+  waitFor:
+    - converge shared-vpc-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify shared-vpc-local']
+- id: destroy shared-vpc-local
+  waitFor:
+    - verify shared-vpc-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy shared-vpc-local']
+- id: converge safer-cluster-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge safer-cluster-local']
+- id: verify safer-cluster-local
+  waitFor:
+    - converge safer-cluster-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify safer-cluster-local']
+- id: destroy safer-cluster-local
+  waitFor:
+    - verify safer-cluster-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy safer-cluster-local']
+- id: converge simple-regional-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge simple-regional-local']
+- id: verify simple-regional-local
+  waitFor:
+    - converge simple-regional-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify simple-regional-local']
+- id: destroy simple-regional-local
+  waitFor:
+    - verify simple-regional-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy simple-regional-local']
+- id: converge simple-regional-private-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge simple-regional-private-local']
+- id: verify simple-regional-private-local
+  waitFor:
+    - converge simple-regional-private-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify simple-regional-private-local']
+- id: destroy simple-regional-private-local
+  waitFor:
+    - verify simple-regional-private-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy simple-regional-private-local']
+- id: converge simple-regional-with-kubeconfig-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge simple-regional-with-kubeconfig-local']
+- id: verify simple-regional-with-kubeconfig-local
+  waitFor:
+    - converge simple-regional-with-kubeconfig-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify simple-regional-with-kubeconfig-local']
+- id: destroy simple-regional-with-kubeconfig-local
+  waitFor:
+    - verify simple-regional-with-kubeconfig-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy simple-regional-with-kubeconfig-local']
+- id: converge simple-regional-with-networking-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge simple-regional-with-networking-local']
+- id: verify simple-regional-with-networking-local
+  waitFor:
+    - converge simple-regional-with-networking-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify simple-regional-with-networking-local']
+- id: destroy simple-regional-with-networking-local
+  waitFor:
+    - verify simple-regional-with-networking-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy simple-regional-with-networking-local']
+- id: converge simple-zonal-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge simple-zonal-local']
+- id: verify simple-zonal-local
+  waitFor:
+    - converge simple-zonal-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify simple-zonal-local']
+- id: destroy simple-zonal-local
+  waitFor:
+    - verify simple-zonal-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy simple-zonal-local']
+- id: converge simple-zonal-private-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge simple-zonal-private-local']
+- id: verify simple-zonal-private-local
+  waitFor:
+    - converge simple-zonal-private-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify simple-zonal-private-local']
+- id: destroy simple-zonal-private-local
+  waitFor:
+    - verify simple-zonal-private-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy simple-zonal-private-local']
+- id: converge stub-domains-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge stub-domains-local']
+- id: verify stub-domains-local
+  waitFor:
+    - converge stub-domains-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify stub-domains-local']
+- id: destroy stub-domains-local
+  waitFor:
+    - verify stub-domains-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy stub-domains-local']
+- id: converge upstream-nameservers-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge upstream-nameservers-local']
+- id: verify upstream-nameservers-local
+  waitFor:
+    - converge upstream-nameservers-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify upstream-nameservers-local']
+- id: destroy upstream-nameservers-local
+  waitFor:
+    - verify upstream-nameservers-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy upstream-nameservers-local']
+- id: converge stub-domains-upstream-nameservers-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge stub-domains-upstream-nameservers-local']
+- id: verify stub-domains-upstream-nameservers-local
+  waitFor:
+    - converge stub-domains-upstream-nameservers-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify stub-domains-upstream-nameservers-local']
+- id: destroy stub-domains-upstream-nameservers-local
+  waitFor:
+    - verify stub-domains-upstream-nameservers-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy stub-domains-upstream-nameservers-local']
+- id: converge workload-metadata-config-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge workload-metadata-config-local']
+- id: verify workload-metadata-config-local
+  waitFor:
+    - converge workload-metadata-config-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify workload-metadata-config-local']
+- id: destroy workload-metadata-config-local
+  waitFor:
+    - verify workload-metadata-config-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy workload-metadata-config-local']
+- id: converge beta-cluster-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge beta-cluster-local']
+- id: verify beta-cluster-local
+  waitFor:
+    - converge beta-cluster-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify beta-cluster-local']
+- id: destroy beta-cluster-local
+  waitFor:
+    - verify beta-cluster-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy beta-cluster-local']
+- id: converge deploy-service-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge deploy-service-local']
+- id: verify deploy-service-local
+  waitFor:
+    - converge deploy-service-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify deploy-service-local']
+- id: destroy deploy-service-local
+  waitFor:
+    - verify deploy-service-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy deploy-service-local']
+- id: converge node-pool-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge node-pool-local']
+- id: verify node-pool-local
+  waitFor:
+    - converge node-pool-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify node-pool-local']
+- id: destroy node-pool-local
+  waitFor:
+    - verify node-pool-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy node-pool-local']
+- id: converge sandbox-enabled-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge sandbox-enabled-local']
+- id: verify sandbox-enabled-local
+  waitFor:
+    - converge sandbox-enabled-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify sandbox-enabled-local']
+- id: destroy sandbox-enabled-local
+  waitFor:
+    - verify sandbox-enabled-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy sandbox-enabled-local']
+- id: converge workload-identity-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge workload-identity-local']
+- id: verify workload-identity-local
+  waitFor:
+    - converge workload-identity-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify workload-identity-local']
+- id: destroy workload-identity-local
+  waitFor:
+    - verify workload-identity-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy workload-identity-local']
+- id: converge safer-cluster-iap-bastion-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge safer-cluster-iap-bastion-local']
+- id: verify safer-cluster-iap-bastion-local
+  waitFor:
+    - converge safer-cluster-iap-bastion-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify safer-cluster-iap-bastion-local']
+- id: destroy safer-cluster-iap-bastion-local
+  waitFor:
+    - verify safer-cluster-iap-bastion-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy safer-cluster-iap-bastion-local']
+- id: converge simple-zonal-with-asm-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge simple-zonal-with-asm-local']
+- id: verify simple-zonal-with-asm-local
+  waitFor:
+    - converge simple-zonal-with-asm-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify simple-zonal-with-asm-local']
+- id: destroy simple-zonal-with-asm-local
+  waitFor:
+    - verify simple-zonal-with-asm-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy simple-zonal-with-asm-local']
+- id: converge simple-autopilot-private-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge simple-autopilot-private-local']
+- id: verify simple-autopilot-private-local
+  waitFor:
+    - converge simple-autopilot-private-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify simple-autopilot-private-local']
+- id: destroy simple-autopilot-private-local
+  waitFor:
+    - verify simple-autopilot-private-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy simple-autopilot-private-local']
+- id: converge simple-autopilot-public-local
+  waitFor:
+    - create all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge simple-autopilot-public-local']
+- id: verify simple-autopilot-public-local
+  waitFor:
+    - converge simple-autopilot-public-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify simple-autopilot-public-local']
+- id: destroy simple-autopilot-public-local
+  waitFor:
+    - verify simple-autopilot-public-local
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do destroy simple-autopilot-public-local']
+tags:
+- 'ci'
+- 'integration'
+substitutions:
+  _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.0'
+options:
+  machineType: 'N1_HIGHCPU_8'

--- a/cli/bptest/testdata/kitchen-tests/simple-example/controls/gcloud.rb
+++ b/cli/bptest/testdata/kitchen-tests/simple-example/controls/gcloud.rb
@@ -1,0 +1,1 @@
+# ruby test

--- a/cli/bptest/testdata/kitchen-tests/simple-example/inspec.yml
+++ b/cli/bptest/testdata/kitchen-tests/simple-example/inspec.yml
@@ -1,0 +1,50 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: simple-example
+depends:
+  - name: inspec-gcp
+    git: https://github.com/inspec/inspec-gcp.git
+    tag: v1.8.0
+attributes:
+  - name: project_id
+    required: true
+    type: string
+  - name: location
+    required: true
+    type: string
+  - name: cluster_name
+    required: true
+    type: string
+  - name: master_kubernetes_version
+    required: true
+    type: string
+  - name: kubernetes_endpoint
+    required: true
+    type: string
+  - name: client_token
+    required: true
+    type: string
+  - name: service_account
+    required: true
+    type: string
+  - name: service_account
+    required: true
+    type: string
+  - name: database_encryption_key_name
+    required: true
+    type: string
+  - name: identity_namespace
+    required: true
+    type: string

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gammazero/workerpool v1.1.2
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
+	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
 	github.com/jedib0t/go-pretty/v6 v6.2.4
 	github.com/mitchellh/go-testing-interface v1.14.2-0.20210217184823-a52172cd2f64

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -11,18 +11,21 @@ require (
 	github.com/gammazero/workerpool v1.1.2
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
-	github.com/iancoleman/strcase v0.2.0 // indirect
+	github.com/iancoleman/strcase v0.2.0
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
 	github.com/jedib0t/go-pretty/v6 v6.2.4
 	github.com/mitchellh/go-testing-interface v1.14.2-0.20210217184823-a52172cd2f64
 	github.com/open-policy-agent/gatekeeper v3.0.4-beta.2+incompatible // indirect
 	github.com/open-policy-agent/opa v0.34.2
+	github.com/otiai10/copy v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.7.0
+	google.golang.org/api v0.58.0
 	google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12
 	gopkg.in/yaml.v2 v2.4.0
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace github.com/open-policy-agent/gatekeeper v3.0.4-beta.2+incompatible => github.com/open-policy-agent/gatekeeper v0.0.0-20210409021048-9b5e4cfe5d7e

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -699,6 +699,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.4/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -960,10 +960,12 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/oracle/oci-go-sdk v7.1.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=
+github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=
 github.com/otiai10/copy v1.6.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.2 h1:VYWnrP5fXmz1MXvjuUvcBrXSjGE6xjON+axB/UrpO3E=
 github.com/otiai10/mint v1.3.2/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=


### PR DESCRIPTION
This adds a new `convert` command that
- removes kitchen tests and replaces them with a skeleton blueprint test with inputs
- updates cloud build file to use cft cli commands