### PR TITLE
fix: revert pinned gcloud version

### DIFF
--- a/infra/build/Makefile
+++ b/infra/build/Makefile
@@ -32,7 +32,7 @@ CFT_CLI_VERSION := 0.4.4
 ASMCLI_VERSION := 1.12
 KUBECTL_VERSION := 1.23.4
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.4.10
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.4.11
 DOCKER_TAG_MAJOR_VERSION_DEVELOPER_TOOLS := $(firstword $(subst ., , $(DOCKER_TAG_VERSION_DEVELOPER_TOOLS)))
 DOCKER_TAG_MINOR_VERSION_DEVELOPER_TOOLS := $(shell echo "${DOCKER_TAG_VERSION_DEVELOPER_TOOLS}" | awk -F. '{print $$1"."$$2}')
 
@@ -45,9 +45,8 @@ REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
 .PHONY: build-image-developer-tools
 build-image-developer-tools:
-	# TODO(bharathkkb): unpin gcloud version after https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/1095 is resolved
 	docker build \
-		--build-arg CLOUD_SDK_VERSION=375.0.0 \
+		--build-arg CLOUD_SDK_VERSION=${CLOUD_SDK_VERSION} \
 		--build-arg GSUITE_PROVIDER_VERSION=${GSUITE_PROVIDER_VERSION} \
 		--build-arg TERRAFORM_VERSION=${TERRAFORM_VERSION} \
 		--build-arg TERRAFORM_VALIDATOR_VERSION=${TERRAFORM_VALIDATOR_VERSION} \


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/1095
Removed pinned gcloud version as upstream issue is fixed