### PR TITLE
Fixed variable definitions

### DIFF
--- a/infra/terraform/test-org/ci-triggers/locals.tf
+++ b/infra/terraform/test-org/ci-triggers/locals.tf
@@ -39,8 +39,8 @@ locals {
   org_id                   = data.terraform_remote_state.org.outputs.org_id
   billing_account          = data.terraform_remote_state.org.outputs.billing_account
   tf_validator_project_id  = data.terraform_remote_state.tf-validator.outputs.project_id
-  tf_validator_folder_id   = data.terraform_remote_state.org.outputs.folders["ci-terraform-validator"]
-  tf_validator_ancestry    = "organizations/${local.org_id}/folders/${data.terraform_remote_state.org.outputs.folders["ci-projects"]}/folders/${local.tf_validator_folder_id}"
+  tf_validator_folder_id   = trimprefix(data.terraform_remote_state.org.outputs.folders["ci-terraform-validator"], "folders/")
+  tf_validator_ancestry    = "organizations/${local.org_id}/${data.terraform_remote_state.org.outputs.folders["ci-projects"]}/folders/${local.tf_validator_folder_id}"
   project_id               = "cloud-foundation-cicd"
   forseti_ci_folder_id     = "542927601143"
   billing_iam_test_account = "0151A3-65855E-5913CF"


### PR DESCRIPTION
- Removed folders/ prefix from folder id var - needs to just be id
- Removed duplicate folders/ prefix in ancestry variable

Basically, org.outputs.folders["key"] is in the format "folders/12345"