### PR TITLE
Made ancestry match legacy format

### DIFF
--- a/infra/terraform/test-org/ci-triggers/locals.tf
+++ b/infra/terraform/test-org/ci-triggers/locals.tf
@@ -40,7 +40,8 @@ locals {
   billing_account          = data.terraform_remote_state.org.outputs.billing_account
   tf_validator_project_id  = data.terraform_remote_state.tf-validator.outputs.project_id
   tf_validator_folder_id   = trimprefix(data.terraform_remote_state.org.outputs.folders["ci-terraform-validator"], "folders/")
-  tf_validator_ancestry    = "organizations/${local.org_id}/${data.terraform_remote_state.org.outputs.folders["ci-projects"]}/folders/${local.tf_validator_folder_id}"
+  # tf validator "ancestry path" expects non-plural type names for historical reasons
+  tf_validator_ancestry    = "organization/${local.org_id}/folder/${trimprefix(data.terraform_remote_state.org.outputs.folders["ci-projects"], "folders/")}/folder/${local.tf_validator_folder_id}"
   project_id               = "cloud-foundation-cicd"
   forseti_ci_folder_id     = "542927601143"
   billing_iam_test_account = "0151A3-65855E-5913CF"


### PR DESCRIPTION
tf validator "ancestry path" expects non-plural type names for historical reasons