### PR TITLE
chore: create release-please.yml

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,16 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+handleGHRelease: true
+manifest: true

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "infra/blueprint-test": "0.0.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,12 @@
+{
+  "separate-pull-requests": true,
+  "packages": {
+    "infra/blueprint-test": {
+      "release-type": "go",
+      "package-name": "blueprint-test",
+      "bump-minor-pre-major": true,
+      "release-as": "0.0.1"
+    }
+  },
+  "bootstrap-sha": "f78304cebc31f2ca29d4303753a8c32ba238ab53"
+}


### PR DESCRIPTION
Fixes #1141 

Example PR: https://github.com/apeabody/cloud-foundation-toolkit/pull/2

NOTE: Remove "release-as" from release-please-config.json after the first release (v0.0.1).  "bootstrap-sha" can optionally be removed after the first release.