### PR TITLE
fix: update infra/blueprint-test release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
     "infra/blueprint-test": {
       "release-type": "go",
       "package-name": "blueprint-test",
+      "component": "infra/blueprint-test",
       "bump-minor-pre-major": true,
       "release-as": "0.0.1"
     }


### PR DESCRIPTION
@bharathkkb - The tag delimiter is now correct, but go needs the tag and nested path to match, e.g. `infra/blueprint-test/v0.0.1`.  Hopefully setting `"component": "infra/blueprint-test"` will suffice, otherwise we might need to set the package name to `"infra/blueprint-test"`.