### PR TITLE
feat:adds base commands for blueprint metadata

### DIFF
--- a/cli/bpmetadata/cmd.go
+++ b/cli/bpmetadata/cmd.go
@@ -8,17 +8,16 @@ import (
 var mdFlags struct {
 	path   string
 	nested bool
-	verfiy bool
 }
 
 func init() {
 	viper.AutomaticEnv()
 
-	MdCmd.Flags().StringVar(&mdFlags.path, "path", ".", "Path to the blueprint for generating metadata.")
-	MdCmd.Flags().BoolVar(&mdFlags.nested, "nested", false, "Flag for generating metadata for nested blueprint, if any.")
+	Cmd.Flags().StringVar(&mdFlags.path, "path", ".", "Path to the blueprint for generating metadata.")
+	Cmd.Flags().BoolVar(&mdFlags.nested, "nested", true, "Flag for generating metadata for nested blueprint, if any.")
 }
 
-var MdCmd = &cobra.Command{
+var Cmd = &cobra.Command{
 	Use:   "metadata",
 	Short: "Generates blueprint metatda",
 	Long:  `Generates metadata.yaml for specified blueprint`,

--- a/cli/bpmetadata/cmd.go
+++ b/cli/bpmetadata/cmd.go
@@ -1,0 +1,29 @@
+package bpmetadata
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var mdFlags struct {
+	path   string
+	nested bool
+	verfiy bool
+}
+
+func init() {
+	viper.AutomaticEnv()
+
+	MdCmd.Flags().StringVar(&mdFlags.path, "path", ".", "Path to the blueprint for generating metadata.")
+	MdCmd.Flags().BoolVar(&mdFlags.nested, "nested", false, "Flag for generating metadata for nested blueprint, if any.")
+}
+
+var MdCmd = &cobra.Command{
+	Use:   "metadata",
+	Short: "Generates blueprint metatda",
+	Long:  `Generates metadata.yaml for specified blueprint`,
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Println("command under construction")
+	},
+}

--- a/cli/bpmetadata/main.go
+++ b/cli/bpmetadata/main.go
@@ -1,0 +1,8 @@
+package bpmetadata
+
+import (
+	log "github.com/inconshreveable/log15"
+)
+
+// bpbuild log15 handler
+var Log = log.New()

--- a/cli/bpmetadata/main.go
+++ b/cli/bpmetadata/main.go
@@ -4,5 +4,5 @@ import (
 	log "github.com/inconshreveable/log15"
 )
 
-// bpbuild log15 handler
+// bpmetadata log15 handler
 var Log = log.New()

--- a/cli/cmd/blueprint.go
+++ b/cli/cmd/blueprint.go
@@ -18,7 +18,7 @@ func init() {
 var blueprintCmd = &cobra.Command{
 	Use:   "blueprint",
 	Short: "Blueprint CLI",
-	Long:  `The CFT blueprint CLI is used to execute commands specific to blueprints such as test, avgtime & metadata`,
+	Long:  `The CFT blueprint CLI is used to execute commands specific to blueprints such as test, builds & metadata`,
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		if args == nil || len(args) == 0 {

--- a/cli/cmd/blueprint.go
+++ b/cli/cmd/blueprint.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpbuild"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpmetadata"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bptest"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	blueprintCmd.AddCommand(bpmetadata.MdCmd)
+	blueprintCmd.AddCommand(bpbuild.Cmd)
+	blueprintCmd.AddCommand(bptest.Cmd)
+
+	rootCmd.AddCommand(blueprintCmd)
+}
+
+var blueprintCmd = &cobra.Command{
+	Use:   "blueprint",
+	Short: "Blueprint CLI",
+	Long:  `The CFT blueprint CLI is used to execute commands specific to blueprints such as test, avgtime & metadata`,
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		if args == nil || len(args) == 0 {
+			cmd.HelpFunc()(cmd, args)
+		}
+	},
+}

--- a/cli/cmd/blueprint.go
+++ b/cli/cmd/blueprint.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	blueprintCmd.AddCommand(bpmetadata.MdCmd)
+	blueprintCmd.AddCommand(bpmetadata.Cmd)
 	blueprintCmd.AddCommand(bpbuild.Cmd)
 	blueprintCmd.AddCommand(bptest.Cmd)
 


### PR DESCRIPTION
This adds a top level `blueprint` command to  the `cft` cli and adds the following commands as sub-commands to it:
- `test`
- `builds`
- `metadata` - new and in-progress

`cft test` will continue to work until we change that to `cft blueprint test` and take `test` out of the root command.