### PR TITLE
fix: exempt mp4 files from whitespace and newline

### DIFF
--- a/infra/build/developer-tools/build/scripts/task_helper_functions.sh
+++ b/infra/build/developer-tools/build/scripts/task_helper_functions.sh
@@ -243,7 +243,7 @@ check_whitespace() {
   fi
   echo "Checking for missing newline at end of file"
   find_files . -print \
-    | grep -v -E '\.(png|gz|tfvars)$' \
+    | grep -v -E '\.(png|gz|tfvars|mp4)$' \
     | compat_xargs check_eof_newline
   return $((rc+$?))
 }

--- a/infra/build/developer-tools/build/scripts/task_helper_functions.sh
+++ b/infra/build/developer-tools/build/scripts/task_helper_functions.sh
@@ -232,7 +232,7 @@ check_whitespace() {
   local rc
   echo "Checking for trailing whitespace"
   find_files . -print \
-    | grep -v -E '\.(pyc|png|gz|tfvars)$' \
+    | grep -v -E '\.(pyc|png|gz|tfvars|mp4)$' \
     | compat_xargs grep -H -n '[[:blank:]]$'
   rc=$?
   if [[ ${rc} -eq 0 ]]; then


### PR DESCRIPTION
example: https://github.com/GoogleCloudPlatform/terraform-google-media-cdn-vod/blob/main/smpte.mp4