### PR TITLE
Allow terraform-google-conversion to use cft github actions workload identity

### DIFF
--- a/infra/terraform/test-org/ci-project/sa.tf
+++ b/infra/terraform/test-org/ci-project/sa.tf
@@ -38,5 +38,9 @@ module "oidc" {
       sa_name   = module.service_accounts.service_account.name
       attribute = "attribute.repository/GoogleCloudPlatform/cloud-foundation-toolkit"
     }
+    cft-github-actions-tgc = {
+      sa_name   = module.service_accounts.service_account.name
+      attribute = "attribute.repository/GoogleCloudPlatform/terraform-google-conversion"
+    }
   }
 }


### PR DESCRIPTION
We'd like to run TFV tests (and some new related tests) from https://github.com/GoogleCloudPlatform/terraform-google-conversion/. We'd also like to switch to github actions for tests for simplicity. In order to have access to the same test environment as we do via cloudbuild, could we potentially use the cft-github-actions workload identity with the tgc repository?