### PR TITLE
feat: consolidate TPG and TPG-Beta, major and minor into single PR

### DIFF
--- a/infra/terraform/test-org/github/renovate.json
+++ b/infra/terraform/test-org/github/renovate.json
@@ -30,6 +30,11 @@
       "matchPackageNames": ["go"],
       "allowedVersions": "<1.19.0",
       "postUpdateOptions": ["gomodTidy"]
+    },
+    {
+      "matchPackageNames": ["google", "google-beta"],
+      "groupName": "terraform googles",
+      "separateMajorMinor": false
     }
   ]
 }


### PR DESCRIPTION
This will greatly reduce the number of PRs by consolidating both the Google and Google-Beta, and also their major and minor versions (eliminate minor v3 PR, and keep the separate v4 PR).  It should also attempt to "widen" the constraint rather than upgrading v3 > v4.