### PR TITLE
feat: new test strategy for redeploy validation

### DIFF
--- a/infra/blueprint-test/examples/simple_pet_module/main.tf
+++ b/infra/blueprint-test/examples/simple_pet_module/main.tf
@@ -1,0 +1,2 @@
+resource "random_pet" "hello" {
+}

--- a/infra/blueprint-test/test/terraform_redeploy_test.go
+++ b/infra/blueprint-test/test/terraform_redeploy_test.go
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func TestRedeploy(t *testing.T) {
+	nt := tft.NewTFBlueprintTest(t,
+		tft.WithTFDir("../examples/simple_pet_module"),
+		tft.WithSetupPath(""),
+	)
+	nt.RedeployTest(3)
+	expectedWorkspaces := []string{"test-1", "test-2", "test-3"}
+	for _, ws := range expectedWorkspaces {
+		terraform.RunTerraformCommand(t, nt.GetTFOptions(), "workspace", "select", ws)
+	}
+}


### PR DESCRIPTION
This adds a new `RedeployTest` strategy for ensuring TF blueprints can be deployed n times in a single project.
Each deployment is done in a separate workspace with a deferred cleanup until all the redeployments have been verified.