### PR TITLE
chore: use a newer gcloud version for CLI release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v1
         with:
-          version: "366.0.0"
+          version: "410.0.0"
 
       # used by make release which runs gcloud alpha storage
       - name: Install gcloud alpha commands 


### PR DESCRIPTION
Aligning this to what we use to devtools build push.