### PR TITLE
remove terraform plan file needed for the terraform vet execution after validation

### DIFF
--- a/infra/blueprint-test/pkg/tft/terraform.go
+++ b/infra/blueprint-test/pkg/tft/terraform.go
@@ -387,6 +387,7 @@ func (b *TFBlueprintTest) Vet(assert *assert.Assertions) {
 	jsonPlan := terraform.Show(b.t, b.GetTFOptions())
 	filepath, err := utils.WriteTmpFileWithExtension(jsonPlan, "json")
 	defer os.Remove(filepath)
+	defer os.Remove(b.planFilePath)
 	assert.NoError(err)
 	results := gcloud.TFVet(b.t, filepath, b.policyLibraryPath, b.terraformVetProject).Array()
 	assert.Empty(results, "Should have no Terraform Vet violations")
@@ -396,6 +397,9 @@ func (b *TFBlueprintTest) Vet(assert *assert.Assertions) {
 func (b *TFBlueprintTest) DefaultApply(assert *assert.Assertions) {
 	if b.shouldRunTerraformVet() {
 		b.Vet(assert)
+		// need to unset the planFilePath to prevent stale plan errors
+		// when retrying apply commands
+		b.planFilePath = ""
 	}
 	terraform.Apply(b.t, b.GetTFOptions())
 }


### PR DESCRIPTION
remove terraform plan file needed for the terraform vet execution after validation.

when retrying a configured retriable error if the plan file exists it will rise an stale plan error because it has been partially executed.

```text
but this error was expected and warrants a retry. Further details: Rate limit exceeded.
...
retry.go:103: terraform [apply -input=false -auto-approve -lock=false /tmp/plan.tfplan] returned an error: error while running command: exit status 1
Error: Error adding network peering: googleapi: Error 403: Rate Limit Exceeded
Sleeping for 2m0s and will try again.
...
retry.go:91: terraform [apply -input=false -auto-approve -lock=false /tmp/plan.tfplan]
retry.go:99: Returning due to fatal error: FatalError Underlying: error while running command: exit status 1

Error: Saved plan is stale
The given plan file can no longer be applied because the state was changed
by another operation after the plan was created.
```