### PR TITLE
chore: create conventional commit bot config

### DIFF
--- a/.github/conventional-commit-lint.yaml
+++ b/.github/conventional-commit-lint.yaml
@@ -1,0 +1,2 @@
+enabled: true
+always_check_pr_title: true


### PR DESCRIPTION
With this config, the bot will always use PR title

fixes #1304