### PR TITLE
chore: gcrane update fix

### DIFF
--- a/.github/workflows/update-tooling.yml
+++ b/.github/workflows/update-tooling.yml
@@ -13,7 +13,7 @@ env:
   KUBECTL_URL: "https://api.github.com/repos/kubernetes/kubernetes/releases"
   GATOR_MINOR: "3.9"
   GATOR_URL: "https://api.github.com/repos/open-policy-agent/gatekeeper/releases"
-  GCRANE_URL: "https://api.github.com/repos/google/go-containerregistry/releases"
+  GCRANE_URL: "https://api.github.com/repos/google/go-containerregistry/releases/latest"
 
 jobs:
   update-tools:


### PR DESCRIPTION
It looked like the gcrane updater failed to get version. Releases is an array so I switched to getting the latest release.