### PR TITLE
fix: replace deprecated protobuf

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -42,3 +42,5 @@ require (
 )
 
 replace github.com/open-policy-agent/gatekeeper v3.0.4-beta.2+incompatible => github.com/open-policy-agent/gatekeeper v0.0.0-20210409021048-9b5e4cfe5d7e
+replace github.com/golang/protobuf/jsonpb v1.5.2 => google.golang.org/protobuf/encoding/protojson v1.20.0
+replace github.com/golang/protobuf/proto v1.5.2 => google.golang.org/protobuf/proto v1.20.0


### PR DESCRIPTION
Fixes #902

```
go test ./...
?   	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli	[no test files]
ok  	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpbuild	0.126s
ok  	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpcatalog	0.055s
ok  	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpmetadata	0.177s
ok  	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bptest	0.265s
?   	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/report	[no test files]
ok  	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/cmd	0.233s
ok  	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/launchpad	0.218s
ok  	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/scorecard	0.465s
ok  	github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/util	0.179s
```