### PR TITLE
fix: update blueprint-test for kpt v1.0.0-beta.16+

### DIFF
--- a/.github/workflows/update-tooling.yml
+++ b/.github/workflows/update-tooling.yml
@@ -24,8 +24,7 @@ jobs:
         run: |
           PR_UPDATE_BODY=""
           newline=$'\n'
-          # Skip "KPT" till resolved: https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/1190
-          tools=("TERRAFORM" "CLOUD_SDK" "CFT_CLI" "KUBECTL" "GATOR" "GCRANE")
+          tools=("TERRAFORM" "CLOUD_SDK" "CFT_CLI" "KUBECTL" "GATOR" "GCRANE" "KPT")
 
           for tool in ${tools[@]}
           do

--- a/infra/blueprint-test/go.mod
+++ b/infra/blueprint-test/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/gjson v1.12.1
 	github.com/tidwall/sjson v1.2.4
+	golang.org/x/mod v0.4.2
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect

--- a/infra/blueprint-test/pkg/kpt/kpt.go
+++ b/infra/blueprint-test/pkg/kpt/kpt.go
@@ -61,7 +61,7 @@ func NewCmdConfig(t testing.TB, opts ...cmdOption) *CmdCfg {
 		kOpts.kptBinary = "kpt"
 	}
 	// Validate required KPT version
-	if err := utils.MinSemver(t, "v" + kOpts.RunCmd("version"), MIN_KPT_VERSION); err != nil {
+	if err := utils.MinSemver("v" + kOpts.RunCmd("version"), MIN_KPT_VERSION); err != nil {
 		t.Fatalf("unable to validate minimum required kpt version: %v", err)
 	}
 

--- a/infra/blueprint-test/pkg/kpt/kpt.go
+++ b/infra/blueprint-test/pkg/kpt/kpt.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/mitchellh/go-testing-interface"
-	"golang.org/x/mod/semver"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -62,14 +61,8 @@ func NewCmdConfig(t testing.TB, opts ...cmdOption) *CmdCfg {
 		kOpts.kptBinary = "kpt"
 	}
 	// Validate required KPT version
-	kptVersion, err := utils.KptVersion(kOpts.kptBinary)
-	if err != nil {
-		t.Fatalf("unable to retrieve kpt version: %v", err)
-	}
-	if semver.Compare(kptVersion, MIN_KPT_VERSION) == -1 {
-		t.Fatalf("found kpt version %q is less than required kpt version: %v", kptVersion, MIN_KPT_VERSION)
-	} else {
-		t.Logf("found kpt version: %v", kptVersion)
+	if err := utils.MinSemver(t, "v" + kOpts.RunCmd("version"), MIN_KPT_VERSION); err != nil {
+		t.Fatalf("unable to validate minimum required kpt version: %v", err)
 	}
 
 	return kOpts

--- a/infra/blueprint-test/pkg/kpt/kpt.go
+++ b/infra/blueprint-test/pkg/kpt/kpt.go
@@ -9,9 +9,13 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/mitchellh/go-testing-interface"
+	"golang.org/x/mod/semver"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
+
+// MIN_KPT_VERSION format: vMAJOR[.MINOR[.PATCH[-PRERELEASE]]]
+const MIN_KPT_VERSION = "v1.0.0-beta.16"
 
 type CmdCfg struct {
 	kptBinary string         // kpt binary
@@ -57,6 +61,17 @@ func NewCmdConfig(t testing.TB, opts ...cmdOption) *CmdCfg {
 		}
 		kOpts.kptBinary = "kpt"
 	}
+	// Validate required KPT version
+	kptVersion, err := utils.KptVersion(kOpts.kptBinary)
+	if err != nil {
+		t.Fatalf("unable to retrieve kpt version: %v", err)
+	}
+	if semver.Compare(kptVersion, MIN_KPT_VERSION) == -1 {
+		t.Fatalf("found kpt version %q is less than required kpt version: %v", kptVersion, MIN_KPT_VERSION)
+	} else {
+		t.Logf("found kpt version: %v", kptVersion)
+	}
+
 	return kOpts
 }
 

--- a/infra/blueprint-test/pkg/kpt/status.go
+++ b/infra/blueprint-test/pkg/kpt/status.go
@@ -7,40 +7,36 @@ import (
 )
 
 const (
-	// Individual apply events can have either of resourceApplied or resourceFailed status.
-	// https://github.com/GoogleContainerTools/kpt/blob/2a817f60cf7132c88fd2e526c02b800cf927c048/thirdparty/cli-utils/printers/json/formatter.go#L31
-	ApplyType                = "apply"
-	ResourceAppliedEventType = "resourceApplied"
-	ResourceFailedEventType  = "resourceFailed"
-	// Unchanged operation represents a resource that remained unchanged.
-	ResourceOperationUnchanged = "Unchanged"
-	// Group event of type apply has completed status
-	CompletedEventType = "completed"
+	// Resource event of type apply has apply type
+	ResourceApplyType  = "apply"
+	// Status of successful resource event
+	ResourceOperationSuccessful = "Successful"
+	// Group event of type apply has summary type
+	CompletedEventType = "summary"
 )
 
 type ResourceApplyStatus struct {
-	EventType string `json:"eventType"`
 	Group     string `json:"group,omitempty"`
 	Kind      string `json:"kind,omitempty"`
 	Name      string `json:"name,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
-	Operation string `json:"operation"`
+	Status    string `json:"status"`
+	Timestamp string `json:"timestamp"`
 	Type      string `json:"type"`
 }
 
 type GroupApplyStatus struct {
-	EventType       string `json:"eventType"`
+	Action          string `json:"action"`
 	Count           int    `json:"count"`
-	CreatedCount    int    `json:"createdCount"`
-	UnchangedCount  int    `json:"unchangedCount"`
-	ConfiguredCount int    `json:"configuredCount"`
-	FailedCount     int    `json:"failedCount"`
-	ServerSideCount int    `json:"serverSideCount"`
-	Operation       string `json:"operation"`
-	Type            string `json:"type"`
+	Failed          int    `json:"failed"`
+	Skipped         int    `json:"skipped"`
+	Status          string `json:"status"`
+	Successful       int   `json:"successful"`
+	Timestamp string `json:"timestamp"`
+	Type      string `json:"type"`
 }
 
-// GetPkgApplyResourcesStatus finds individual kpt apply statuses from newline seperated string of apply statuses
+// GetPkgApplyResourcesStatus finds individual kpt apply statuses from newline separated string of apply statuses
 // and converts them into a slice of ResourceApplyStatus.
 func GetPkgApplyResourcesStatus(jsonStatus string) ([]ResourceApplyStatus, error) {
 	var statuses []ResourceApplyStatus
@@ -51,7 +47,7 @@ func GetPkgApplyResourcesStatus(jsonStatus string) ([]ResourceApplyStatus, error
 		if err != nil {
 			return nil, fmt.Errorf("error unmarshalling %s: %v", status, err)
 		}
-		if s.Type == ApplyType && (s.EventType == ResourceAppliedEventType || s.EventType == ResourceFailedEventType) {
+		if s.Type == ResourceApplyType {
 			statuses = append(statuses, s)
 		}
 
@@ -59,7 +55,7 @@ func GetPkgApplyResourcesStatus(jsonStatus string) ([]ResourceApplyStatus, error
 	return statuses, nil
 }
 
-// GetPkgApplyGroupStatus finds the first group kpt apply status from newline seperated string of apply statuses
+// GetPkgApplyGroupStatus finds the first group kpt apply status from newline separated string of apply statuses
 // and converts it into a GroupApplyStatus.
 func GetPkgApplyGroupStatus(jsonStatus string) (GroupApplyStatus, error) {
 	var s GroupApplyStatus
@@ -70,7 +66,7 @@ func GetPkgApplyGroupStatus(jsonStatus string) (GroupApplyStatus, error) {
 		if err != nil {
 			return s, fmt.Errorf("error unmarshalling %s: %v", resourceStatuses[i], err)
 		}
-		if s.Type == ApplyType && (s.EventType == CompletedEventType) {
+		if s.Type == CompletedEventType {
 			return s, nil
 		}
 	}

--- a/infra/blueprint-test/pkg/krmt/krm.go
+++ b/infra/blueprint-test/pkg/krmt/krm.go
@@ -286,21 +286,21 @@ func (b *KRMBlueprintTest) DefaultApply(assert *assert.Assertions) {
 	b.kpt.RunCmd("live", "status", "--output", "json", "--poll-until", "current", "--timeout", b.timeout)
 }
 
-// DefaultVerify asserts no resource changes exist after apply.
+// DefaultVerify asserts all resources are status successful
 func (b *KRMBlueprintTest) DefaultVerify(assert *assert.Assertions) {
 	jsonOp := b.kpt.RunCmd("live", "apply", "--output", "json")
 
-	// assert each resource is unchanged from initial apply
+	// assert each resource status is successful
 	resourceStatus, err := kpt.GetPkgApplyResourcesStatus(jsonOp)
 	assert.NoError(err, "Resource statuses should be parsable")
 	for _, r := range resourceStatus {
-		assert.Equal(kpt.ResourceOperationUnchanged, r.Operation, "Resource should be unchanged")
+		assert.Equal(kpt.ResourceOperationSuccessful, r.Status, "Status should be successful")
 	}
 
-	// assert count of resources applied equals count of resources unchanged
+	// assert count of resources applied equals count of resources successful
 	groupStatus, err := kpt.GetPkgApplyGroupStatus(jsonOp)
 	assert.NoError(err, "Group status should be parsable")
-	assert.Equal(groupStatus.Count, groupStatus.UnchangedCount, "All resources should be unchanged")
+	assert.Equal(groupStatus.Count, groupStatus.Successful, "All resources should be successful")
 
 }
 

--- a/infra/blueprint-test/pkg/utils/bincheck.go
+++ b/infra/blueprint-test/pkg/utils/bincheck.go
@@ -16,9 +16,7 @@
 
 package utils
 
-import (
-	"os/exec"
-)
+import "os/exec"
 
 // BinaryInPath checks if a given binary is in path.
 func BinaryInPath(bin string) error {

--- a/infra/blueprint-test/pkg/utils/bincheck.go
+++ b/infra/blueprint-test/pkg/utils/bincheck.go
@@ -16,7 +16,13 @@
 
 package utils
 
-import "os/exec"
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
 
 // BinaryInPath checks if a given binary is in path.
 func BinaryInPath(bin string) error {
@@ -24,4 +30,18 @@ func BinaryInPath(bin string) error {
 		return err
 	}
 	return nil
+}
+
+// Return validated canonical KPT version string
+func KptVersion(bin string) (string, error) {
+	cmd, err := exec.Command(bin, "version").Output()
+	kptVersion := "v" + strings.TrimSpace(string(cmd))
+	if err != nil {
+		return "", err
+	}
+	if semver.IsValid(kptVersion) != true {
+		return "", fmt.Errorf("Unable to parse kpt version")
+	}
+
+	return semver.Canonical(kptVersion), nil
 }

--- a/infra/blueprint-test/pkg/utils/version.go
+++ b/infra/blueprint-test/pkg/utils/version.go
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,22 @@
 package utils
 
 import (
-	"os/exec"
+	"fmt"
+
+	"github.com/mitchellh/go-testing-interface"
+	"golang.org/x/mod/semver"
 )
 
-// BinaryInPath checks if a given binary is in path.
-func BinaryInPath(bin string) error {
-	if _, err := exec.LookPath(bin); err != nil {
-		return err
+// MinSemver validates gotSemver is not less than minSemver
+func MinSemver(t testing.TB, gotSemver string, minSemver string) error {
+	if semver.IsValid(gotSemver) != true {
+		return fmt.Errorf("unable to parse got version %q", gotSemver)
+	} else 	if semver.IsValid(minSemver) != true {
+		return fmt.Errorf("unable to parse minimum version %q", minSemver)
 	}
+	if semver.Compare(gotSemver, minSemver) == -1 {
+		return fmt.Errorf("got version %q is less than minimum version %q", gotSemver, minSemver)
+	}
+
 	return nil
 }

--- a/infra/blueprint-test/pkg/utils/version.go
+++ b/infra/blueprint-test/pkg/utils/version.go
@@ -19,7 +19,6 @@ package utils
 import (
 	"fmt"
 
-	"github.com/mitchellh/go-testing-interface"
 	"golang.org/x/mod/semver"
 )
 
@@ -27,7 +26,7 @@ import (
 func MinSemver(gotSemver string, minSemver string) error {
 	if !semver.IsValid(gotSemver) {
 		return fmt.Errorf("unable to parse got version %q", gotSemver)
-	} else 	if !semver.IsValid(gotSemver) {
+	} else 	if !semver.IsValid(minSemver) {
 		return fmt.Errorf("unable to parse minimum version %q", minSemver)
 	}
 	if semver.Compare(gotSemver, minSemver) == -1 {

--- a/infra/blueprint-test/pkg/utils/version.go
+++ b/infra/blueprint-test/pkg/utils/version.go
@@ -24,10 +24,10 @@ import (
 )
 
 // MinSemver validates gotSemver is not less than minSemver
-func MinSemver(t testing.TB, gotSemver string, minSemver string) error {
-	if semver.IsValid(gotSemver) != true {
+func MinSemver(gotSemver string, minSemver string) error {
+	if !semver.IsValid(gotSemver) {
 		return fmt.Errorf("unable to parse got version %q", gotSemver)
-	} else 	if semver.IsValid(minSemver) != true {
+	} else 	if !semver.IsValid(gotSemver) {
 		return fmt.Errorf("unable to parse minimum version %q", minSemver)
 	}
 	if semver.Compare(gotSemver, minSemver) == -1 {

--- a/infra/build/Makefile
+++ b/infra/build/Makefile
@@ -30,8 +30,7 @@ PACKER_VERSION := 1.4.4
 TERRAGRUNT_VERSION := 0.25.3
 KUSTOMIZE_VERSION := 3.6.1
 # Updated by Update Tooling Workflow
-# Hold KPT at 1.0.0-beta.15 till resolved: https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/1190
-KPT_VERSION := 1.0.0-beta.15
+KPT_VERSION := 1.0.0-beta.24
 # Updated by Update Tooling Workflow
 CFT_CLI_VERSION := 0.5.1
 # Updated by Update Tooling Workflow


### PR DESCRIPTION
NOTE: `kpt live apply` no longer includes "unchanged" status, so this somewhat changes the behavior of `DefaultVerify` to verify all are applied successfully.  If the verification of "unchanged" status is used by other consumers (@kaariger) of this package we should revisit the design.

Tested with `go test -v krm_simple_blueprint_test.go`

Fixes: #1190