### PR TITLE
fix: bpmetadata cli accepts abs and relative paths

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 # Changing this value will trigger a new release
-VERSION=v0.6.0
+VERSION=v0.6.1
 BINARY=bin/cft
 GITHUB_REPO=github.com/GoogleCloudPlatform/cloud-foundation-toolkit
 PLATFORMS := linux windows darwin

--- a/cli/bpmetadata/cmd.go
+++ b/cli/bpmetadata/cmd.go
@@ -55,8 +55,12 @@ func generate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error getting working dir: %w", err)
 	}
 
+	currBpPath := mdFlags.path
+	if !path.IsAbs(mdFlags.path) {
+		currBpPath = path.Join(wdPath, mdFlags.path)
+	}
+
 	var allBpPaths []string
-	currBpPath := path.Join(wdPath, mdFlags.path)
 	_, err = os.Stat(path.Join(currBpPath, readmeFileName))
 
 	// throw an error and exit if root level readme.md doesn't exist


### PR DESCRIPTION
Fixes #1434 