### PR TITLE
fix: kpt tests without existing working dir

### DIFF
--- a/infra/blueprint-test/pkg/kpt/kpt.go
+++ b/infra/blueprint-test/pkg/kpt/kpt.go
@@ -61,7 +61,7 @@ func NewCmdConfig(t testing.TB, opts ...cmdOption) *CmdCfg {
 		kOpts.kptBinary = "kpt"
 	}
 	// Validate required KPT version
-	if err := utils.MinSemver("v" + kOpts.RunCmd("version"), MIN_KPT_VERSION); err != nil {
+	if err := utils.MinSemver("v"+GetKptVersion(t, kOpts.kptBinary), MIN_KPT_VERSION); err != nil {
 		t.Fatalf("unable to validate minimum required kpt version: %v", err)
 	}
 
@@ -95,4 +95,15 @@ func findKptfile(nodes []*yaml.RNode) (*kptfilev1.KptFile, error) {
 		}
 	}
 	return nil, fmt.Errorf("unable to find Kptfile, please include --include-meta-resources flag if a Kptfile is present")
+}
+
+// GetKptVersion gets the version of kptBinary
+func GetKptVersion(t testing.TB, kptBinary string) string {
+	kVersionOpts := &CmdCfg{
+		kptBinary: kptBinary,
+		dir:       utils.GetWD(t),
+		logger:    utils.GetLoggerFromT(),
+		t:         t,
+	}
+	return kVersionOpts.RunCmd("version")
 }

--- a/infra/blueprint-test/pkg/kpt/setters.go
+++ b/infra/blueprint-test/pkg/kpt/setters.go
@@ -41,7 +41,7 @@ func UpsertSetters(nodes []*yaml.RNode, setters map[string]string) error {
 	return nil
 }
 
-//findSetterNode finds setter node from a slice of nodes.
+// findSetterNode finds setter node from a slice of nodes.
 func findSetterNode(nodes []*yaml.RNode, path string) (*yaml.RNode, error) {
 	for _, node := range nodes {
 		np := node.GetAnnotations()[kioutil.PathAnnotation]

--- a/infra/blueprint-test/pkg/kpt/status.go
+++ b/infra/blueprint-test/pkg/kpt/status.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// Resource event of type apply has apply type
-	ResourceApplyType  = "apply"
+	ResourceApplyType = "apply"
 	// Status of successful resource event
 	ResourceOperationSuccessful = "Successful"
 	// Group event of type apply has summary type
@@ -26,14 +26,14 @@ type ResourceApplyStatus struct {
 }
 
 type GroupApplyStatus struct {
-	Action          string `json:"action"`
-	Count           int    `json:"count"`
-	Failed          int    `json:"failed"`
-	Skipped         int    `json:"skipped"`
-	Status          string `json:"status"`
-	Successful       int   `json:"successful"`
-	Timestamp string `json:"timestamp"`
-	Type      string `json:"type"`
+	Action     string `json:"action"`
+	Count      int    `json:"count"`
+	Failed     int    `json:"failed"`
+	Skipped    int    `json:"skipped"`
+	Status     string `json:"status"`
+	Successful int    `json:"successful"`
+	Timestamp  string `json:"timestamp"`
+	Type       string `json:"type"`
 }
 
 // GetPkgApplyResourcesStatus finds individual kpt apply statuses from newline separated string of apply statuses

--- a/infra/blueprint-test/pkg/krmt/krm.go
+++ b/infra/blueprint-test/pkg/krmt/krm.go
@@ -132,11 +132,7 @@ func NewKRMBlueprintTest(t testing.TB, opts ...krmtOption) *KRMBlueprintTest {
 			t.Fatalf("Dir path %s does not exist", krmt.exampleDir)
 		}
 	} else {
-		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatalf("unable to get wd :%v", err)
-		}
-		exampleDir, err := discovery.GetConfigDirFromTestDir(cwd)
+		exampleDir, err := discovery.GetConfigDirFromTestDir(utils.GetWD(t))
 		if err != nil {
 			t.Fatalf("unable to detect KRM dir :%v", err)
 		}
@@ -173,12 +169,8 @@ func NewKRMBlueprintTest(t testing.TB, opts ...krmtOption) *KRMBlueprintTest {
 
 // getDefaultBuildDir returns a temporary build directory for hydrated configs.
 func (b *KRMBlueprintTest) getDefaultBuildDir() string {
-	cwd, err := os.Getwd()
-	if err != nil {
-		b.t.Fatalf("unable to get wd :%v", err)
-	}
-	buildDir := path.Join(cwd, tmpBuildDir)
-	err = os.MkdirAll(buildDir, 0755)
+	buildDir := path.Join(utils.GetWD(b.t), tmpBuildDir)
+	err := os.MkdirAll(buildDir, 0755)
 	if err != nil {
 		b.t.Fatalf("unable to create %s :%v", buildDir, err)
 	}

--- a/infra/blueprint-test/pkg/tft/terraform.go
+++ b/infra/blueprint-test/pkg/tft/terraform.go
@@ -176,11 +176,7 @@ func NewTFBlueprintTest(t testing.TB, opts ...tftOption) *TFBlueprintTest {
 			t.Fatalf("TFDir path %s does not exist", tft.tfDir)
 		}
 	} else {
-		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatalf("unable to get wd :%v", err)
-		}
-		tfdir, err := discovery.GetConfigDirFromTestDir(cwd)
+		tfdir, err := discovery.GetConfigDirFromTestDir(utils.GetWD(t))
 		if err != nil {
 			t.Fatalf("unable to detect TFDir :%v", err)
 		}

--- a/infra/blueprint-test/pkg/utils/env.go
+++ b/infra/blueprint-test/pkg/utils/env.go
@@ -39,3 +39,12 @@ func SetEnv(t testing.TB, key string, value string) {
 		t.Fatal("Unable to put environment variable %s: %v", key, err)
 	}
 }
+
+// Get the environment Working Directory.
+func GetWD(t testing.TB) string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("unable to get wd :%v", err)
+	}
+	return cwd
+}

--- a/infra/blueprint-test/pkg/utils/files.go
+++ b/infra/blueprint-test/pkg/utils/files.go
@@ -20,7 +20,7 @@ func WriteTmpFile(data string) (string, error) {
 
 // WriteTmpFileWithExtension writes data to a temp file with given extension and returns the path.
 func WriteTmpFileWithExtension(data string, extension string) (string, error) {
-	f, err := ioutil.TempFile("", "*." + extension)
+	f, err := ioutil.TempFile("", "*."+extension)
 	if err != nil {
 		return "", err
 	}

--- a/infra/blueprint-test/pkg/utils/version.go
+++ b/infra/blueprint-test/pkg/utils/version.go
@@ -26,7 +26,7 @@ import (
 func MinSemver(gotSemver string, minSemver string) error {
 	if !semver.IsValid(gotSemver) {
 		return fmt.Errorf("unable to parse got version %q", gotSemver)
-	} else 	if !semver.IsValid(minSemver) {
+	} else if !semver.IsValid(minSemver) {
 		return fmt.Errorf("unable to parse minimum version %q", minSemver)
 	}
 	if semver.Compare(gotSemver, minSemver) == -1 {


### PR DESCRIPTION
* Fixes #1445 
* Adds `kpt.GetKptVersion()`
* Adds `utils.GetWD()`
* Go code formating


Tested with `go test -v krm_simple_blueprint_test.g`