### PR TITLE
Add basic boilerplate code for blueprint metadata consumption CLI command

### DIFF
--- a/cli/bpconsume/cmd.go
+++ b/cli/bpconsume/cmd.go
@@ -1,0 +1,22 @@
+package bpconsume
+
+import (
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpconsume/jumpstartsolutions"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	Cmd.AddCommand(jumpstartsolutions.Cmd)
+}
+
+var Cmd = &cobra.Command{
+	Use:   "consume",
+	Short: "Consumes blueprint metadata",
+	Long:  `Consumes blueprint metadata to generate solution specific metadata`,
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		if args == nil || len(args) == 0 {
+			cmd.HelpFunc()(cmd, args)
+		}
+	},
+}

--- a/cli/bpconsume/jumpstartsolutions/cmd.go
+++ b/cli/bpconsume/jumpstartsolutions/cmd.go
@@ -1,0 +1,88 @@
+package jumpstartsolutions
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpmetadata"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	metadataFileName = "metadata.yaml"
+)
+
+var jssConsumptionFlags struct {
+	bpPath string
+}
+
+func init() {
+	viper.AutomaticEnv()
+
+	Cmd.Flags().StringVarP(&jssConsumptionFlags.bpPath, "path", "p", ".", "path to blueprint for metadata consumption")
+}
+
+var Cmd = &cobra.Command{
+	Use:   "jump-start-solutions",
+	Short: "Generates blueprint metadata for jump start solutions",
+	Long:  `Generates blueprint metadata for jump start solutions`,
+	Args:  cobra.NoArgs,
+	RunE:  generate,
+}
+
+// The top-level command function that consumes blueprint metadata and
+// generates metadata for jump start solutions.
+func generate(cmd *cobra.Command, args []string) error {
+	wdPath, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("error getting working dir: %w", err)
+	}
+
+	bpPath := jssConsumptionFlags.bpPath
+	if !path.IsAbs(bpPath) {
+		bpPath = path.Join(wdPath, bpPath)
+	}
+
+	err = consumeMetadata(bpPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// consumeMetadata reads the metadata.yaml from the provided path and
+// generates textproto and soy files.
+func consumeMetadata(bpPath string) error {
+	bpObj, err := bpmetadata.UnmarshalMetadata(bpPath, metadataFileName)
+	if err != nil {
+		return err
+	}
+
+	err = generateSoyFile(bpObj)
+	if err != nil {
+		return err
+	}
+
+	err = generateTextprotoFile(bpObj)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// generateSoyFile consumes the blueprint metadata object to generate soy file.
+func generateSoyFile(bpObj *bpmetadata.BlueprintMetadata) error {
+	// TODO
+	return nil
+}
+
+// generateTextprotoFile consumes the blueprint metadata object to
+// generate the textproto file.
+func generateTextprotoFile(bpObj *bpmetadata.BlueprintMetadata) error {
+	// TODO
+	return nil
+}

--- a/cli/cmd/blueprint.go
+++ b/cli/cmd/blueprint.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpbuild"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpcatalog"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpconsume"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpmetadata"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bptest"
 	"github.com/spf13/cobra"
@@ -13,6 +14,7 @@ func init() {
 	blueprintCmd.AddCommand(bpbuild.Cmd)
 	blueprintCmd.AddCommand(bptest.Cmd)
 	blueprintCmd.AddCommand(bpcatalog.Cmd)
+	blueprintCmd.AddCommand(bpconsume.Cmd)
 
 	rootCmd.AddCommand(blueprintCmd)
 }


### PR DESCRIPTION
Adding boilerplate code for blueprint metadata consumption CLI command.

Usage e.g.: cft blueprint consume jump-start-solutions -p <path-to-metadata.yaml>

This will be used to produce .textproto and .soy files which can be consumed by jump start solutions.

