### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,8 @@
 # Main team administering overall repo
-*           @bharathkkb @ocsig @kaariger @g-awmalik @apeabody
+*           @bharathkkb @g-awmalik @apeabody
 
 # Deployment Manager Reviewers
 /dm/        @ocsig @sjvanrossum
-
-# CLI owners
-/cli/       @bharathkkb @kaariger @g-awmalik @apeabody
 
 # Config Connector team
 /config-connector/ @ocsig @AlexBulankou @maqiuyujoyce


### PR DESCRIPTION
Also removing `cli`, we can always re-add in the future if needed.