### PR TITLE
chore: remove dead links from #1550

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -11,7 +11,7 @@ assignees: ''
 
 Dear CFT User! 
 
-If you are looking to build new GCP infrastructure, we recommend that you use [Terraform CFT modules](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/blob/master/docs/terraform.md)
+If you are looking to build new GCP infrastructure, we recommend that you use [Terraform CFT modules](https://g.co/dev/terraformfoundation)
 Terraform CFT supports the most recent GCP resources, reflects GCP best practices can be used off-the-shelf to quickly build a repeatable enterprise-ready foundation.
 Additionally, if you are a looking to manage your GCP resources through Kubernetes, consider using [Config Connector CFT solutions](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/tree/master/config-connector/solutions).
 

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,5 +1,5 @@
 Dear CFT User!
 
-If you are looking to build new GCP infrastructure, we recommend that you use [Terraform CFT modules](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/blob/master/docs/terraform.md)
+If you are looking to build new GCP infrastructure, we recommend that you use [Terraform CFT modules](https://g.co/dev/terraformfoundation)
 Terraform CFT supports the most recent GCP resources, reflects GCP best practices can be used off-the-shelf to quickly build a repeatable enterprise-ready foundation.
 Additionally, if you are a looking to manage your GCP resources through Kubernetes, consider using [Config Connector CFT solutions](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/tree/master/config-connector/solutions).

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.iml
 .idea
 credentials.json
-docs/meta/env
 config-connector/tests/testcases/environments.yaml
 .DS_Store
 .vscode

--- a/dm/README.md
+++ b/dm/README.md
@@ -1,6 +1,6 @@
 # Dear CFT User! 
 
-If you are looking to build new GCP infrastructure, we recommend that you use [Terraform CFT modules](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/blob/master/docs/terraform.md)
+If you are looking to build new GCP infrastructure, we recommend that you use [Terraform CFT modules](https://g.co/dev/terraformfoundation)
 Terraform CFT supports the most recent GCP resources, reflects GCP best practices can be used off-the-shelf to quickly build a repeatable enterprise-ready foundation.
 Additionally, if you are a looking to manage your GCP resources through Kubernetes, consider using [Config Connector CFT solutions](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/tree/master/config-connector/solutions).
 


### PR DESCRIPTION
`docs/` is gone, so this removes/redirects references to it