### PR TITLE
chore: add terraform-ml-image-annotation-gcf repo

### DIFF
--- a/infra/terraform/test-org/ci-triggers/locals.tf
+++ b/infra/terraform/test-org/ci-triggers/locals.tf
@@ -39,6 +39,7 @@ locals {
     "large-data-sharing-java-app" = "terraform-large-data-sharing-java-webapp"
     "large-data-sharing-go-app"   = "terraform-large-data-sharing-golang-webapp"
     "java-dynamic-point-of-sale"  = "terraform-example-java-dynamic-point-of-sale"
+    "ml-image-annotation-gcf"     = "terraform-ml-image-annotation-gcf"
   }
   # example foundation has custom test modes
   example_foundation                = { "terraform-example-foundation" = data.terraform_remote_state.org.outputs.ci_repos_folders["example-foundation"] }

--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -635,5 +635,13 @@ locals {
       description = "Deploys a large data sharing Golang web app"
       groups      = ["torus-dpe", "dee-platform-ops", "dee-data-ai", local.jss_common_group]
     },
+    {
+      name        = "terraform-ml-image-annotation-gcf"
+      short_name  = "ml-image-annotation-gcf"
+      org         = "GoogleCloudPlatform"
+      description = "Deploys an app for ml image annotation using gcf"
+      owners      = ["xsxm", "ivanmkc", "balajismaniam", "donmccasland"]
+      groups      = ["dee-data-ai", local.jss_common_group]
+    },
   ]
 }


### PR DESCRIPTION
Onboarding https://github.com/GoogleCloudPlatform/terraform-ml-image-annotation-gcf. This repo hosts UP3.1.