### PR TITLE
chore: update release-cli to GO 1.18

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '~1.16'
+          go-version: '~1.18'
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'


### PR DESCRIPTION
Overlooked as part of https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/pull/1593