### PR TITLE
chore: change ci_team to triage

### DIFF
--- a/infra/terraform/modules/repositories/main.tf
+++ b/infra/terraform/modules/repositories/main.tf
@@ -95,5 +95,5 @@ resource "github_team_repository" "ci_teams" {
   }
   repository = each.value.repo
   team_id    = each.value.team
-  permission = "pull"
+  permission = "triage"
 }


### PR DESCRIPTION
Appears to worked in this test: https://github.com/terraform-google-modules/terraform-google-vm/pull/313

Somewhat unclear as dpebot has pull