### PR TITLE
chore: update update-tooling

### DIFF
--- a/.github/workflows/update-tooling.yml
+++ b/.github/workflows/update-tooling.yml
@@ -105,3 +105,4 @@ jobs:
           labels: automated pr
           reviewers: bharathkkb, apeabody
           branch: create-pull-request/patch-tools-version
+          base: master


### PR DESCRIPTION
* `base` is needed for the on-release trigger as it's from a commit