### PR TITLE
fix: changing order in which args and commonOpts slices are combined

### DIFF
--- a/infra/blueprint-test/pkg/bq/bq.go
+++ b/infra/blueprint-test/pkg/bq/bq.go
@@ -95,7 +95,7 @@ func RunCmdE(t testing.TB, cmd string, opts ...cmdOption) (string, error) {
 	args := strings.Fields(cmd)
 	bqCmd := shell.Command{
 		Command: "bq",
-		Args:    append(args, gOpts.commonArgs...),
+		Args:    append(gOpts.commonArgs, args...),
 		Logger:  gOpts.logger,
 	}
 	return shell.RunCommandAndGetStdOutE(t, bqCmd)

--- a/infra/blueprint-test/pkg/bq/bq_test.go
+++ b/infra/blueprint-test/pkg/bq/bq_test.go
@@ -32,7 +32,7 @@ func TestRunf(t *testing.T) {
 	}{
 		{
 			name:            "Runf",
-			cmd:             "ls --datasets --project_id=%s",
+			cmd:             "query --nouse_legacy_sql 'select * FROM %s.samples.INFORMATION_SCHEMA.TABLES limit 1;'",
 			projectIdEnvVar: "bigquery-public-data",
 		},
 	}
@@ -41,7 +41,7 @@ func TestRunf(t *testing.T) {
 			if projectName, present := os.LookupEnv(tt.projectIdEnvVar); present {
 				op := Runf(t, tt.cmd, projectName)
 				assert := assert.New(t)
-				assert.Equal("bigquery#dataset", op.Array()[0].Get("kind").String())
+				assert.Contains(op.Array()[0], "creation_time")
 			} else {
 				t.Logf("Skipping test, %s envvar not set", tt.projectIdEnvVar)
 				t.Skip()


### PR DESCRIPTION
bq commonArgs should come before command args: https://cloud.google.com/bigquery/docs/bq-command-line-tool#positioning_flags_and_arguments

Refactored test to catch this going forward.