### PR TITLE
fix: add bq init step to create local config file

### DIFF
--- a/infra/blueprint-test/pkg/bq/bq.go
+++ b/infra/blueprint-test/pkg/bq/bq.go
@@ -85,8 +85,8 @@ func initBq(t testing.TB) {
 	}
 	fileName := homeDir + "/.bigqueryrc"
 	 _ , err = os.Stat(fileName)
-	if err != nil && !os.IsNotExist(err) { 
-		t.Fatal(err) 
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
 	}
 	file, err := os.Create(fileName)
 	if err != nil {

--- a/infra/blueprint-test/pkg/bq/bq.go
+++ b/infra/blueprint-test/pkg/bq/bq.go
@@ -78,20 +78,21 @@ func newCmdConfig(opts ...cmdOption) (*CmdCfg, error) {
 }
 
 // initBq checks for a local .bigqueryrc file and creates an empty one if not to avoid forced bigquery initialization, which doesn't output valid json.
-func initBq() (error) {
+func initBq(t testing.TB) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return err
+		t.Fatal(err)
 	}
 	fileName := homeDir + "/.bigqueryrc"
 	 _ , err = os.Stat(fileName)
-	if !os.IsNotExist(err) { return nil }
+	if err != nil && !os.IsNotExist(err) { 
+		t.Fatal(err) 
+	}
 	file, err := os.Create(fileName)
 	if err != nil {
-		return err
+		t.Fatal(err)
 	}
 	file.Close()
-	return nil
 }
 
 // RunCmd executes a bq command and fails test if there are any errors.
@@ -109,11 +110,7 @@ func RunCmdE(t testing.TB, cmd string, opts ...cmdOption) (string, error) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	err = initBq()
-	if err != nil {
-		t.Fatal(err)
-	}
+        initBq(t)
 	// split command into args
 	args := strings.Fields(cmd)
 	bqCmd := shell.Command{

--- a/infra/blueprint-test/pkg/bq/bq.go
+++ b/infra/blueprint-test/pkg/bq/bq.go
@@ -85,14 +85,13 @@ func initBq() (error) {
 	}
 	fileName := homeDir + "/.bigqueryrc"
 	 _ , err = os.Stat(fileName)
-	if os.IsNotExist(err) {
-		file, err := os.Create(fileName)
-		if err != nil {
-			return err
-		}
-		file.Close()
+	if !os.IsNotExist(err) { return nil }
+	file, err := os.Create(fileName)
+	if err != nil {
+		return err
 	}
-        return nil
+	file.Close()
+	return nil
 }
 
 // RunCmd executes a bq command and fails test if there are any errors.

--- a/infra/blueprint-test/pkg/bq/bq.go
+++ b/infra/blueprint-test/pkg/bq/bq.go
@@ -84,7 +84,7 @@ func initBq() (error) {
 		return err
 	}
 	fileName := homeDir + "/.bigqueryrc"
-	 _ , err := os.Stat(fileName)
+	 _ , err = os.Stat(fileName)
 	if os.IsNotExist(err) {
 		file, err := os.Create(fileName)
 		if err != nil {
@@ -111,7 +111,7 @@ func RunCmdE(t testing.TB, cmd string, opts ...cmdOption) (string, error) {
 		t.Fatal(err)
 	}
 
-	err := initBq()
+	err = initBq()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
If the local environment does not have a .bigqueryrc file, using the tool will faill as bq initializing itself does not output valid json data.