### PR TITLE
chore: update CI-trigger ignore filter to ignore png files

### DIFF
--- a/infra/terraform/test-org/ci-triggers/triggers.tf
+++ b/infra/terraform/test-org/ci-triggers/triggers.tf
@@ -419,7 +419,7 @@ resource "google_cloudbuild_trigger" "example_foundations_int_trigger" {
   }
 
   filename      = "build/int.cloudbuild.yaml"
-  ignored_files = ["**/*.md", ".gitignore", ".github/**"]
+  ignored_files = ["**/*.md", "**/*.png", ".gitignore", ".github/**"]
 }
 
 


### PR DESCRIPTION
This PR updates the Terraform Example Foundation CI-trigger ignore filter to ignore png files