### PR TITLE
chore: update renovate.json

### DIFF
--- a/infra/terraform/test-org/github/resources/renovate.json
+++ b/infra/terraform/test-org/github/resources/renovate.json
@@ -31,6 +31,7 @@
     {"matchDepTypes": ["module"], "groupName": "TF modules"},
     {
       "matchManagers": ["regex", "gomod"],
+      "groupName": "GO and Dev-Tools",
       "rangeStrategy": "bump",
       "postUpdateOptions": ["gomodTidy"]
     },

--- a/infra/terraform/test-org/github/resources/renovate.json
+++ b/infra/terraform/test-org/github/resources/renovate.json
@@ -30,10 +30,14 @@
     },
     {"matchDepTypes": ["module"], "groupName": "TF modules"},
     {
+      "matchDatasources": ["golang-version"],
+      "rangeStrategy": "replace",
+      "allowedVersions": "1.21",
+      "postUpdateOptions": ["gomodTidy"]
+    },
+    {
       "matchManagers": ["regex", "gomod"],
       "groupName": "GO and Dev-Tools",
-      "rangeStrategy": "bump",
-      "postUpdateOptions": ["gomodTidy"]
     },
     {
       "matchDepNames": ["google", "google-beta"],

--- a/infra/terraform/test-org/github/resources/renovate.json
+++ b/infra/terraform/test-org/github/resources/renovate.json
@@ -30,6 +30,10 @@
     },
     {"matchDepTypes": ["module"], "groupName": "TF modules"},
     {
+      "matchDepTypes": ["require"],
+      "postUpdateOptions": ["gomodTidy"]
+    },
+    {
       "matchDatasources": ["golang-version"],
       "rangeStrategy": "replace",
       "allowedVersions": "1.21",


### PR DESCRIPTION
combine GO and Dev-Tools update PRs while setting GO version to 1.21