### PR TITLE
feat: Add secrets for GitHub/GitLab tokens

### DIFF
--- a/infra/terraform/test-org/ci-triggers/secrets.tf
+++ b/infra/terraform/test-org/ci-triggers/secrets.tf
@@ -29,3 +29,35 @@ resource "google_secret_manager_secret_iam_member" "tfe_token_member" {
   role      = "roles/secretmanager.secretAccessor"
   member    = "group:${data.terraform_remote_state.org.outputs.cft_ci_group}"
 }
+
+resource "google_secret_manager_secret" "im_github_pat" {
+  project = local.project_id
+  secret_id = "im_github_pat"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "im_github_pat_member" {
+  project = google_secret_manager_secret.im_github_pat.project
+  secret_id = google_secret_manager_secret.im_github_pat.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "group:${data.terraform_remote_state.org.outputs.cft_ci_group}"
+}
+
+resource "google_secret_manager_secret" "im_gitlab_pat" {
+  project = local.project_id
+  secret_id = "im_gitlab_pat"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "im_gitlab_pat_member" {
+  project = google_secret_manager_secret.im_gitlab_pat.project
+  secret_id = google_secret_manager_secret.im_gitlab_pat.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "group:${data.terraform_remote_state.org.outputs.cft_ci_group}"
+}

--- a/infra/terraform/test-org/ci-triggers/secrets.tf
+++ b/infra/terraform/test-org/ci-triggers/secrets.tf
@@ -31,7 +31,7 @@ resource "google_secret_manager_secret_iam_member" "tfe_token_member" {
 }
 
 resource "google_secret_manager_secret" "im_github_pat" {
-  project = local.project_id
+  project   = local.project_id
   secret_id = "im_github_pat"
 
   replication {
@@ -40,14 +40,14 @@ resource "google_secret_manager_secret" "im_github_pat" {
 }
 
 resource "google_secret_manager_secret_iam_member" "im_github_pat_member" {
-  project = google_secret_manager_secret.im_github_pat.project
+  project   = google_secret_manager_secret.im_github_pat.project
   secret_id = google_secret_manager_secret.im_github_pat.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "group:${data.terraform_remote_state.org.outputs.cft_ci_group}"
 }
 
 resource "google_secret_manager_secret" "im_gitlab_pat" {
-  project = local.project_id
+  project   = local.project_id
   secret_id = "im_gitlab_pat"
 
   replication {
@@ -56,7 +56,7 @@ resource "google_secret_manager_secret" "im_gitlab_pat" {
 }
 
 resource "google_secret_manager_secret_iam_member" "im_gitlab_pat_member" {
-  project = google_secret_manager_secret.im_gitlab_pat.project
+  project   = google_secret_manager_secret.im_gitlab_pat.project
   secret_id = google_secret_manager_secret.im_gitlab_pat.secret_id
   role      = "roles/secretmanager.secretAccessor"
   member    = "group:${data.terraform_remote_state.org.outputs.cft_ci_group}"


### PR DESCRIPTION
To be used in testing setting up Cloud Build repository connections to GitHub/GitLab repositories for a new Infrastructure Manager blueprint.