### PR TITLE
fix: Add local.jss_common_group to dataanalytics-eventdriven JSS

### DIFF
--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -893,6 +893,7 @@ locals {
       short_name  = "dataanalytics-eventdriven"
       org         = "GoogleCloudPlatform"
       description = "Uses click-to-deploy to demonstrate how to load data from Cloud Storage to BigQuery using an event-driven load function."
+      groups      = [local.jss_common_group]
       owners      = ["fellipeamedeiros", "sylvioneto"]
     },
   ]


### PR DESCRIPTION
* I am adding `local.jss_common_group` ([jump-start-solutions-admins GitHub team](https://github.com/orgs/GoogleCloudPlatform/teams/jump-start-solutions-admins)) to the `dataanalytics-eventdriven` JSS.
* Members of this GitHub team (including myself and Karl) may sometimes help unblock small PRs (like Renovate PRs) and regularly work on continuous improvement projects — across all JSS repos.
* I'll also work on improving the related instructions (from the JSS authoring guide) via [cl/622203416](http://cl/622203416).
* CC: @fellipeamedeiros (just for visibility)