### PR TITLE
chore: Exclude tflint plugin from lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,5 +34,5 @@ jobs:
       - uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # v4
       - run: docker run --rm -e EXCLUDE_LINT_DIRS -e EXCLUDE_HEADER_CHECK -v ${{ github.workspace }}:/workspace gcr.io/cloud-foundation-cicd/cft/developer-tools:1 /usr/local/bin/test_lint.sh
         env:
-          EXCLUDE_LINT_DIRS: '\./cli|\./infra/build|\./infra/utils|\./infra/blueprint-test|\./infra/concourse|\./infra/modules|\./reports|\./.github|\./docs|\./infra/module-swapper'
+          EXCLUDE_LINT_DIRS: '\./cli|\./tflint-ruleset-blueprint|\./infra/build|\./infra/utils|\./infra/blueprint-test|\./infra/concourse|\./infra/modules|\./reports|\./.github|\./docs|\./infra/module-swapper'
           EXCLUDE_HEADER_CHECK: '.*'


### PR DESCRIPTION
Testdata may contain invalid config for test purposes