### PR TITLE
chore: add release automation for tflint plugin

### DIFF
--- a/.github/workflows/release-tflint-plugin.yml
+++ b/.github/workflows/release-tflint-plugin.yml
@@ -1,0 +1,39 @@
+name: release-tflint
+
+on:
+  push:
+    tags:
+    - tflint-ruleset-blueprint/v*.*.*
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 'tflint-ruleset-blueprint'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Set up Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version-file: 'tflint-ruleset-blueprint/go.mod'
+        - run: echo "GORELEASER_CURRENT_TAG=${GITHUB_REF#refs/tags/tflint-ruleset-blueprint/}" >> $GITHUB_ENV
+    - run: echo "${{env.GORELEASER_CURRENT_TAG}}"
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v5
+      with:
+        version: latest
+        args: release --clean --skip=validate,publish
+        workdir: tflint-ruleset-blueprint
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: upload
+      run: |
+          gh release upload "tflint-ruleset-blueprint/${{env.GORELEASER_CURRENT_TAG}}" dist/tflint-ruleset-blueprint_*.zip dist/checksums.txt --repo ${{ github.repository }} --clobber
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
   "infra/blueprint-test": "0.14.0",
-  "infra/module-swapper": "0.4.5"
+  "infra/module-swapper": "0.4.5",
+  "tflint-ruleset-blueprint": "0.0.1"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,13 @@
       "component": "infra/module-swapper",
       "pull-request-title-pattern": "chore${scope}: release module-swapper ${version}",
       "bump-minor-pre-major": true
+    },
+    "tflint-ruleset-blueprint": {
+      "release-type": "go",
+      "package-name": "tflint-ruleset-blueprint",
+      "component": "tflint-ruleset-blueprint",
+      "pull-request-title-pattern": "chore${scope}: release tflint-ruleset-blueprint ${version}",
+      "bump-minor-pre-major": true
     }
   }
 }

--- a/tflint-ruleset-blueprint/.goreleaser.yml
+++ b/tflint-ruleset-blueprint/.goreleaser.yml
@@ -1,0 +1,32 @@
+project_name: tflint-ruleset-blueprint
+env:
+  - CGO_ENABLED=0
+builds:
+  - targets:
+      - darwin_amd64
+      - darwin_arm64
+      - linux_386
+      - linux_amd64
+      - linux_arm
+      - linux_arm64
+      - windows_386
+      - windows_amd64
+    hooks:
+      post:
+        - mkdir -p ./dist/raw
+        - cp "{{ .Path }}" "./dist/raw/{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+archives:
+  - id: zip
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    format: zip
+    files:
+      - none*
+checksum:
+  name_template: 'checksums.txt'
+  extra_files:
+    - glob: ./dist/raw/*
+changelog:
+  disable: true
+release:
+  mode: 'keep-existing'
+  name_template: "tflint-ruleset-blueprint/v{{.Version}}"


### PR DESCRIPTION
This adds release please configs for releasing plugin and a workflow that is triggered on release to build and upload artifacts.  

Goreleaser is used to build and package the artifacts in the format expected by tflint https://github.com/terraform-linters/tflint/blob/master/docs/developer-guide/plugins.md#4-creating-a-github-release. We don't use goreleaser to publish them as mono support is a pro (paid) feature https://goreleaser.com/customization/monorepo. Instead I used the gh cli to upload artifacts to the release.