### PR TITLE
feat: expose plan stage via test cli

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 # Changing this value will trigger a new release
-VERSION=v1.2.20
+VERSION=v1.3.20
 BINARY=bin/cft
 GITHUB_REPO=github.com/GoogleCloudPlatform/cloud-foundation-toolkit
 PLATFORMS := linux windows darwin

--- a/cli/bptest/cmd.go
+++ b/cli/bptest/cmd.go
@@ -25,7 +25,7 @@ func init() {
 	Cmd.AddCommand(initCmd)
 
 	Cmd.PersistentFlags().StringVar(&flags.testDir, "test-dir", "", "Path to directory containing integration tests (default is computed by scanning current working directory)")
-	runCmd.Flags().StringVar(&flags.testStage, "stage", "", "Test stage to execute (default is running all stages in order - init, apply, verify, teardown)")
+	runCmd.Flags().StringVar(&flags.testStage, "stage", "", "Test stage to execute (default is running all stages in order - init, plan, apply, verify, teardown)")
 	runCmd.Flags().StringToStringVar(&flags.setupVars, "setup-var", map[string]string{}, "Specify outputs from the setup phase (useful with --stage=verify)")
 }
 

--- a/cli/bptest/convert.go
+++ b/cli/bptest/convert.go
@@ -29,9 +29,9 @@ var (
 	templateFiles          embed.FS
 	kitchenCFTStageMapping = map[string]string{
 		"create":   stages[0],
-		"converge": stages[1],
-		"verify":   stages[2],
-		"destroy":  stages[3],
+		"converge": stages[2],
+		"verify":   stages[3],
+		"destroy":  stages[4],
 	}
 )
 

--- a/cli/bptest/stages.go
+++ b/cli/bptest/stages.go
@@ -2,13 +2,14 @@ package bptest
 
 import "fmt"
 
-var stages = []string{"init", "apply", "verify", "teardown"}
+var stages = []string{"init", "plan", "apply", "verify", "teardown"}
 
 var stagesWithAlias = map[string][]string{
 	stages[0]: {"create"},
-	stages[1]: {"converge"},
-	stages[2]: {},
-	stages[3]: {"destroy"},
+	stages[1]: {},
+	stages[2]: {"converge"},
+	stages[3]: {},
+	stages[4]: {"destroy"},
 }
 
 // validateAndGetStage validates given stage and resolves to stage name if an alias is provided

--- a/cli/bptest/stages_test.go
+++ b/cli/bptest/stages_test.go
@@ -1,6 +1,7 @@
 package bptest
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +32,7 @@ func TestValidateAndGetStage(t *testing.T) {
 		{
 			name:   "invalid name",
 			stage:  "foo",
-			errMsg: "invalid stage name foo - one of [\"init\" \"apply\" \"verify\" \"teardown\"] expected",
+			errMsg: fmt.Sprintf("invalid stage name foo - one of %+q expected", stages),
 		},
 		{
 			name:  "empty (all stages)",


### PR DESCRIPTION
We added plan support in https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/pull/2258 but I missed to add it to CLI