### PR TITLE
chore(CI): ignore example.tfvars and helpers/foundation-deployer in example-foundation-int tests

### DIFF
--- a/infra/terraform/test-org/ci-triggers/triggers.tf
+++ b/infra/terraform/test-org/ci-triggers/triggers.tf
@@ -422,7 +422,7 @@ resource "google_cloudbuild_trigger" "example_foundations_int_trigger" {
   }
 
   filename      = "build/int.cloudbuild.yaml"
-  ignored_files = ["**/*.md", "**/*.png", ".gitignore", ".github/**"]
+  ignored_files = ["**/*.md", "**/*.png", ".gitignore", ".github/**", "**/*.example.tfvars"]
 }
 
 

--- a/infra/terraform/test-org/ci-triggers/triggers.tf
+++ b/infra/terraform/test-org/ci-triggers/triggers.tf
@@ -422,7 +422,7 @@ resource "google_cloudbuild_trigger" "example_foundations_int_trigger" {
   }
 
   filename      = "build/int.cloudbuild.yaml"
-  ignored_files = ["**/*.md", "**/*.png", ".gitignore", ".github/**", "**/*.example.tfvars"]
+  ignored_files = ["**/*.md", "**/*.png", ".gitignore", ".github/**", "**/*.example.tfvars", "helpers/foundation-deployer/**"]
 }
 
 


### PR DESCRIPTION
Doesn't appear the Integration tests cover foundation-deployer, so I've opened PR https://github.com/terraform-google-modules/terraform-example-foundation/pull/1218 for a dedicated workflow.