### PR TITLE
chore(CI): bump repo's renovate go version

### DIFF
--- a/infra/terraform/test-org/github/resources/renovate.json
+++ b/infra/terraform/test-org/github/resources/renovate.json
@@ -13,7 +13,7 @@
     "labels": ["type:security"],
     "minimumReleaseAge": "0 days"
   },
-  "constraints": {"go": "1.21"},
+  "constraints": {"go": "1.22"},
   "packageRules": [
     {
       "matchFileNames": ["*", "modules/**"],
@@ -42,7 +42,7 @@
       "matchManagers": ["gomod"],
       "matchDatasources": ["golang-version"],
       "rangeStrategy": "replace",
-      "allowedVersions": "1.21",
+      "allowedVersions": "1.22",
       "postUpdateOptions": ["gomodTidy"]
     },
     {


### PR DESCRIPTION
- All renovate to update repo's to GO 1.22 as dev-tools 1.21