### PR TITLE
fix: Disable JSS 15.1 periodic tests

### DIFF
--- a/infra/terraform/test-org/org/github.tf
+++ b/infra/terraform/test-org/org/github.tf
@@ -34,9 +34,10 @@ variable "temp_allow_invalid_owners" {
   type        = list(string)
   description = "Googlers added as owners on TF blueprint repos but are not part of the GCP or TGM orgs yet."
   default = [
-    "dulacp",
     "nidhi0710", # remove once heynidhi@ is added to GCP org
     "sylvioneto",
+    "erictune",
+    "megelatim",
   ]
 }
 

--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -642,7 +642,7 @@ locals {
       description     = "Deploy a multizone Java application"
       owners          = ["donmccasland"]
       groups          = [local.jss_common_group]
-      enable_periodic = true
+      enable_periodic = false
       lint_env = {
         ENABLE_BPMETADATA = "1"
       }


### PR DESCRIPTION
* See Google-internal bug: [b/351840017](http://b/351840017)
* We would like to stop all deployments of JSS 15.1.
* JSS 15.1 = Deploy a Java application with Compute Engine
* CC: @donmccasland, @duncantech 