### PR TITLE
chore: bump cli version

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 # Changing this value will trigger a new release
-VERSION=v1.3.6
+VERSION=v1.4.0
 BINARY=bin/cft
 GITHUB_REPO=github.com/GoogleCloudPlatform/cloud-foundation-toolkit
 PLATFORMS := linux windows darwin


### PR DESCRIPTION
To support new connection metadata