### PR TITLE
chore: Add terraform-google-apphub to list of repos

### DIFF
--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -892,5 +892,11 @@ locals {
       groups      = [local.jss_common_group]
       owners      = ["fellipeamedeiros", "sylvioneto"]
     },
+    {
+      name        = "terraform-google-apphub"
+      org         = "GoogleCloudPlatform"
+      description = "Creates and manages AppHub resources"
+      owners      = ["bharathkkb", "q2w"]
+    },
   ]
 }


### PR DESCRIPTION
This PR add new blueprint for apphub to blueprint list.