### PR TITLE
chore(CI): fix custom tflint path

### DIFF
--- a/infra/build/developer-tools/build/scripts/task_helper_functions.sh
+++ b/infra/build/developer-tools/build/scripts/task_helper_functions.sh
@@ -376,14 +376,14 @@ function check_tflint() {
       # load default ruleset
       tflintCfg="/root/tflint/.tflint.example.hcl"
       # load if local repo ruleset
-      if [[ -f "./github/.tflint.repo.hcl" ]]; then
-        tflintCfg="./github/.tflint.repo.hcl"
+      if [[ -f "./.github/.tflint.repo.hcl" ]]; then
+        tflintCfg="./.github/.tflint.repo.hcl"
       # if module, load tighter ruleset
       elif [[ $path == "." || $path == "./modules"* || $path =~ "^[0-9]+-.*" ]]; then
         tflintCfg="/root/tflint/.tflint.module.hcl"
       fi
 
-      cd "${path}" && echo "Working in ${path} ..."
+      cd "${path}" && echo "Working in ${path} using ${tflintCfg}..."
       tflint --config=${tflintCfg} --no-color
       rc=$?
       if [[ "${rc}" -ne 0 ]]; then

--- a/infra/build/developer-tools/build/scripts/task_helper_functions.sh
+++ b/infra/build/developer-tools/build/scripts/task_helper_functions.sh
@@ -376,8 +376,8 @@ function check_tflint() {
       # load default ruleset
       tflintCfg="/root/tflint/.tflint.example.hcl"
       # load if local repo ruleset
-      if [[ -f "./.github/.tflint.repo.hcl" ]]; then
-        tflintCfg="./.github/.tflint.repo.hcl"
+      if [[ -f "/workspace/.github/.tflint.repo.hcl" ]]; then
+        tflintCfg="/workspace/.github/.tflint.repo.hcl"
       # if module, load tighter ruleset
       elif [[ $path == "." || $path == "./modules"* || $path =~ "^[0-9]+-.*" ]]; then
         tflintCfg="/root/tflint/.tflint.module.hcl"


### PR DESCRIPTION
There is a subsequent `cd`, so we should use a non-referential path.