### PR TITLE
feat: preserve manually added connections fields

### DIFF
--- a/cli/bpmetadata/cmd.go
+++ b/cli/bpmetadata/cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"sigs.k8s.io/yaml"
 )
 
@@ -230,9 +231,10 @@ func CreateBlueprintMetadata(bpPath string, bpMetadataObj *BlueprintMetadata) (*
 	}
 
 	var existingInterfaces *BlueprintInterface
-	*existingInterfaces = *bpMetadataObj.Spec.Interfaces
 	if bpMetadataObj.Spec.Interfaces == nil {
 		bpMetadataObj.Spec.Interfaces = &BlueprintInterface{}
+	} else {
+		existingInterfaces = proto.Clone(bpMetadataObj.Spec.Interfaces).(*BlueprintInterface)
 	}
 
 	// create blueprint interfaces i.e. variables & outputs

--- a/cli/bpmetadata/cmd.go
+++ b/cli/bpmetadata/cmd.go
@@ -244,7 +244,7 @@ func CreateBlueprintMetadata(bpPath string, bpMetadataObj *BlueprintMetadata) (*
 	}
 
     // Merge existing connections (if any) into the newly generated interfaces
-    MergeExistingConnections(bpMetadataObj.Spec.Interfaces, existingInterfaces)
+    mergeExistingConnections(bpMetadataObj.Spec.Interfaces, existingInterfaces)
 
 	// get blueprint requirements
 	rolesCfgPath := path.Join(repoDetails.Source.BlueprintRootPath, tfRolesFileName)

--- a/cli/bpmetadata/cmd.go
+++ b/cli/bpmetadata/cmd.go
@@ -229,6 +229,8 @@ func CreateBlueprintMetadata(bpPath string, bpMetadataObj *BlueprintMetadata) (*
 		return nil, fmt.Errorf("error creating blueprint info: %w", err)
 	}
 
+	var existingInterfaces *BlueprintInterface
+	*existingInterfaces = *bpMetadataObj.Spec.Interfaces
 	if bpMetadataObj.Spec.Interfaces == nil {
 		bpMetadataObj.Spec.Interfaces = &BlueprintInterface{}
 	}
@@ -238,6 +240,9 @@ func CreateBlueprintMetadata(bpPath string, bpMetadataObj *BlueprintMetadata) (*
 	if err != nil {
 		return nil, fmt.Errorf("error creating blueprint interfaces: %w", err)
 	}
+
+    // Merge existing connections (if any) into the newly generated interfaces
+    MergeExistingConnections(bpMetadataObj.Spec.Interfaces, existingInterfaces)
 
 	// get blueprint requirements
 	rolesCfgPath := path.Join(repoDetails.Source.BlueprintRootPath, tfRolesFileName)

--- a/cli/bpmetadata/tfconfig.go
+++ b/cli/bpmetadata/tfconfig.go
@@ -395,3 +395,19 @@ func hasTfconfigErrors(diags tfconfig.Diagnostics) error {
 
 	return nil
 }
+
+// MergeExistingConnections merges existing connections from an old BlueprintInterface into a new one,
+// preserving manually authored connections.
+func MergeExistingConnections(newInterfaces, existingInterfaces *BlueprintInterface) {
+    if existingInterfaces == nil {
+        return // Nothing to merge if existingInterfaces is nil
+    }
+
+    for i, variable := range newInterfaces.Variables {
+        for _, existingVariable := range existingInterfaces.Variables {
+            if variable.Name == existingVariable.Name && existingVariable.Connections != nil {
+                newInterfaces.Variables[i].Connections = existingVariable.Connections
+            }
+        }
+    }
+}

--- a/cli/bpmetadata/tfconfig.go
+++ b/cli/bpmetadata/tfconfig.go
@@ -398,7 +398,7 @@ func hasTfconfigErrors(diags tfconfig.Diagnostics) error {
 
 // MergeExistingConnections merges existing connections from an old BlueprintInterface into a new one,
 // preserving manually authored connections.
-func MergeExistingConnections(newInterfaces, existingInterfaces *BlueprintInterface) {
+func mergeExistingConnections(newInterfaces, existingInterfaces *BlueprintInterface) {
     if existingInterfaces == nil {
         return // Nothing to merge if existingInterfaces is nil
     }

--- a/cli/bpmetadata/tfconfig_test.go
+++ b/cli/bpmetadata/tfconfig_test.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	tfTestdataPath = "../testdata/bpmetadata/tf"
+	metadataTestdataPath = "../testdata/bpmetadata/metadata"
 	interfaces     = "sample-module"
 )
 
@@ -263,6 +264,48 @@ func TestTFRoles(t *testing.T) {
 			got, err := parseBlueprintRoles(content)
 			require.NoError(t, err)
 			assert.Equal(t, got, tt.wantRoles)
+		})
+	}
+}
+
+func TestMergeExistingConnections(t *testing.T) {
+	tests := []struct {
+		name                string
+		newInterfacesFile   string
+		existingInterfacesFile string
+	}{
+		{
+			name:                "No existing connections",
+			newInterfacesFile:   "new_interfaces_no_connections_metadata.yaml",
+			existingInterfacesFile: "existing_interfaces_without_connections_metadata.yaml",
+		},
+		{
+			name:                "One existing connection is preserved",
+			newInterfacesFile:   "new_interfaces_no_connections_metadata.yaml",
+			existingInterfacesFile: "existing_interfaces_with_one_connection_metadata.yaml",
+		},
+		{
+			name:                "Multiple existing connections are preserved",
+			newInterfacesFile:   "new_interfaces_no_connections_metadata.yaml",
+			existingInterfacesFile: "existing_interfaces_with_some_connections_metadata.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Load new interfaces from file
+			newInterfaces, err := UnmarshalMetadata(metadataTestdataPath, tt.newInterfacesFile)
+			require.NoError(t, err)
+
+			// Load existing interfaces from file
+			existingInterfaces, err := UnmarshalMetadata(metadataTestdataPath, tt.existingInterfacesFile)
+			require.NoError(t, err)
+
+			// Perform the merge
+			MergeExistingConnections(newInterfaces.Spec.Interfaces, existingInterfaces.Spec.Interfaces)
+
+			// Assert that the merged interfaces match the existing ones
+			assert.Equal(t, existingInterfaces.Spec.Interfaces, newInterfaces.Spec.Interfaces)
 		})
 	}
 }

--- a/cli/bpmetadata/tfconfig_test.go
+++ b/cli/bpmetadata/tfconfig_test.go
@@ -302,7 +302,7 @@ func TestMergeExistingConnections(t *testing.T) {
 			require.NoError(t, err)
 
 			// Perform the merge
-			MergeExistingConnections(newInterfaces.Spec.Interfaces, existingInterfaces.Spec.Interfaces)
+			mergeExistingConnections(newInterfaces.Spec.Interfaces, existingInterfaces.Spec.Interfaces)
 
 			// Assert that the merged interfaces match the existing ones
 			assert.Equal(t, existingInterfaces.Spec.Interfaces, newInterfaces.Spec.Interfaces)

--- a/cli/testdata/bpmetadata/metadata/existing_interfaces_with_one_connection_metadata.yaml
+++ b/cli/testdata/bpmetadata/metadata/existing_interfaces_with_one_connection_metadata.yaml
@@ -1,0 +1,65 @@
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-memorystore
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: Google Cloud Memorystore Terraform Module
+    source:
+      repo: https://github.com/terraform-google-modules/terraform-google-memorystore.git
+      sourceType: git
+    version: 10.0.0
+    actuationTool:
+      flavor: Terraform
+      version: ">= 0.13"
+    description: {}
+  content:
+    subBlueprints:
+      - name: memcache
+        location: modules/memcache
+      - name: redis-cluster
+        location: modules/redis-cluster
+    examples:
+      - name: basic
+        location: examples/basic
+      - name: memcache
+        location: examples/memcache
+      - name: minimal
+        location: examples/minimal
+      - name: redis
+        location: examples/redis
+      - name: redis-cluster
+        location: examples/redis-cluster
+  interfaces:
+    variables:
+      - name: auth_enabled
+        description: Indicates whether OSS Redis AUTH is enabled for the instance. If set to true AUTH is enabled on the instance.
+        varType: bool
+        defaultValue: false
+      - name: authorized_network
+        description: The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
+        varType: string
+        connections:
+        - source:
+            source: github.com/terraform-google-modules/terraform-google-network//modules/vpc
+            version: v9.1.0
+          spec:
+            outputExpr: network_name
+      - name: customer_managed_key
+        description: Default encryption key to apply to the Redis instance. Defaults to null (Google-managed).
+        varType: string
+  requirements:
+    roles:
+      - level: Project
+        roles:
+          - roles/owner
+    services:
+      - cloudresourcemanager.googleapis.com
+      - serviceusage.googleapis.com
+      - redis.googleapis.com
+      - memcache.googleapis.com
+      - serviceconsumermanagement.googleapis.com
+      - networkconnectivity.googleapis.com
+      - compute.googleapis.com

--- a/cli/testdata/bpmetadata/metadata/existing_interfaces_with_some_connections_metadata.yaml
+++ b/cli/testdata/bpmetadata/metadata/existing_interfaces_with_some_connections_metadata.yaml
@@ -1,0 +1,76 @@
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-memorystore
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: Google Cloud Memorystore Terraform Module
+    source:
+      repo: https://github.com/terraform-google-modules/terraform-google-memorystore.git
+      sourceType: git
+    version: 10.0.0
+    actuationTool:
+      flavor: Terraform
+      version: ">= 0.13"
+    description: {}
+  content:
+    subBlueprints:
+      - name: memcache
+        location: modules/memcache
+      - name: redis-cluster
+        location: modules/redis-cluster
+    examples:
+      - name: basic
+        location: examples/basic
+      - name: memcache
+        location: examples/memcache
+      - name: minimal
+        location: examples/minimal
+      - name: redis
+        location: examples/redis
+      - name: redis-cluster
+        location: examples/redis-cluster
+  interfaces:
+    variables:
+      - name: auth_enabled
+        description: Indicates whether OSS Redis AUTH is enabled for the instance. If set to true AUTH is enabled on the instance.
+        varType: bool
+        defaultValue: false
+      - name: authorized_network
+        description: The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
+        varType: string
+        connections:
+        - source:
+            source: github.com/terraform-google-modules/terraform-google-network//modules/vpc
+            version: v9.1.0
+          spec:
+            outputExpr: network_name
+        - source:
+            source: github.com/terraform-google-modules/terraform-google-vpc-service-controls//modules/access_level
+            version: v6.0.0
+          spec:
+            outputExpr: network_acl_name
+      - name: customer_managed_key
+        description: Default encryption key to apply to the Redis instance. Defaults to null (Google-managed).
+        varType: string
+        connections:
+        - source:
+            source: github.com/terraform-google-modules/terraform-google-kms
+            version: v2.3.0
+          spec:
+            outputExpr: kms_name
+  requirements:
+    roles:
+      - level: Project
+        roles:
+          - roles/owner
+    services:
+      - cloudresourcemanager.googleapis.com
+      - serviceusage.googleapis.com
+      - redis.googleapis.com
+      - memcache.googleapis.com
+      - serviceconsumermanagement.googleapis.com
+      - networkconnectivity.googleapis.com
+      - compute.googleapis.com

--- a/cli/testdata/bpmetadata/metadata/existing_interfaces_without_connections_metadata.yaml
+++ b/cli/testdata/bpmetadata/metadata/existing_interfaces_without_connections_metadata.yaml
@@ -1,0 +1,59 @@
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-memorystore
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: Google Cloud Memorystore Terraform Module
+    source:
+      repo: https://github.com/terraform-google-modules/terraform-google-memorystore.git
+      sourceType: git
+    version: 10.0.0
+    actuationTool:
+      flavor: Terraform
+      version: ">= 0.13"
+    description: {}
+  content:
+    subBlueprints:
+      - name: memcache
+        location: modules/memcache
+      - name: redis-cluster
+        location: modules/redis-cluster
+    examples:
+      - name: basic
+        location: examples/basic
+      - name: memcache
+        location: examples/memcache
+      - name: minimal
+        location: examples/minimal
+      - name: redis
+        location: examples/redis
+      - name: redis-cluster
+        location: examples/redis-cluster
+  interfaces:
+    variables:
+      - name: auth_enabled
+        description: Indicates whether OSS Redis AUTH is enabled for the instance. If set to true AUTH is enabled on the instance.
+        varType: bool
+        defaultValue: false
+      - name: authorized_network
+        description: The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
+        varType: string
+      - name: customer_managed_key
+        description: Default encryption key to apply to the Redis instance. Defaults to null (Google-managed).
+        varType: string
+  requirements:
+    roles:
+      - level: Project
+        roles:
+          - roles/owner
+    services:
+      - cloudresourcemanager.googleapis.com
+      - serviceusage.googleapis.com
+      - redis.googleapis.com
+      - memcache.googleapis.com
+      - serviceconsumermanagement.googleapis.com
+      - networkconnectivity.googleapis.com
+      - compute.googleapis.com

--- a/cli/testdata/bpmetadata/metadata/new_interfaces_no_connections_metadata.yaml
+++ b/cli/testdata/bpmetadata/metadata/new_interfaces_no_connections_metadata.yaml
@@ -1,0 +1,59 @@
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-memorystore
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: Google Cloud Memorystore Terraform Module
+    source:
+      repo: https://github.com/terraform-google-modules/terraform-google-memorystore.git
+      sourceType: git
+    version: 10.0.0
+    actuationTool:
+      flavor: Terraform
+      version: ">= 0.13"
+    description: {}
+  content:
+    subBlueprints:
+      - name: memcache
+        location: modules/memcache
+      - name: redis-cluster
+        location: modules/redis-cluster
+    examples:
+      - name: basic
+        location: examples/basic
+      - name: memcache
+        location: examples/memcache
+      - name: minimal
+        location: examples/minimal
+      - name: redis
+        location: examples/redis
+      - name: redis-cluster
+        location: examples/redis-cluster
+  interfaces:
+    variables:
+      - name: auth_enabled
+        description: Indicates whether OSS Redis AUTH is enabled for the instance. If set to true AUTH is enabled on the instance.
+        varType: bool
+        defaultValue: false
+      - name: authorized_network
+        description: The full name of the Google Compute Engine network to which the instance is connected. If left unspecified, the default network will be used.
+        varType: string
+      - name: customer_managed_key
+        description: Default encryption key to apply to the Redis instance. Defaults to null (Google-managed).
+        varType: string
+  requirements:
+    roles:
+      - level: Project
+        roles:
+          - roles/owner
+    services:
+      - cloudresourcemanager.googleapis.com
+      - serviceusage.googleapis.com
+      - redis.googleapis.com
+      - memcache.googleapis.com
+      - serviceconsumermanagement.googleapis.com
+      - networkconnectivity.googleapis.com
+      - compute.googleapis.com


### PR DESCRIPTION
Preserve manually added connections fields in the metadata.yaml files when the metadata files are recompiled for whatever the reason (version updates, dependency changes, etc).

Also added test cases to make sure the logic works in multiple conditions.