### PR TITLE
fix: Version config path should look for versions.tf in current blueprint dirctory

### DIFF
--- a/cli/bpmetadata/cmd.go
+++ b/cli/bpmetadata/cmd.go
@@ -259,7 +259,7 @@ func CreateBlueprintMetadata(bpPath string, bpMetadataObj *BlueprintMetadata) (*
 	// get blueprint requirements
 	rolesCfgPath := path.Join(repoDetails.Source.BlueprintRootPath, tfRolesFileName)
 	svcsCfgPath := path.Join(repoDetails.Source.BlueprintRootPath, tfServicesFileName)
-	versionsCfgPath := path.Join(repoDetails.Source.BlueprintRootPath, tfVersionsFileName)
+	versionsCfgPath := path.Join(bpPath, tfVersionsFileName)
 	requirements, err := getBlueprintRequirements(rolesCfgPath, svcsCfgPath, versionsCfgPath)
 	if err != nil {
 		Log.Info("skipping blueprint requirements since roles and/or services configurations were not found as per https://tinyurl.com/tf-iam and https://tinyurl.com/tf-services")


### PR DESCRIPTION
In blueprint metadata generation step, versions.tf needs to be loaded for generating version metadata. 
Currently versions.tf file is being only searched in the root directory of the blueprint. This fails to generated version metadata for the submodules.
This feature was added in https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/pull/2496