### PR TITLE
feat: Support display metadata AlternateDefault validate

### DIFF
--- a/cli/bpmetadata/schema/gcp-blueprint-metadata.json
+++ b/cli/bpmetadata/schema/gcp-blueprint-metadata.json
@@ -856,9 +856,7 @@
             }
           ]
         },
-        "value": {
-          "$ref": "#/$defs/Value"
-        }
+        "value": true
       },
       "additionalProperties": false,
       "type": "object"

--- a/cli/bpmetadata/schema/generate.go
+++ b/cli/bpmetadata/schema/generate.go
@@ -57,6 +57,10 @@ func GenerateSchema() ([]byte, error) {
 	if defExists {
 		oDef.Properties.Set("type", jsonschema.TrueSchema)
 	}
+	altDefaultDef, defExists := s.Definitions["DisplayVariable_AlternateDefault"]
+	if defExists {
+		altDefaultDef.Properties.Set("value", jsonschema.TrueSchema)
+	}
 
 	sData, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {

--- a/cli/bpmetadata/validate_test.go
+++ b/cli/bpmetadata/validate_test.go
@@ -33,6 +33,11 @@ func TestValidateMetadata(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "valid display metadata with alternate defaults",
+			path:    "valid-display-metadata-alternate-defaults.yaml",
+			wantErr: false,
+		},
+		{
 			name:    "invalid metadata - title missing",
 			path:    "invalid-metadata.yaml",
 			wantErr: true,

--- a/cli/testdata/bpmetadata/schema/valid-display-metadata-alternate-defaults.yaml
+++ b/cli/testdata/bpmetadata/schema/valid-display-metadata-alternate-defaults.yaml
@@ -1,0 +1,50 @@
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-module
+spec:
+  info:
+    title: Terraform Google Module
+    source:
+      repo: https://github.com/GoogleCloudPlatform/terraform-google-module.git
+      sourceType: git
+  ui:
+    input:
+      variables:
+        string_type:
+          name: string_type
+          title: String type
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: REGIONAL
+        bool_type:
+          name: bool_type
+          title: Bool type
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: true
+        number_type:
+          name: number_type
+          title: Number type
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value: 1
+        object_type:
+          name: object_type
+          title: Object type
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value:
+                key: value
+        list_type:
+          name: list_type
+          title: List type
+          altDefaults:
+            - type: ALTERNATE_TYPE_DC
+              value:
+                - item1
+                - item2
+    runtime:
+      outputs:
+        output1:
+          visibility: VISIBILITY_ROOT


### PR DESCRIPTION
This is a follow-up PR of https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/pull/2453. The AlternateDefault value field is of type `google.protobuf.Value`. Similar to other fields of same type, it requires workaround so that JsonSchema doesn't treat it as object.