### PR TITLE
feat: Bypass `cft test lint` rules

### DIFF
--- a/cli/bptest/lint_interface.go
+++ b/cli/bptest/lint_interface.go
@@ -1,7 +1,9 @@
 package bptest
 
 import (
+	"fmt"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpmetadata"
+	"os"
 )
 
 // lintRule defines the common interface for all metadata lint rules.
@@ -30,6 +32,11 @@ func (r *lintRunner) RegisterRule(rule lintRule) {
 // Run runs all the registered rules on the provided context.
 func (r *lintRunner) Run(ctx lintContext) []error {
 	var errs []error
+	if os.Getenv("BLUEPRINT_LINT_DISABLE") == "1" {
+		fmt.Println("BLUEPRINT_LINT_DISABLE is set to 1. Skipping lint checks.")
+		return errs
+	}
+
 	for _, rule := range r.rules {
 		if rule.enabled() {
 			err := rule.check(ctx)

--- a/cli/bptest/lint_interface_test.go
+++ b/cli/bptest/lint_interface_test.go
@@ -9,29 +9,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type MockLintRule struct {
+const BlueprintLintDisableEnv = "BLUEPRINT_LINT_DISABLE"
+
+type mockLintRule struct {
 	Name    string
 	Enabled bool
 	Err     error
 }
 
-func (m *MockLintRule) name() string {
+func (m *mockLintRule) name() string {
 	return m.Name
 }
 
-func (m *MockLintRule) enabled() bool {
+func (m *mockLintRule) enabled() bool {
 	return m.Enabled
 }
 
-func (m *MockLintRule) check(ctx lintContext) error {
+func (m *mockLintRule) check(ctx lintContext) error {
 	return m.Err
 }
 
 func TestLintRunner(t *testing.T) {
 	t.Run("register and run rules with lintRunner", func(t *testing.T) {
-		mockRule1 := &MockLintRule{Name: "MockRule1", Enabled: true, Err: nil}
-		mockRule2 := &MockLintRule{Name: "MockRule2", Enabled: true, Err: errors.New("lint error")}
-		mockRule3 := &MockLintRule{Name: "MockRule3", Enabled: false, Err: nil}
+		mockRule1 := &mockLintRule{Name: "MockRule1", Enabled: true, Err: nil}
+		mockRule2 := &mockLintRule{Name: "MockRule2", Enabled: true, Err: errors.New("lint error")}
+		mockRule3 := &mockLintRule{Name: "MockRule3", Enabled: false, Err: nil}
 
 		runner := lintRunner{}
 		runner.RegisterRule(mockRule1)
@@ -59,11 +61,11 @@ func TestLintRunner(t *testing.T) {
 		assert.Empty(t, errs, "No errors should be returned when no rules are registered")
 	})
 	t.Run("skip lint rules when BLUEPRINT_LINT_DISABLE is set", func(t *testing.T) {
-		os.Setenv("BLUEPRINT_LINT_DISABLE", "1")
-		defer os.Unsetenv("BLUEPRINT_LINT_DISABLE")
+		os.Setenv(BlueprintLintDisableEnv, "1")
+		defer os.Unsetenv(BlueprintLintDisableEnv)
 
-		mockRule1 := &MockLintRule{Name: "MockRule1", Enabled: true, Err: errors.New("lint error")}
-		mockRule2 := &MockLintRule{Name: "MockRule2", Enabled: true, Err: errors.New("another lint error")}
+		mockRule1 := &mockLintRule{Name: "MockRule1", Enabled: true, Err: errors.New("lint error")}
+		mockRule2 := &mockLintRule{Name: "MockRule2", Enabled: true, Err: errors.New("another lint error")}
 
 		runner := lintRunner{}
 		runner.RegisterRule(mockRule1)

--- a/cli/bptest/lint_interface_test.go
+++ b/cli/bptest/lint_interface_test.go
@@ -1,0 +1,97 @@
+package bptest
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpmetadata"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockLintRule struct {
+	Name    string
+	Enabled bool
+	Err     error
+}
+
+func (m *MockLintRule) name() string {
+	return m.Name
+}
+
+func (m *MockLintRule) enabled() bool {
+	return m.Enabled
+}
+
+func (m *MockLintRule) check(ctx lintContext) error {
+	return m.Err
+}
+
+func TestLintRunner(t *testing.T) {
+	t.Run("register and run rules with lintRunner", func(t *testing.T) {
+		mockRule1 := &MockLintRule{Name: "MockRule1", Enabled: true, Err: nil}
+		mockRule2 := &MockLintRule{Name: "MockRule2", Enabled: true, Err: errors.New("lint error")}
+		mockRule3 := &MockLintRule{Name: "MockRule3", Enabled: false, Err: nil}
+
+		runner := lintRunner{}
+		runner.RegisterRule(mockRule1)
+		runner.RegisterRule(mockRule2)
+		runner.RegisterRule(mockRule3)
+
+		ctx := lintContext{
+			metadata: &bpmetadata.BlueprintMetadata{ApiVersion: "v1", Kind: "Blueprint"},
+			filePath: "/path/to/metadata/file.yaml",
+		}
+
+		errs := runner.Run(ctx)
+		assert.Len(t, errs, 1, "Only one rule should return an error")
+		assert.Equal(t, "lint error", errs[0].Error(), "Error message should match the expected lint error")
+	})
+
+	t.Run("run without registered rules", func(t *testing.T) {
+		runner := lintRunner{}
+		ctx := lintContext{
+			metadata: &bpmetadata.BlueprintMetadata{ApiVersion: "v1", Kind: "Blueprint"},
+			filePath: "/path/to/metadata/file.yaml",
+		}
+
+		errs := runner.Run(ctx)
+		assert.Empty(t, errs, "No errors should be returned when no rules are registered")
+	})
+	t.Run("skip lint rules when BLUEPRINT_LINT_DISABLE is set", func(t *testing.T) {
+		os.Setenv("BLUEPRINT_LINT_DISABLE", "1")
+		defer os.Unsetenv("BLUEPRINT_LINT_DISABLE")
+
+		mockRule1 := &MockLintRule{Name: "MockRule1", Enabled: true, Err: errors.New("lint error")}
+		mockRule2 := &MockLintRule{Name: "MockRule2", Enabled: true, Err: errors.New("another lint error")}
+
+		runner := lintRunner{}
+		runner.RegisterRule(mockRule1)
+		runner.RegisterRule(mockRule2)
+
+		ctx := lintContext{
+			metadata: &bpmetadata.BlueprintMetadata{ApiVersion: "v1", Kind: "Blueprint"},
+			filePath: "/path/to/metadata/file.yaml",
+		}
+
+		errs := runner.Run(ctx)
+		assert.Empty(t, errs, "No errors should be returned when BLUEPRINT_LINT_DISABLE is set")
+	})
+}
+
+//func TestRunLint(t *testing.T) {
+//t.Run("skip lint when BLUEPRINT_LINT_DISABLE is set", func(t *testing.T) {
+//os.Setenv("BLUEPRINT_LINT_DISABLE", "1")
+//defer os.Unsetenv("BLUEPRINT_LINT_DISABLE")
+
+//err := Run()
+//assert.NoError(t, err, "Lint should be skipped without error")
+//})
+
+//t.Run("run lint when BLUEPRINT_LINT_DISABLE is not set", func(t *testing.T) {
+//os.Unsetenv("BLUEPRINT_LINT_DISABLE")
+
+//err := Run()
+//assert.NoError(t, err, "Lint should run without error")
+//})
+//}

--- a/cli/bptest/lint_interface_test.go
+++ b/cli/bptest/lint_interface_test.go
@@ -78,20 +78,3 @@ func TestLintRunner(t *testing.T) {
 		assert.Empty(t, errs, "No errors should be returned when BLUEPRINT_LINT_DISABLE is set")
 	})
 }
-
-//func TestRunLint(t *testing.T) {
-//t.Run("skip lint when BLUEPRINT_LINT_DISABLE is set", func(t *testing.T) {
-//os.Setenv("BLUEPRINT_LINT_DISABLE", "1")
-//defer os.Unsetenv("BLUEPRINT_LINT_DISABLE")
-
-//err := Run()
-//assert.NoError(t, err, "Lint should be skipped without error")
-//})
-
-//t.Run("run lint when BLUEPRINT_LINT_DISABLE is not set", func(t *testing.T) {
-//os.Unsetenv("BLUEPRINT_LINT_DISABLE")
-
-//err := Run()
-//assert.NoError(t, err, "Lint should run without error")
-//})
-//}


### PR DESCRIPTION
Add `BLUEPRINT_LINT_DISABLE` env var to bypass `cft test lint` rules when set to 1.