### PR TITLE
fix: JSONEq() whitespace backwards compatible

### DIFF
--- a/infra/blueprint-test/pkg/golden/golden.go
+++ b/infra/blueprint-test/pkg/golden/golden.go
@@ -154,10 +154,10 @@ func (g *GoldenFile) GetJSON() gjson.Result {
 // JSONEq asserts that json content in jsonPath for got and goldenfile is the same
 func (g *GoldenFile) JSONEq(a *assert.Assertions, got gjson.Result, jsonPath string) {
 	gf := g.GetJSON()
-	getPath := fmt.Sprintf("%s|@tostr", jsonPath)
+	getPath := fmt.Sprintf("%s|@ugly", jsonPath)
 	gotData := g.ApplySanitizers(got.Get(getPath).String())
 	gfData := gf.Get(getPath).String()
-	a.JSONEq(gfData, gotData, fmt.Sprintf("expected %s to match fixture %s", jsonPath, gfData))
+	a.Equalf(gfData, gotData, "For path %q expected %q to match fixture %q", jsonPath, gotData, gfData)
 }
 
 // JSONPathEqs asserts that json content in jsonPaths for got and goldenfile are the same


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/pull/2719 wasn't compatible with invalid JSON from testing empty paths.  This adds backwards compatibility to the original implementation, while still resolving the whitespace equality issue.