### PR TITLE
chore: add pubsub devs as pubsub module owners

### DIFF
--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -479,7 +479,7 @@ locals {
       description = "Creates Pub/Sub topic and subscriptions associated with the topic"
       topics      = local.common_topics.da
       maintainers = ["imrannayer"]
-      groups      = ["github-api-pubsub"]
+      groups      = ["api-pubsub-and-pubsublite"]
       lint_env = {
         ENABLE_BPMETADATA = "1"
       }

--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -478,7 +478,7 @@ locals {
       org         = "terraform-google-modules"
       description = "Creates Pub/Sub topic and subscriptions associated with the topic"
       topics      = local.common_topics.da
-      maintainers = ["imrannayer"]
+      maintainers = ["imrannayer", "github-api-pubsub"]
       lint_env = {
         ENABLE_BPMETADATA = "1"
       }

--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -478,7 +478,8 @@ locals {
       org         = "terraform-google-modules"
       description = "Creates Pub/Sub topic and subscriptions associated with the topic"
       topics      = local.common_topics.da
-      maintainers = ["imrannayer", "github-api-pubsub"]
+      maintainers = ["imrannayer"]
+      groups      = ["github-api-pubsub"]
       lint_env = {
         ENABLE_BPMETADATA = "1"
       }


### PR DESCRIPTION
Add Pub/Sub devs with terraform experience to the pubsub terraform module owners.