### PR TITLE
chore: remove go.work

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,9 +1,0 @@
-go 1.23.0
-
-use (
-	./cli
-	./infra/blueprint-test
-	./infra/module-swapper
-	./infra/utils/fbf
-	./tflint-ruleset-blueprint
-)


### PR DESCRIPTION
- It's not currently feasible to sync the imports across the entire repo