### PR TITLE
chore: Enable metadata validation in lint test for terraform-google-bigtable

### DIFF
--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -335,7 +335,7 @@ locals {
       topics      = local.common_topics.da
       lint_env = {
         ENABLE_BPMETADATA = "1"
-      }      
+      }
     },
     {
       name        = "terraform-google-datalab"

--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -333,6 +333,9 @@ locals {
       org         = "terraform-google-modules"
       description = "Handles opinionated Dataflow job configuration and deployments"
       topics      = local.common_topics.da
+      lint_env = {
+        ENABLE_BPMETADATA = "1"
+      }      
     },
     {
       name        = "terraform-google-datalab"

--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -895,6 +895,9 @@ locals {
       description = "Create and manage Google Bigtable resources"
       maintainers = ["hariprabhaam"]
       topics      = local.common_topics.da
+      lint_env = {
+        ENABLE_BPMETADATA = "1"
+      }
     },
     {
       name        = "terraform-google-secure-web-proxy"


### PR DESCRIPTION
This PR also enables metadata validation for terraform-google-dataflow