### PR TITLE
chore: Adding erlanderlo to secured data warehouse maintainers

### DIFF
--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -103,7 +103,7 @@ locals {
       name        = "terraform-google-secured-data-warehouse"
       org         = "GoogleCloudPlatform"
       description = "Deploys a secured BigQuery data warehouse"
-      maintainers = ["lanre-OG"]
+      maintainers = ["lanre-OG", "erlanderlo"]
       topics      = join(",", [local.common_topics.da, local.common_topics.e2e])
       lint_env = {
         SHELLCHECK_OPTS = "-e SC2154 -e SC2171 -e SC2086"
@@ -802,7 +802,7 @@ locals {
       short_name  = "sdw-onprem-ingest"
       org         = "GoogleCloudPlatform"
       description = "Deploys a secured data warehouse variant for ingesting encrypted data from on-prem sources"
-      maintainers = ["lanre-OG"]
+      maintainers = ["lanre-OG", "erlanderlo"]
       topics      = join(",", [local.common_topics.da, local.common_topics.security, local.common_topics.e2e])
     },
     {


### PR DESCRIPTION
Add erlanderlo as maintainer of the following repositories:

- [terraform-google-secured-data-warehouse](https://github.com/GoogleCloudPlatform/terraform-google-secured-data-warehouse-onprem-ingest)
- [terraform-google-secured-data-warehouse-onprem-ingest](https://github.com/GoogleCloudPlatform/terraform-google-secured-data-warehouse-onprem-ingest)
