### PR TITLE
feat: generate_metadata support multiple args

### DIFF
--- a/infra/build/developer-tools/build/scripts/task_helper_functions.sh
+++ b/infra/build/developer-tools/build/scripts/task_helper_functions.sh
@@ -319,7 +319,7 @@ function generate_docs() {
     echo "ENABLE_BPMETADATA not set to 1. Skipping metadata generation."
     return 0
   fi
-  generate_metadata "${1-default}"
+  generate_metadata "$@"
 }
 
 function generate_metadata() {
@@ -331,7 +331,7 @@ function generate_metadata() {
   elif [ "${arg}" = "display" ]; then
     cft blueprint metadata -d
   else
-    eval "cft blueprint metadata $arg"
+    eval "cft blueprint metadata $@"
   fi
 
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
Rather than just the first argument, pass through all args to `generate_metadata`, and then all args to `cft blueprint metadata` for the fall back.

Fixes: #3140