### PR TITLE
chore: Update Cloud Run maintainers

### DIFF
--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -93,7 +93,7 @@ locals {
       name        = "terraform-google-cloud-run"
       org         = "GoogleCloudPlatform"
       description = "Deploys apps to Cloud Run, along with option to map custom domain"
-      maintainers = concat(["prabhu34", "anamer"], local.adc_common_admins)
+      maintainers = concat(["prabhu34", "anamer", "avianap", "bskaplan", "qwerjkl112", "ian-mi", "joananlin", "kminsu-google", "paridhishah18", "rafaeltello", "sammccauley117", "yanweiguo", "whaught", "trshafer"], local.adc_common_admins)
       topics      = "cloudrun,google-cloud-platform,terraform-modules,${local.common_topics.serverless}"
       lint_env = {
         ENABLE_BPMETADATA = "1"

--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -93,7 +93,8 @@ locals {
       name        = "terraform-google-cloud-run"
       org         = "GoogleCloudPlatform"
       description = "Deploys apps to Cloud Run, along with option to map custom domain"
-      maintainers = concat(["prabhu34", "anamer", "avianap", "bskaplan", "qwerjkl112", "ian-mi", "joananlin", "kminsu-google", "paridhishah18", "rafaeltello", "sammccauley117", "yanweiguo", "whaught", "trshafer"], local.adc_common_admins)
+      maintainers = concat(["prabhu34", "anamer"], local.adc_common_admins)
+      groups      = ["cloud-run-control-plane", local.jss_common_group]
       topics      = "cloudrun,google-cloud-platform,terraform-modules,${local.common_topics.serverless}"
       lint_env = {
         ENABLE_BPMETADATA = "1"


### PR DESCRIPTION
This should include the new list of maintainers. If there is a way to add a group that would be preferred.