### PR TITLE
chore: Add ADC maintainers to cloud-router repo

### DIFF
--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -299,7 +299,7 @@ locals {
       org         = "terraform-google-modules"
       description = "Manages a Cloud Router on Google Cloud"
       topics      = local.common_topics.net
-      maintainers = ["imrannayer"]
+      maintainers = concat(["imrannayer"], local.adc_common_admins)
     },
     {
       name        = "terraform-google-cloud-storage"


### PR DESCRIPTION
"Adds the common ADC administrators to the maintainers list for the terraform-google-cloud-router module in locals.tf."