### PR TITLE
chore: update commitlint and ignore header-max-length

### DIFF
--- a/infra/terraform/modules/workflow_files/lint.yaml.tftpl
+++ b/infra/terraform/modules/workflow_files/lint.yaml.tftpl
@@ -69,7 +69,8 @@ jobs:
           node-version: lts/*
       - name: Install commitlint
         run: |
-          npm install -D @commitlint/cli@20.1.0 @commitlint/config-conventional@20.1.0
+          COMMITLINT_VERSION=20.1.0
+          npm install -D @commitlint/cli@$COMMITLINT_VERSION @commitlint/config-conventional@$COMMITLINT_VERSION
           echo "module.exports = { extends: ['@commitlint/config-conventional'], rules: {'subject-case': [0], 'header-max-length': [0]} };" > commitlint.config.js
           npx commitlint --version
       - name: Validate PR commits with commitlint


### PR DESCRIPTION
Fix: https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/issues/3264