### PR TITLE
chore: Add ADC maintainers to vertex ai repo

### DIFF
--- a/infra/terraform/test-org/org/locals.tf
+++ b/infra/terraform/test-org/org/locals.tf
@@ -632,7 +632,7 @@ locals {
       name        = "terraform-google-vertex-ai"
       org         = "GoogleCloudPlatform"
       description = "Deploy Vertex AI resources"
-      maintainers = ["imrannayer"]
+      maintainers = concat(["imrannayer"], local.adc_common_admins)
       topics      = join(",", [local.common_topics.compute])
     },
     {


### PR DESCRIPTION
Add ADC maintainers to https://github.com/GoogleCloudPlatform/terraform-google-vertex-ai repo.