### PR TITLE
ci: declare workflow-level permissions on eight workflows

### DIFF
--- a/.github/workflows/go-fbf-test.yml
+++ b/.github/workflows/go-fbf-test.yml
@@ -12,6 +12,9 @@ concurrency:
   group: '${{github.workflow}}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   unit:
     name: ${{ matrix.operating-system }} unit tests

--- a/.github/workflows/go-module-swapper.yml
+++ b/.github/workflows/go-module-swapper.yml
@@ -12,6 +12,9 @@ concurrency:
   group: '${{github.workflow}}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   unit:
     name: ${{ matrix.operating-system }} unit tests

--- a/.github/workflows/go-tflint-plugin.yml
+++ b/.github/workflows/go-tflint-plugin.yml
@@ -18,6 +18,9 @@ concurrency:
   group: '${{github.workflow}}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   unit:
     name: ${{ matrix.operating-system }} unit tests

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,6 +26,9 @@ concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: 'lint-infra-terraform'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-cft-devtools.yml
+++ b/.github/workflows/test-cft-devtools.yml
@@ -11,6 +11,9 @@ concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-dev-tools:
     name: Build CFT dev tools image

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -18,6 +18,9 @@ concurrency:
   group: '${{github.workflow}}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   unit:
     name: ${{ matrix.operating-system }} unit tests

--- a/.github/workflows/update-tooling.yml
+++ b/.github/workflows/update-tooling.yml
@@ -24,6 +24,10 @@ env:
   TFLINT_URL: "https://api.github.com/repos/terraform-linters/tflint/releases/latest"
   GOLANGCI_URL: "https://api.github.com/repos/golangci/golangci-lint/releases/latest"
 
+permissions:
+  contents: write       # peter-evans/create-pull-request pushes a branch
+  pull-requests: write  # peter-evans/create-pull-request opens the PR
+
 jobs:
   update-tools:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Eight workflows declared no permissions block. Scoped per workflow:

- Seven pure CI workflows (`go-fbf-test`, `go-module-swapper`, `go-tflint-plugin`, `lint`, `pre-commit`, `test-cft-devtools`, `test-cli`) get `contents: read`.
- `update-tooling.yml` uses [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request) to open PRs that auto-bump tool versions. That requires:
  - `contents: write` (the action pushes a new branch via the git CLI)
  - `pull-requests: write` (the action creates the PR via the REST API)

The cwd is `.github/workflows/` and YAML validates for all eight.