### PR TITLE
chore(infra): pin and update GitHub Actions in workflow templates

### DIFF
--- a/infra/terraform/modules/workflow_files/lint.yaml.tftpl
+++ b/infra/terraform/modules/workflow_files/lint.yaml.tftpl
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,8 +34,9 @@ jobs:
   lint:
     name: 'lint'
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 60
     steps:
-      - uses: 'actions/checkout@v6'
+      - uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' # v7.0.1
       - id: variables
         run: |
           MAKEFILE=$(find . -name Makefile -print -quit)
@@ -47,26 +48,28 @@ jobs:
             REGISTRY=$(grep "REGISTRY_URL := " $MAKEFILE | cut -d\  -f3)
             echo dev-tools=$${REGISTRY}/$${IMAGE}:$${VERSION} >> "$GITHUB_OUTPUT"
           fi
-      - run: docker run --rm %{if lint_env != null }%{ for key, value in lint_env ~}-e ${key} %{ endfor ~}%{ endif }-v $${{ github.workspace }}:/workspace $${STEPS_VARIABLES_OUTPUTS_DEV_TOOLS} module-swapper
+      - run: docker run --rm %{if lint_env != null }%{ for key, value in lint_env ~}-e ${key} %{ endfor ~}%{ endif }-v "$GITHUB_WORKSPACE":/workspace "$STEPS_VARIABLES_OUTPUTS_DEV_TOOLS" module-swapper
         env:
 %{ if lint_env != null ~}%{ for key, value in lint_env ~}
           ${key}: ${value}
 %{ endfor ~}%{ endif ~}
           STEPS_VARIABLES_OUTPUTS_DEV_TOOLS: $${{ steps.variables.outputs.dev-tools }}
-      - run: docker run --rm %{if lint_env != null }%{ for key, value in lint_env ~}-e ${key} %{ endfor ~}%{ endif }-v $${{ github.workspace }}:/workspace $${STEPS_VARIABLES_OUTPUTS_DEV_TOOLS} /usr/local/bin/test_lint.sh
+      - run: docker run --rm %{if lint_env != null }%{ for key, value in lint_env ~}-e ${key} %{ endfor ~}%{ endif }-v "$GITHUB_WORKSPACE":/workspace "$STEPS_VARIABLES_OUTPUTS_DEV_TOOLS" /usr/local/bin/test_lint.sh
         env:
 %{ if lint_env != null ~}%{ for key, value in lint_env ~}
           ${key}: ${value}
 %{ endfor ~}%{ endif ~}
           STEPS_VARIABLES_OUTPUTS_DEV_TOOLS: $${{ steps.variables.outputs.dev-tools }}
   commitlint:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/*
       - name: Install commitlint
@@ -75,7 +78,6 @@ jobs:
           echo "module.exports = { extends: ['@commitlint/config-conventional'], rules: {'subject-case': [0], 'header-max-length': [0]} };" > commitlint.config.js
           npx commitlint --version
       - name: Validate PR commits with commitlint
-        if: github.event_name == 'pull_request'
         env:
           TITLE: $${{ github.event.pull_request.title }}
         run: 'echo "$TITLE" | npx commitlint --verbose'

--- a/infra/terraform/modules/workflow_files/periodic-reporter.yaml
+++ b/infra/terraform/modules/workflow_files/periodic-reporter.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Google LLC
+# Copyright 2023-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,10 @@ on:
     - cron: '0 5,17 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: periodic-reporter-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   report:
     if: github.repository_owner == 'GoogleCloudPlatform' || github.repository_owner == 'terraform-google-modules'
@@ -31,9 +35,10 @@ jobs:
       issues: 'write'
 
     runs-on: 'ubuntu-latest'
+    timeout-minutes: 30
 
     steps:
-      - uses: 'actions/github-script@v8'
+      - uses: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3' # v9.0.0
         with:
           script: |-
                   // label for all issues opened by reporter

--- a/infra/terraform/test-org/github/resources/stale.yml
+++ b/infra/terraform/test-org/github/resources/stale.yml
@@ -1,4 +1,4 @@
-# Copyright 2022-2025 Google LLC
+# Copyright 2022-2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ name: "Close stale issues"
 on:
   schedule:
   - cron: "0 23 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -30,8 +31,9 @@ jobs:
   stale:
     if: github.repository_owner == 'GoogleCloudPlatform' || github.repository_owner == 'terraform-google-modules'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-    - uses: actions/stale@v10
+    - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days'


### PR DESCRIPTION
- Pin actions to full commit SHAs (actions/checkout@v7.0.1, actions/setup-node@v7.0.0, actions/github-script@v9.0.0, actions/stale@v11.0.0).
- Add timeout-minutes to workflow jobs.
- Add workflow_dispatch trigger to stale.yml.
- Add concurrency control to periodic-reporter.yaml.
- Move commitlint PR event check to job level in lint.yaml.tftpl.